### PR TITLE
Adds windows 10 as an OS option using Linux

### DIFF
--- a/site/content/en/docs/Getting started/prerequisites.md
+++ b/site/content/en/docs/Getting started/prerequisites.md
@@ -11,6 +11,7 @@ To run Amazon Genomics CLI the following prerequisites must be met:
   * macOS 10.14+
   * Amazon Linux 2
   * Ubuntu 20.04
+  * Windows 10 with a Windows subsystem running Ubuntu which runs the commands
 * Internet access
 * An AWS Account
 * An AWS role with sufficient access. To generate the minimum required policies for admins and users, please follow the instructions [here](https://github.com/aws/amazon-genomics-cli/tree/main/extras/agc-minimal-permissions).


### PR DESCRIPTION
Tested AGC on a windows 10 machine running Ubuntu

Issue #, if available:

**Description of Changes**

Updates the description of relevant OS's that can be used to run AGC

**Description of how you validated changes**

Installed AGC, ran activate account, context deploy, workflow run, logs workflow and context destroy on my windows 10 machine using the Windows Subsystem for Linux. In particular the Ubuntu image from the Windows Store.


**Checklist**

- [x] If this change would make any existing documentation invalid, I have included those updates within this PR
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have linted my code before raising the PR


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
