### PR TITLE
rnaseq pipeline to use proper inputs.json file

### DIFF
--- a/examples/nf-core-project/workflows/rnaseq/MANIFEST.json
+++ b/examples/nf-core-project/workflows/rnaseq/MANIFEST.json
@@ -1,7 +1,7 @@
 {
   "mainWorkflowURL": "https://github.com/nextflow-io/rnaseq-nf.git",
   "inputFileURLs": [
-    "workflows/atacseq/inputs.json"
+    "workflows/rnaseq/inputs.json"
   ],
   "engineOptions": "-resume"
 }


### PR DESCRIPTION
The rnaseq pipeline was referencing the inputs.json file from the atacseq example. This PR switches it to the proper inputs.json file.

The old inputs.json file:
```

{
  "input": "s3://healthai-public-assets-us-east-1/agc-demo-data/atacseq/design.csv",
  "genome": "GRCh38",
  "single_end": true
}
```
The new inputs.json file:
```
{
  "reads": "s3://1000genomes/phase3/data/HG00243/sequence_read/SRR*_{1,2}.filt.fastq.gz",
  "genome": "GRCh37",
  "skip_qc": true
}
```

Issue #, if available:

**Description of Changes**

[//]: #  (A description of the change that you made and the new user experience that it creates)

**Description of how you validated changes**

[//]: #  (A description of you validated your changes and any relevant logs that show your change works)


**Checklist**

- [ ] If this change would make any existing documentation invalid, I have included those updates within this PR
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have linted my code before raising the PR


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
