### PR TITLE
update version number in the S3 path

### DIFF
--- a/site/content/en/docs/Getting started/installation.md
+++ b/site/content/en/docs/Getting started/installation.md
@@ -10,7 +10,7 @@ weight: 20
 Download the Amazon Genomics CLI zip, unzip its contents, and run the `install.sh` script:
 
 ```
-aws s3 cp s3://healthai-public-assets-us-east-1/amazon-genomics-cli/0.9.0/amazon-genomics-cli.zip .
+aws s3 cp s3://healthai-public-assets-us-east-1/amazon-genomics-cli/1.0.0/amazon-genomics-cli.zip .
 unzip amazon-genomics-cli.zip -d agc
 ./agc/install.sh
 ```


### PR DESCRIPTION
*Description of changes:*

`s3://healthai-public-assets-us-east-1/amazon-genomics-cli/0.9.0/amazon-genomics-cli.zip` is not public accessible. It must be updated to `1.0.0`.

On the other hands, I think using `latest` instead of version number could be better for tutorial document.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
