### PR TITLE
Rename println to avoid builtin name clash

### DIFF
--- a/packages/cli/internal/pkg/cli/logs_core.go
+++ b/packages/cli/internal/pkg/cli/logs_core.go
@@ -39,7 +39,7 @@ Valid time units are "s", "m", and "h".`
 	tailFlagDescription = "Follow the log output."
 )
 
-var println = fmt.Println
+var printLn = fmt.Println
 
 type logsSharedVars struct {
 	tail        bool
@@ -76,7 +76,7 @@ func (v *logsSharedVars) setFilterFlags(cmd *cobra.Command) {
 
 func (v *logsSharedVars) setContextFlag(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&v.contextName, contextFlag, contextFlagShort, "", contextFlagDescription)
-	cmd.MarkFlagRequired(contextFlag) //nolint:errcheck
+	_ = cmd.MarkFlagRequired(contextFlag)
 }
 
 func (o *logsSharedOpts) setDefaultEndTimeIfEmpty() {
@@ -120,7 +120,7 @@ func (o *logsSharedOpts) followLogGroup(logGroupName string, streams ...string) 
 		}
 		if len(event.Logs) > 0 {
 			for _, line := range event.Logs {
-				println(line) //nolint:errcheck
+				_, _ = printLn(line)
 			}
 		} else {
 			log.Debug().Msg("No new logs")
@@ -143,7 +143,7 @@ func (o *logsSharedOpts) displayLogGroup(logGroupName string, startTime, endTime
 			return err
 		}
 		for _, line := range logs {
-			println(line) //nolint:errcheck
+			_, _ = printLn(line)
 		}
 	}
 	return nil

--- a/packages/cli/internal/pkg/cli/logs_core.go
+++ b/packages/cli/internal/pkg/cli/logs_core.go
@@ -39,7 +39,9 @@ Valid time units are "s", "m", and "h".`
 	tailFlagDescription = "Follow the log output."
 )
 
-var printLn = fmt.Println
+var printLn = func(args ...interface{}) {
+	_, _ = fmt.Println(args)
+}
 
 type logsSharedVars struct {
 	tail        bool
@@ -120,7 +122,7 @@ func (o *logsSharedOpts) followLogGroup(logGroupName string, streams ...string) 
 		}
 		if len(event.Logs) > 0 {
 			for _, line := range event.Logs {
-				_, _ = printLn(line)
+				printLn(line)
 			}
 		} else {
 			log.Debug().Msg("No new logs")
@@ -143,7 +145,7 @@ func (o *logsSharedOpts) displayLogGroup(logGroupName string, startTime, endTime
 			return err
 		}
 		for _, line := range logs {
-			_, _ = printLn(line)
+			printLn(line)
 		}
 	}
 	return nil

--- a/packages/cli/internal/pkg/cli/logs_workflow_test.go
+++ b/packages/cli/internal/pkg/cli/logs_workflow_test.go
@@ -233,11 +233,11 @@ func TestLogsWorkflowOpts_Execute(t *testing.T) {
 			defer ctrl.Finish()
 
 			var output strings.Builder
-			println = func(args ...interface{}) (n int, err error) {
+			printLn = func(args ...interface{}) (n int, err error) {
 				output.WriteString(fmt.Sprintln(args...))
 				return
 			}
-			defer func() { println = fmt.Println }()
+			defer func() { printLn = fmt.Println }()
 
 			mockWorkflow := managermocks.NewMockWorkflowManager(ctrl)
 			mockContext := contextmocks.NewMockContextManager(ctrl)

--- a/packages/cli/internal/pkg/cli/logs_workflow_test.go
+++ b/packages/cli/internal/pkg/cli/logs_workflow_test.go
@@ -233,11 +233,11 @@ func TestLogsWorkflowOpts_Execute(t *testing.T) {
 			defer ctrl.Finish()
 
 			var output strings.Builder
-			printLn = func(args ...interface{}) (n int, err error) {
+			origPrintLn := printLn
+			printLn = func(args ...interface{}) {
 				output.WriteString(fmt.Sprintln(args...))
-				return
 			}
-			defer func() { printLn = fmt.Println }()
+			defer func() { printLn = origPrintLn }()
 
 			mockWorkflow := managermocks.NewMockWorkflowManager(ctrl)
 			mockContext := contextmocks.NewMockContextManager(ctrl)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
[println](https://pkg.go.dev/builtin#println) is a builtin function in Go. We were overriding that function which could have unintended consequences. I am renaming our function to `printLn` to avoid the conflict.

Additionally, I have replaced lint exception comments with Blank Identifiers to explicitly indicate we don't care about the return values rather than rely on the linter comment.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
