### PR TITLE
add instructions to use AGC local CDK for bootstrapping

### DIFF
--- a/site/content/en/docs/Getting started/setup.md
+++ b/site/content/en/docs/Getting started/setup.md
@@ -11,6 +11,18 @@ Amazon Genomics CLI uses AWS CDK to deploy infrastructure. If you have not alrea
 CDK Bootstrap deploys the infrastructure needed to allow CDK to deploy CDK defined infrastructure. Full details are available
 [here](https://docs.aws.amazon.com/cdk/latest/guide/bootstrapping.html).
 
+Amazon Genomics CLI will install its own local copy of of the AWS CDK. If you do not have the AWS CDK installed globally on your machine use can also use this local copy by changing to the Amazon Genomics CLI CDK installation location:
+
+```
+cd $HOME/.agc/cdk
+```
+
+and using `npx` to invoke the CDK:
+
+```
+npx cdk ...
+```
+
 To bootstrap a single region:
 
 `cdk bootstrap aws://ACCOUNT-NUMBER-1/REGION-1`


### PR DESCRIPTION
**Description of Changes**

[//]: #  (A description of the change that you made and the new user experience that it creates)
CDK Bootstrapping an account assumes a CDK installation. AGC will install a local version of the CDK. For users that do not have the CDK installed globally (or do not have the means to do so), provide instructions to use the AGC local version of the CDK to perform account bootstrapping.

**Description of how you validated changes**

[//]: #  (A description of you validated your changes and any relevant logs that show your change works)
Tested in CloudShell:

```shell
# no CDK available to user globally
$ cd ~
$ cdk --version
bash: cdk: command not found

# fully functional CDK installed with AGC
$ cd ~/.agc/cdk
$ npx cdk --version
1.126.0 (build f004e1a)

```

**Checklist**

- [x] If this change would make any existing documentation invalid, I have included those updates within this PR
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have linted my code before raising the PR


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
