### PR TITLE
Restore tags to ec2 instances used by AWS Batch

### DIFF
--- a/packages/cdk/lib/stacks/nested/batch-stack.ts
+++ b/packages/cdk/lib/stacks/nested/batch-stack.ts
@@ -72,7 +72,7 @@ export class BatchStack extends NestedStack {
       computeType,
       launchTemplateData: LAUNCH_TEMPLATE,
       awsPolicyNames: ["AmazonSSMManagedInstanceCore", "CloudWatchAgentServerPolicy"],
-      resourceTags: this.tags.tagValues(),
+      resourceTags: this.nestedStackParent?.tags.tagValues(),
     });
   }
 }


### PR DESCRIPTION
## Change

Use nested stack parent tags as `resourceTags` for Batch construct.

## Testing

`agc context deploy -c spotCtx`

Compute Environment contains expected EC2 tags