### PR TITLE
Add Stale Issue Handling

### DIFF
--- a/.github/workflows/stale_issue.yml
+++ b/.github/workflows/stale_issue.yml
@@ -1,0 +1,46 @@
+name: "Close stale issues"
+
+# Controls when the action will run.
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    name: Stale issue job
+    steps:
+    - uses: aws-actions/stale-issue-cleanup@v3
+      with:
+        # Setting messages to an empty string will cause the automation to skip
+        # that category
+        ancient-issue-message: Greetings! Sorry to say but this is a very old issue that is probably not getting as much attention as it deservers. We encourage you to check if this is still an issue in the latest release and if you find that this is still a problem, please feel free to open a new one.
+        stale-issue-message: Greetings! It looks like this issue hasn’t been active in longer than three months. We encourage you to check if this is still an issue in the latest release. Because it has been longer than three months since the last update on this, and in the absence of more information, we will be closing this issue soon. If you find that this is still a problem, please feel free to provide a comment or add an upvote to prevent automatic closure, or if the issue is already closed, please feel free to open a new one.
+        stale-pr-message: Greetings! It looks like this PR hasn’t been active in longer than three months, add a comment or an upvote to prevent automatic closure, or if the issue is already closed, please feel free to open a new one.
+
+        # These labels are required
+        stale-issue-label: closing-soon
+        exempt-issue-label: automation-exempt
+        stale-pr-label: closing-soon
+        exempt-pr-label: needs-review
+        response-requested-label: response-requested
+
+        # Don't set closed-for-staleness label to skip closing very old issues
+        # regardless of label
+        closed-for-staleness-label: closed-for-staleness
+
+        # Issue timing
+        days-before-stale: 1
+        days-before-close: 1
+        days-before-ancient: 90
+
+        # If you don't want to mark a issue as being ancient based on a
+        # threshold of "upvotes", you can set this here. An "upvote" is
+        # the total number of +1, heart, hooray, and rocket reactions
+        # on an issue.
+        minimum-upvotes-to-exempt: 1
+
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        loglevel: DEBUG
+        # Set dry-run to true to not perform label or close actions.
+        dry-run: false


### PR DESCRIPTION
Issue #, if available:

**Description of Changes**
Add Stale Issue Handling. Runs daily to scan for issues and PRs that are older than 90 days and prompt users and close them accordingly. 

[//]: #  (A description of the change that you made and the new user experience that it creates)

**Description of how you validated changes**
* Tested these changes on my personal forked repo: https://github.com/a-li/amazon-genomics-cli/issues/9 The SLA has been changed on my own repo for quicker experimentation turnaround.

[//]: #  (A description of you validated your changes and any relevant logs that show your change works)


**Checklist**

- [x] If this change would make any existing documentation invalid, I have included those updates within this PR
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have linted my code before raising the PR


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
