### PR TITLE
Allowing adapter role to access the correct job queue for head jobs t…

### DIFF
--- a/packages/cdk/lib/stacks/nested/nextflow-engine-stack.ts
+++ b/packages/cdk/lib/stacks/nested/nextflow-engine-stack.ts
@@ -47,7 +47,7 @@ export class NextflowEngineStack extends NestedEngineStack {
 
     const adapterRole = new NextflowAdapterRole(this, "NextflowAdapterRole", {
       headJobDefinitionArn: this.nextflowEngine.headJobDefinition.jobDefinitionArn,
-      jobQueueArn: props.jobQueue.jobQueueArn,
+      jobQueueArn: props.headQueue.jobQueueArn,
       readOnlyBucketArns: [],
       readWriteBucketArns: [outputBucket.bucketArn],
     });


### PR DESCRIPTION
This change is fixing a bug introduced in https://github.com/aws/amazon-genomics-cli/pull/57, where nextflow adapter role doesn't have sufficient privileges to submit a new work request into HeadJob in spot context situation.

**Description of Changes**

Providing the correct JobQueue for role creation class

**Description of how you validated changes**

I've deployed the modified version of CDK into my own test account and ran a workflow successfully.


**Checklist**

- [ ] If this change would make any existing documentation invalid, I have included those updates within this PR
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have linted my code before raising the PR


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
