### PR TITLE
Adds workflow type to the command use example for project init

### DIFF
--- a/packages/cli/internal/pkg/cli/project_init.go
+++ b/packages/cli/internal/pkg/cli/project_init.go
@@ -125,7 +125,7 @@ func (o *initProjectOpts) validateProject() error {
 func BuildProjectInitCommand() *cobra.Command {
 	vars := initProjectVars{}
 	cmd := &cobra.Command{
-		Use:   "init project_name",
+		Use:   "init project_name --workflow-type my_workflow_type",
 		Short: "Initialize current directory with a new empty AGC project for a particular workflow type.",
 		Long: `Initialize current directory with a new empty AGC project for a particular workflow type.
 Project specification file 'agc-project.yaml' will be created in the current directory.`,

--- a/packages/cli/internal/pkg/cli/project_init.go
+++ b/packages/cli/internal/pkg/cli/project_init.go
@@ -125,7 +125,7 @@ func (o *initProjectOpts) validateProject() error {
 func BuildProjectInitCommand() *cobra.Command {
 	vars := initProjectVars{}
 	cmd := &cobra.Command{
-		Use:   "init project_name --workflow-type my_workflow_type",
+		Use:   "init project_name --workflow-type {wdl|nextflow}",
 		Short: "Initialize current directory with a new empty AGC project for a particular workflow type.",
 		Long: `Initialize current directory with a new empty AGC project for a particular workflow type.
 Project specification file 'agc-project.yaml' will be created in the current directory.`,


### PR DESCRIPTION
*Description of changes:*
Updates the Use part of the project init command. I also checked the documentation but we include workflow type there which is why it isn't updated there.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
