### PR TITLE
Display message if no contexts deployed

### DIFF
--- a/packages/cli/internal/pkg/cli/context_status.go
+++ b/packages/cli/internal/pkg/cli/context_status.go
@@ -54,7 +54,11 @@ func BuildContextStatusCommand() *cobra.Command {
 			if err != nil {
 				return clierror.New("context status", nil, err)
 			}
-			format.Default.Write(contextInstances)
+			if len(contextInstances) > 0 {
+				format.Default.Write(contextInstances)
+			} else {
+				format.Default.Write("There are no contexts deployed.")
+			}
 			return nil
 		}),
 	}

--- a/packages/cli/internal/pkg/cli/context_status.go
+++ b/packages/cli/internal/pkg/cli/context_status.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/amazon-genomics-cli/internal/pkg/cli/clierror"
 	"github.com/aws/amazon-genomics-cli/internal/pkg/cli/context"
 	"github.com/aws/amazon-genomics-cli/internal/pkg/cli/format"
+	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )
 
@@ -57,7 +58,7 @@ func BuildContextStatusCommand() *cobra.Command {
 			if len(contextInstances) > 0 {
 				format.Default.Write(contextInstances)
 			} else {
-				format.Default.Write("There are no contexts deployed.")
+				log.Info().Msg("There are no contexts deployed.")
 			}
 			return nil
 		}),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The `context status` command prints nothing if no contexts are deployed. I am modifying the command to inform the user when this is the case.

No contexts
```
$ agc context status
2021-10-04T12:50:09-07:00 𝒊  There are no contexts deployed.
```

One context
```
$ agc context status
INSTANCE	myContext		STARTED	true
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
