### PR TITLE
Passing environment variables to increase tolerance for metadata serv…

### DIFF
--- a/packages/cdk/lib/constructs/engines/nextflow/nextflow-engine.ts
+++ b/packages/cdk/lib/constructs/engines/nextflow/nextflow-engine.ts
@@ -34,6 +34,8 @@ export class NextflowEngine extends Construct {
           NF_JOB_QUEUE: props.jobQueueArn,
           NF_WORKDIR: `${props.rootDir}/runs`,
           NF_LOGSDIR: `${props.rootDir}/logs`,
+          AWS_METADATA_SERVICE_TIMEOUT: "10",
+          AWS_METADATA_SERVICE_NUM_ATTEMPTS: "10",
         },
         volumes: [],
       },


### PR DESCRIPTION
During large scatter steps (e.g. nextflow sarek workflow), container jobs may fail to get credentials. In Cromwell this was due to jobs swamping the host metadata service. The fix in that case was to include the following in the container environment:

```
export AWS_METADATA_SERVICE_TIMEOUT=10
export AWS_METADATA_SERVICE_NUM_ATTEMPTS=10
```

**Description of Changes**
Passing the environment variables alongside the other ones we have

**Description of how you validated changes**
I've deployed the new CDK code into my own test account, ran a workflow and verified that newly provided env variables are printed out to me in the job log 


**Checklist**

- [x] If this change would make any existing documentation invalid, I have included those updates within this PR
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have linted my code before raising the PR


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
