### PR TITLE
Remove title from slack payload

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -27,6 +27,6 @@ jobs:
         with:
           # Event payload can be parsed from
           # https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request
-          payload: "{\"number\":\"${{ github.event.number }}\",\"url\":\"${{ github.event.pull_request.html_url }}\",\"title\":\"${{ github.event.pull_request.title }}\",\"user\":\"${{ github.event.pull_request.user.login }}\"}"
+          payload: "{\"number\":\"${{ github.event.number }}\",\"url\":\"${{ github.event.pull_request.html_url }}\",\"user\":\"${{ github.event.pull_request.user.login }}\"}"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_FEED_WEBHOOK_URL }}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
I'm removing the title from the Slack payload. Quotes in the title can escape the workflow payload JSON, causing the Slack workflow to fail. Since Slack expands the PR link with a preview, the title is less important to have in the message.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
