### PR TITLE
feat: context destroy --force flag

### DIFF
--- a/packages/cli/internal/pkg/cli/context_destroy.go
+++ b/packages/cli/internal/pkg/cli/context_destroy.go
@@ -60,7 +60,7 @@ func (o *destroyContextOpts) Validate() error {
 
 	wfsManager := o.wfsManager()
 	for _, ctx := range o.contexts {
-		workflows, err := wfsManager.StatusWorkflowByContext(ctx, workflowMaxInstanceDefault)
+		workflows, err := wfsManager.StatusWorkflowByContext(ctx, workflowMaxAllowedInstance)
 		if err != nil {
 			return err
 		}

--- a/packages/cli/internal/pkg/cli/context_destroy_test.go
+++ b/packages/cli/internal/pkg/cli/context_destroy_test.go
@@ -23,7 +23,7 @@ func TestDestroyContextOpts_Validate_ValidContexts(t *testing.T) {
 	ctxMock := contextmocks.NewMockContextManager(ctrl)
 	ctxMock.EXPECT().List().Return(map[string]context.Summary{testContextName1: {}, testContextName2: {}}, nil)
 	wfMock := workflowmocks.NewMockWorkflowManager(ctrl)
-	wfMock.EXPECT().StatusWorkflowByContext(testContextName1, 20).Return([]workflow.InstanceSummary{}, nil)
+	wfMock.EXPECT().StatusWorkflowByContext(testContextName1, workflowMaxAllowedInstance).Return([]workflow.InstanceSummary{}, nil)
 	opts := &destroyContextOpts{
 		destroyContextVars: destroyContextVars{contexts: []string{testContextName1}},
 		wfsManager: func() workflow.Interface {
@@ -44,8 +44,8 @@ func TestDestroyContextOpts_Validate_ValidAll(t *testing.T) {
 	workflowCtrl := gomock.NewController(t)
 	defer workflowCtrl.Finish()
 	wfMock := workflowmocks.NewMockWorkflowManager(workflowCtrl)
-	wfMock.EXPECT().StatusWorkflowByContext(testContextName1, workflowMaxInstanceDefault).Return([]workflow.InstanceSummary{}, nil)
-	wfMock.EXPECT().StatusWorkflowByContext(testContextName2, workflowMaxInstanceDefault).Return([]workflow.InstanceSummary{}, nil)
+	wfMock.EXPECT().StatusWorkflowByContext(testContextName1, workflowMaxAllowedInstance).Return([]workflow.InstanceSummary{}, nil)
+	wfMock.EXPECT().StatusWorkflowByContext(testContextName2, workflowMaxAllowedInstance).Return([]workflow.InstanceSummary{}, nil)
 	opts := &destroyContextOpts{
 		destroyContextVars: destroyContextVars{destroyAll: true},
 		wfsManager: func() workflow.Interface {
@@ -128,7 +128,7 @@ func TestDestroyContextOpts_Validate_ContainsRunningContext(t *testing.T) {
 	failedSummary := []workflow.InstanceSummary{{State: "RUNNING"}}
 	expectedError := fmt.Sprintf("context '%s' contains running workflows. Please stop all workflows before destroying context", testContextName1)
 	ctxMock.EXPECT().List().Return(map[string]context.Summary{testContextName1: {}, testContextName2: {}}, nil)
-	wfMock.EXPECT().StatusWorkflowByContext(testContextName1, workflowMaxInstanceDefault).Return(failedSummary, nil)
+	wfMock.EXPECT().StatusWorkflowByContext(testContextName1, workflowMaxAllowedInstance).Return(failedSummary, nil)
 	opts := &destroyContextOpts{
 		destroyContextVars: destroyContextVars{contexts: contexts},
 		wfsManager: func() workflow.Interface {
@@ -152,7 +152,7 @@ func TestDestroyContextOpts_ValidateForce_ContainsRunningContext(t *testing.T) {
 	runId := "testId"
 	runningSummary := []workflow.InstanceSummary{{State: "RUNNING", Id: runId}}
 	ctxMock.EXPECT().List().Return(map[string]context.Summary{testContextName1: {}, testContextName2: {}}, nil)
-	wfMock.EXPECT().StatusWorkflowByContext(testContextName1, workflowMaxInstanceDefault).Return(runningSummary, nil)
+	wfMock.EXPECT().StatusWorkflowByContext(testContextName1, workflowMaxAllowedInstance).Return(runningSummary, nil)
 	wfMock.EXPECT().StopWorkflowInstance(runId)
 	opts := &destroyContextOpts{
 		destroyContextVars: destroyContextVars{contexts: contexts, destroyForce: true},

--- a/packages/cli/internal/pkg/cli/workflow_status.go
+++ b/packages/cli/internal/pkg/cli/workflow_status.go
@@ -24,6 +24,7 @@ type workflowStatusOpts struct {
 }
 
 const workflowMaxInstanceDefault = 20
+const workflowMaxAllowedInstance = 1000
 
 func newWorkflowStatusOpts(vars workflowStatusVars) (*workflowStatusOpts, error) {
 	return &workflowStatusOpts{
@@ -37,7 +38,7 @@ func (o *workflowStatusOpts) Validate() error {
 	if o.MaxInstances <= 0 {
 		return fmt.Errorf("max number of workflow instances should be grater than 0, provided value: %d", o.MaxInstances)
 	}
-	if o.MaxInstances > 1000 {
+	if o.MaxInstances > workflowMaxAllowedInstance {
 		return fmt.Errorf("max number of workflow instances should not be greater than 1000, provided value: %d", o.MaxInstances)
 	}
 	return nil


### PR DESCRIPTION
<!-- Title format: type(scope): Short description (72 chars max for line) -->
<!-- `(scope)` is optional and `type` is one of: build, ci, chore, docs, feat, fix, perf, refactor, revert, style, test -->
<!-- Available types:
- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit -->

**Description of Changes**

Added `--force` flag to context destroy which will run  terminate all running workflow within a context, then continue to destroy the context

**Description of how you validated changes**

All code tested with `make` and manually tested with running contexts to make sure they will be properly stopped.

**Checklist**

- [x] If this change would make any existing documentation invalid, I have included those updates within this PR
- [x] have added unit tests that prove my fix is effective or that my feature works
- [x] I have linted my code before raising the PR
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
