### PR TITLE
Workflow and Context autocomplete implementation

### DIFF
--- a/packages/cli/internal/pkg/cli/context_auto_complete.go
+++ b/packages/cli/internal/pkg/cli/context_auto_complete.go
@@ -1,0 +1,22 @@
+package cli
+
+import (
+	"github.com/aws/amazon-genomics-cli/internal/pkg/cli/context"
+	"github.com/spf13/cobra"
+)
+
+func ContextAutoComplete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) != 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	manager := context.NewManager(profile)
+	workflows, err := manager.List()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+	workflowNames := make([]string, len(workflows))
+	for k := range workflows {
+		workflowNames = append(workflowNames, k)
+	}
+	return workflowNames, cobra.ShellCompDirectiveNoFileComp
+}

--- a/packages/cli/internal/pkg/cli/context_deploy.go
+++ b/packages/cli/internal/pkg/cli/context_deploy.go
@@ -146,5 +146,6 @@ It creates AGC resources in AWS.
 	}
 	cmd.Flags().BoolVar(&vars.deployAll, deployContextAllFlag, false, deployContextAllDescription)
 	cmd.Flags().StringSliceVarP(&vars.contexts, contextFlag, contextFlagShort, nil, deployContextDescription)
+	cmd.RegisterFlagCompletionFunc(contextFlag, ContextAutoComplete)
 	return cmd
 }

--- a/packages/cli/internal/pkg/cli/context_destroy.go
+++ b/packages/cli/internal/pkg/cli/context_destroy.go
@@ -148,5 +148,6 @@ It destroys AGC resources in AWS.`,
 	}
 	cmd.Flags().BoolVar(&vars.destroyAll, destroyContextAllFlag, false, destroyContextAllDescription)
 	cmd.Flags().StringSliceVarP(&vars.contexts, contextFlag, contextFlagShort, nil, destroyContextDescription)
+	cmd.RegisterFlagCompletionFunc(contextFlag, ContextAutoComplete)
 	return cmd
 }

--- a/packages/cli/internal/pkg/cli/logs_core.go
+++ b/packages/cli/internal/pkg/cli/logs_core.go
@@ -81,6 +81,7 @@ func (v *logsSharedVars) setFilterFlags(cmd *cobra.Command) {
 func (v *logsSharedVars) setContextFlag(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&v.contextName, contextFlag, contextFlagShort, "", contextFlagDescription)
 	_ = cmd.MarkFlagRequired(contextFlag)
+	cmd.RegisterFlagCompletionFunc(contextFlag, ContextAutoComplete)
 }
 
 func (o *logsSharedOpts) setDefaultEndTimeIfEmpty() {

--- a/packages/cli/internal/pkg/cli/logs_workflow.go
+++ b/packages/cli/internal/pkg/cli/logs_workflow.go
@@ -193,6 +193,7 @@ If the --run flag is omitted then the latest workflow run is used.`,
 			}
 			return nil
 		}),
+		ValidArgsFunction: WorkflowAutoComplete,
 	}
 	vars.setFilterFlags(cmd)
 	cmd.Flags().StringVarP(&vars.runId, logWorkflowRunFlag, logWorkflowRunFlagShort, "", logWorkflowRunFlagDescription)

--- a/packages/cli/internal/pkg/cli/workflow_auto_complete.go
+++ b/packages/cli/internal/pkg/cli/workflow_auto_complete.go
@@ -1,0 +1,22 @@
+package cli
+
+import (
+	"github.com/aws/amazon-genomics-cli/internal/pkg/cli/workflow"
+	"github.com/spf13/cobra"
+)
+
+func WorkflowAutoComplete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) != 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	manager := workflow.NewManager(profile)
+	workflows, err := manager.ListWorkflows()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+	workflowNames := make([]string, len(workflows))
+	for k := range workflows {
+		workflowNames = append(workflowNames, k)
+	}
+	return workflowNames, cobra.ShellCompDirectiveNoFileComp
+}

--- a/packages/cli/internal/pkg/cli/workflow_describe.go
+++ b/packages/cli/internal/pkg/cli/workflow_describe.go
@@ -77,6 +77,7 @@ An instance is created every time we run a workflow.
 			format.Default.Write(workflow)
 			return nil
 		}),
+		ValidArgsFunction: WorkflowAutoComplete,
 	}
 	return cmd
 }

--- a/packages/cli/internal/pkg/cli/workflow_run.go
+++ b/packages/cli/internal/pkg/cli/workflow_run.go
@@ -77,5 +77,6 @@ using input parameters contained in file "file:///Users/ec2-user/myproj/test-arg
 	cmd.Flags().StringVarP(&vars.Arguments, argsFlag, argsFlagShort, "", argsFlagDescription)
 	cmd.Flags().StringVarP(&vars.ContextName, contextFlag, contextFlagShort, "", contextFlagDescription)
 	_ = cmd.MarkFlagRequired(contextFlag)
+	cmd.RegisterFlagCompletionFunc(contextFlag, ContextAutoComplete)
 	return cmd
 }


### PR DESCRIPTION
**Description of Changes**

Implemented autocomplete functionality for the Context flag, and whenever a workflow name is required.
This functionality is implemented by using `"Context/Workflow"manager.List` which lists the contexts and workflows defined in the agc-project.yaml file.

**Description of how you validated changes**

Ran `make`, installed the local version of AGC, and followed the steps to use auto complete. Then attempted to use autocomplete for workflows and contexts successfully.


**Checklist**

- [x] If this change would make any existing documentation invalid, I have included those updates within this PR
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have linted my code before raising the PR


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
