### PR TITLE
Target new base Go dir after refactor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 defaults:
   run:
-    working-directory: packages/cli
+    working-directory: packages/cli/
 
 jobs:
 
@@ -41,7 +41,7 @@ jobs:
           version: v1.29
 
           # Optional: working directory, useful for monorepos
-          working-directory: packages/cli
+          working-directory: packages/cli/
 
           # Optional: golangci-lint command line arguments.
           # args: --issues-exit-code=0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 defaults:
   run:
-    working-directory: packages/
+    working-directory: packages/cli
 
 jobs:
 
@@ -41,7 +41,7 @@ jobs:
           version: v1.29
 
           # Optional: working directory, useful for monorepos
-          working-directory: packages/
+          working-directory: packages/cli
 
           # Optional: golangci-lint command line arguments.
           # args: --issues-exit-code=0


### PR DESCRIPTION


*Description of changes:* After refactoring out the common package, `/packages/cli` is now the base directory for the go project. Update the CI workflow to reflect that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
