### PR TITLE
fix: Adds a message when new logs aren't shown to the user immediately

### DIFF
--- a/packages/cli/internal/pkg/aws/cwl/stream_logs.go
+++ b/packages/cli/internal/pkg/aws/cwl/stream_logs.go
@@ -38,6 +38,8 @@ func (c Client) StreamLogs(ctx context.Context, logGroupName string, streams ...
 			if aws.ToString(lastToken) != aws.ToString(output.NextToken) {
 				stream <- StreamEvent{Logs: parseEventLogs(output.Events, startTime)}
 				lastToken = output.NextToken
+			} else {
+				stream <- StreamEvent{}
 			}
 
 			select {

--- a/packages/cli/internal/pkg/cli/logs_core.go
+++ b/packages/cli/internal/pkg/cli/logs_core.go
@@ -124,6 +124,19 @@ func (o *logsSharedOpts) followLogGroup(logGroupName string) error {
 }
 
 func (o *logsSharedOpts) displayEventFromChannel(channel <-chan cwl.StreamEvent) error {
+	firstEvent := <-channel
+
+	if firstEvent.Err != nil {
+		return firstEvent.Err
+	}
+	if len(firstEvent.Logs) > 0 {
+		for _, line := range firstEvent.Logs {
+			printLn(line)
+		}
+	} else {
+		printLn("There are no new logs. Please wait for new logs to show...")
+	}
+
 	for event := range channel {
 		if event.Err != nil {
 			return event.Err

--- a/packages/cli/internal/pkg/cli/logs_core_test.go
+++ b/packages/cli/internal/pkg/cli/logs_core_test.go
@@ -116,7 +116,7 @@ func Test_displayEventFromChannel_noLogs_showsWaitingMessage(t *testing.T) {
 		channel <- cwl.StreamEvent{Logs: []string{}}
 		close(channel)
 	}()
-	opts.displayEventFromChannel(channel)
+	_ = opts.displayEventFromChannel(channel)
 }
 
 func Test_displayEventFromChannel_oneLog_OnlyShowsMessageFromChannel(t *testing.T) {
@@ -136,5 +136,5 @@ func Test_displayEventFromChannel_oneLog_OnlyShowsMessageFromChannel(t *testing.
 		channel <- cwl.StreamEvent{Logs: []string{"hi"}}
 		defer close(channel)
 	}()
-	opts.displayEventFromChannel(channel)
+	_ = opts.displayEventFromChannel(channel)
 }

--- a/packages/cli/internal/pkg/mocks/io/interfaces.go
+++ b/packages/cli/internal/pkg/mocks/io/interfaces.go
@@ -25,3 +25,7 @@ type FileReader interface {
 type FileWriter interface {
 	WriteFile(filename string, data []byte, perm fs.FileMode) error
 }
+
+type Format interface {
+	LogsPrintLn(args ...interface{})
+}

--- a/packages/cli/internal/pkg/mocks/io/mock_interfaces.go
+++ b/packages/cli/internal/pkg/mocks/io/mock_interfaces.go
@@ -256,3 +256,42 @@ func (mr *MockFileWriterMockRecorder) WriteFile(filename, data, perm interface{}
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteFile", reflect.TypeOf((*MockFileWriter)(nil).WriteFile), filename, data, perm)
 }
+
+// MockFormat is a mock of Format interface.
+type MockFormat struct {
+	ctrl     *gomock.Controller
+	recorder *MockFormatMockRecorder
+}
+
+// MockFormatMockRecorder is the mock recorder for MockFormat.
+type MockFormatMockRecorder struct {
+	mock *MockFormat
+}
+
+// NewMockFormat creates a new mock instance.
+func NewMockFormat(ctrl *gomock.Controller) *MockFormat {
+	mock := &MockFormat{ctrl: ctrl}
+	mock.recorder = &MockFormatMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockFormat) EXPECT() *MockFormatMockRecorder {
+	return m.recorder
+}
+
+// LogsPrintLn mocks base method.
+func (m *MockFormat) LogsPrintLn(args ...interface{}) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{}
+	for _, a := range args {
+		varargs = append(varargs, a)
+	}
+	m.ctrl.Call(m, "LogsPrintLn", varargs...)
+}
+
+// LogsPrintLn indicates an expected call of LogsPrintLn.
+func (mr *MockFormatMockRecorder) LogsPrintLn(args ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogsPrintLn", reflect.TypeOf((*MockFormat)(nil).LogsPrintLn), args...)
+}


### PR DESCRIPTION
Issue #, if available: NA

**Description of Changes**

Currently, when you run the tail logs command it can look like the command hung when it is run. This change provides some messaging to the user so that they are aware that the reason that there are no logs shows is because there aren't any new ones.

NB: The current approach *can* show the message immediately before messages are shown if they exist since we split up the request to AWS if the number of streams is larger than the limit. However, this is unlikely, could also happen if the logs start appearing immediately after the first request is made and would make the logic more complicated because of this I have gone with the simpler solution.


**Description of how you validated changes**
Ran the commands while running workflows

```
$ agc logs engine -c onDemandContext -t
2021-10-29T10:53:41-07:00 𝒊  Showing engine logs for 'onDemandContext'
There are no new logs. Please wait for new logs to show...
```


**Checklist**

- [ ] If this change would make any existing documentation invalid, I have included those updates within this PR
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have linted my code before raising the PR
- [ ] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
