### PR TITLE
Centralizes the logic for retrieving context information

### DIFF
--- a/packages/cli/internal/pkg/cli/context/manager.go
+++ b/packages/cli/internal/pkg/cli/context/manager.go
@@ -1,7 +1,6 @@
 package context
 
 import (
-	"fmt"
 	"net/url"
 	"os"
 	"strings"
@@ -99,9 +98,9 @@ func (m *Manager) readContextSpec(contextName string) {
 	if m.err != nil {
 		return
 	}
-	contextSpec, ok := m.projectSpec.Contexts[contextName]
-	if !ok {
-		m.err = fmt.Errorf("context '%s' is not defined in Project '%s' specification", contextName, m.projectSpec.Name)
+	contextSpec, err := spec.GetContext(m.projectSpec, contextName)
+	if err != nil {
+		m.err = err
 		return
 	}
 	m.contextSpec = contextSpec
@@ -175,8 +174,9 @@ func (m *Manager) setContextEnv(contextName string) {
 		return
 	}
 
-	if _, contextFound := m.projectSpec.Contexts[contextName]; !contextFound {
-		m.err = fmt.Errorf("context '%s' does not exist", contextName)
+	context, err := spec.GetContext(m.projectSpec, contextName)
+	if err != nil {
+		m.err = err
 		return
 	}
 
@@ -193,8 +193,8 @@ func (m *Manager) setContextEnv(contextName string) {
 		RequestSpotInstances: m.contextSpec.RequestSpotInstances,
 		// TODO: we default to a single engine in a context for now
 		// need to allow for multiple engines in the same context
-		EngineName:        m.projectSpec.Contexts[contextName].Engines[0].Engine,
-		EngineDesignation: m.projectSpec.Contexts[contextName].Engines[0].Engine,
+		EngineName:        context.Engines[0].Engine,
+		EngineDesignation: context.Engines[0].Engine,
 	}
 }
 

--- a/packages/cli/internal/pkg/cli/context/manager.go
+++ b/packages/cli/internal/pkg/cli/context/manager.go
@@ -98,7 +98,7 @@ func (m *Manager) readContextSpec(contextName string) {
 	if m.err != nil {
 		return
 	}
-	contextSpec, err := spec.GetContext(m.projectSpec, contextName)
+	contextSpec, err := m.projectSpec.GetContext(contextName)
 	if err != nil {
 		m.err = err
 		return
@@ -174,7 +174,7 @@ func (m *Manager) setContextEnv(contextName string) {
 		return
 	}
 
-	context, err := spec.GetContext(m.projectSpec, contextName)
+	context, err := m.projectSpec.GetContext(contextName)
 	if err != nil {
 		m.err = err
 		return

--- a/packages/cli/internal/pkg/cli/context/manager_info_test.go
+++ b/packages/cli/internal/pkg/cli/context/manager_info_test.go
@@ -95,7 +95,7 @@ func TestManager_Info(t *testing.T) {
 			},
 		},
 		"unknown context": {
-			expectedErr: fmt.Errorf("context 'testContextName1' does not exist"),
+			expectedErr: fmt.Errorf("context 'testContextName1' is not defined in Project 'testProjectName' specification"),
 			setupMocks: func(t *testing.T) mockClients {
 				mockClients := createMocks(t)
 				mockClients.configMock.EXPECT().GetUserEmailAddress().Return(testUserEmail, nil)
@@ -140,7 +140,7 @@ func TestManager_Info(t *testing.T) {
 			},
 		},
 		"context not exist error": {
-			expectedErr: fmt.Errorf("context 'testContextName1' does not exist"),
+			expectedErr: fmt.Errorf("context 'testContextName1' is not defined in Project 'testProjectName' specification"),
 			setupMocks: func(t *testing.T) mockClients {
 				mockClients := createMocks(t)
 				mockClients.configMock.EXPECT().GetUserEmailAddress().Return(testUserEmail, nil)

--- a/packages/cli/internal/pkg/cli/spec/project.go
+++ b/packages/cli/internal/pkg/cli/spec/project.go
@@ -1,5 +1,7 @@
 package spec
 
+import "fmt"
+
 const LatestVersion = 1
 
 type Project struct {
@@ -8,4 +10,13 @@ type Project struct {
 	Workflows     map[string]Workflow `yaml:"workflows,omitempty"`
 	Data          []Data              `yaml:"data,omitempty"`
 	Contexts      map[string]Context  `yaml:"contexts,omitempty"`
+}
+
+func GetContext(projectSpec Project, contextName string) (Context, error) {
+	contextSpec, ok := projectSpec.Contexts[contextName]
+	if !ok {
+		return Context{}, fmt.Errorf("context '%s' is not defined in Project '%s' specification", contextName, projectSpec.Name)
+	}
+
+	return contextSpec, nil
 }

--- a/packages/cli/internal/pkg/cli/spec/project.go
+++ b/packages/cli/internal/pkg/cli/spec/project.go
@@ -12,7 +12,7 @@ type Project struct {
 	Contexts      map[string]Context  `yaml:"contexts,omitempty"`
 }
 
-func GetContext(projectSpec Project, contextName string) (Context, error) {
+func (projectSpec *Project) GetContext(contextName string) (Context, error) {
 	contextSpec, ok := projectSpec.Contexts[contextName]
 	if !ok {
 		return Context{}, fmt.Errorf("context '%s' is not defined in Project '%s' specification", contextName, projectSpec.Name)

--- a/packages/cli/internal/pkg/cli/spec/project_test.go
+++ b/packages/cli/internal/pkg/cli/spec/project_test.go
@@ -207,7 +207,7 @@ func TestGetContext(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			context, err := GetContext(tt.args.projectSpec, tt.args.contextName)
+			context, err := tt.args.projectSpec.GetContext(tt.args.contextName)
 			if tt.expectedError != nil {
 				assert.Error(t, err, tt.expectedError.Error())
 			} else {

--- a/packages/cli/internal/pkg/cli/workflow/manager.go
+++ b/packages/cli/internal/pkg/cli/workflow/manager.go
@@ -335,9 +335,9 @@ func (m *Manager) setContext(contextName string) {
 		return
 	}
 
-	contextSpec, ok := m.projectSpec.Contexts[contextName]
-	if !ok {
-		m.err = fmt.Errorf("context '%s' is not defined in project specificaiton", contextName)
+	contextSpec, err := spec.GetContext(m.projectSpec, contextName)
+	if err != nil {
+		m.err = err
 		return
 	}
 	m.contextSpec = contextSpec

--- a/packages/cli/internal/pkg/cli/workflow/manager.go
+++ b/packages/cli/internal/pkg/cli/workflow/manager.go
@@ -335,7 +335,7 @@ func (m *Manager) setContext(contextName string) {
 		return
 	}
 
-	contextSpec, err := spec.GetContext(m.projectSpec, contextName)
+	contextSpec, err := m.projectSpec.GetContext(contextName)
 	if err != nil {
 		m.err = err
 		return


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently, we retrieve the context information in several locations using different error messages. This change allows us to centralize the error messaging between the different components.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
