### PR TITLE
fix: Pass engine endpoint directly to the wes adapter

### DIFF
--- a/packages/cdk/lib/env/context-app-parameters.ts
+++ b/packages/cdk/lib/env/context-app-parameters.ts
@@ -130,7 +130,7 @@ export class ContextAppParameters {
     };
   }
 
-  public getAdapterContainer(): ServiceContainer {
+  public getAdapterContainer(additionalEnvVars?: { [key: string]: string }): ServiceContainer {
     return {
       serviceName: this.adapterName,
       imageConfig: { designation: this.adapterDesignation },
@@ -141,6 +141,7 @@ export class ContextAppParameters {
         CONTEXT_NAME: this.contextName,
         USER_ID: this.userId,
         ENGINE_NAME: this.engineName,
+        ...additionalEnvVars,
       },
     };
   }

--- a/packages/cdk/lib/util/index.ts
+++ b/packages/cdk/lib/util/index.ts
@@ -82,13 +82,11 @@ export const renderServiceWithTaskDefinition = (
   id: string,
   serviceContainer: ServiceContainer,
   taskDefinition: TaskDefinition,
-  vpc: IVpc,
-  cloudMapOptions?: CloudMapOptions
+  vpc: IVpc
 ): SecureService => {
   return new SecureService(scope, id, {
     vpc,
     serviceName: serviceContainer.serviceName,
-    cloudMapOptions,
     taskDefinition: taskDefinition,
     healthCheck: {
       path: serviceContainer.healthCheckPath ?? defaultHealthCheckPath,


### PR DESCRIPTION

<!-- Title format: type(scope): Short description (72 chars max for line) -->
<!-- `(scope)` is optional and `type` is one of: build, ci, chore, docs, feat, fix, perf, refactor, revert, style, test -->
<!-- Available types:
- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit -->

Issue #, if available:

**Description of Changes**

Currently, we use CloudMap and a PrivateDnsNamespace to compose the engine endpoint name in the wes adapter,
this would create a private dns name in a private hostedZone. This is unnecessary since we have engine loadbalancer's DNS name,
we can directly tell the wes adapter how to talk to the engine.


**Checklist**

- [x] If this change would make any existing documentation invalid, I have included those updates within this PR
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have linted my code before raising the PR
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
