### PR TITLE
Add run-id flag to workflow status command

### DIFF
--- a/site/content/en/docs/Getting started/helloworld.md
+++ b/site/content/en/docs/Getting started/helloworld.md
@@ -15,7 +15,7 @@ with some demo projects including a simple "hello world" workflow.
 3. `cd ~/agc/examples/demo-wdl-project`
 4. `agc context deploy --context myContext`, this step takes approximately 5 minutes to deploy the infrastructure
 5. `agc workflow run hello --context myContext`, take note of the returned workflow instance ID.
-6. Check on the status of the workflow `agc workflow status <workflow-instance-id>`. Initially you will see status like `SUBMITTED` but after the elastic compute resources have been spun up and the workflow runs you should see something like the following: `WORKFLOWINSTANCE    ctx1    9ff7600a-6d6e-4bda-9ab6-c615f5d90734    COMPLETE    2021-09-01T20:17:49Z`
+6. Check on the status of the workflow `agc workflow status -r <workflow-instance-id>`. Initially you will see status like `SUBMITTED` but after the elastic compute resources have been spun up and the workflow runs you should see something like the following: `WORKFLOWINSTANCE    ctx1    9ff7600a-6d6e-4bda-9ab6-c615f5d90734    COMPLETE    2021-09-01T20:17:49Z`
 
 Congratulations! You have just run your first workflow in the cloud using Amazon Genomics CLI! At this point you can run additional workflows, including submitting several instances of the "hello world" workflow.
 The elastic compute resources will expand and contract as necessary to accommodate the backlog of submitted workflows.


### PR DESCRIPTION
`agc workflow status` command was missing the `-r` flag to indicate that the string we are passing in is the run-id.

Issue #, if available:

**Description of Changes**

[//]: #  This change makes the workflow status command in the tutorial work.

**Description of how you validated changes**

[//]: # Ran the command successfully as well as referred to agc workflow status --help documentation which declares the -r (or --run-id) flag is necessary when specifying the run-id string.


**Checklist**

- [x] If this change would make any existing documentation invalid, I have included those updates within this PR
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have linted my code before raising the PR


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
