### PR TITLE
fix: Adds a message when new logs aren't shown to the user immediately

### DIFF
--- a/packages/cli/internal/pkg/aws/cwl/stream_logs.go
+++ b/packages/cli/internal/pkg/aws/cwl/stream_logs.go
@@ -38,6 +38,8 @@ func (c Client) StreamLogs(ctx context.Context, logGroupName string, streams ...
 			if aws.ToString(lastToken) != aws.ToString(output.NextToken) {
 				stream <- StreamEvent{Logs: parseEventLogs(output.Events, startTime)}
 				lastToken = output.NextToken
+			} else {
+				stream <- StreamEvent{}
 			}
 
 			select {

--- a/packages/cli/internal/pkg/cli/logs_core.go
+++ b/packages/cli/internal/pkg/cli/logs_core.go
@@ -42,6 +42,8 @@ Use a question mark for OR, such as "?ERROR ?WARN". Filter out terms with a minu
 	tailFlagDescription = "Follow the log output."
 )
 
+var logInfo = log.Info
+
 var printLn = func(args ...interface{}) {
 	_, _ = fmt.Println(args...)
 }
@@ -137,7 +139,7 @@ func (o *logsSharedOpts) displayEventFromChannel(channel <-chan cwl.StreamEvent)
 			firstEvent = false
 		} else if firstEvent {
 			firstEvent = false
-			printLn("There are no new logs. Please wait for the first logs to appear...")
+			logInfo().Msg("There are no new logs. Please wait for the first logs to appear...")
 		} else {
 			log.Debug().Msg("No new logs")
 		}

--- a/packages/cli/internal/pkg/cli/logs_core.go
+++ b/packages/cli/internal/pkg/cli/logs_core.go
@@ -136,13 +136,13 @@ func (o *logsSharedOpts) displayEventFromChannel(channel <-chan cwl.StreamEvent)
 			for _, line := range event.Logs {
 				printLn(line)
 			}
-			firstEvent = false
 		} else if firstEvent {
-			firstEvent = false
 			logInfo().Msg("There are no new logs. Please wait for the first logs to appear...")
 		} else {
 			log.Debug().Msg("No new logs")
 		}
+
+		firstEvent = false
 	}
 
 	return nil

--- a/packages/cli/internal/pkg/cli/logs_core.go
+++ b/packages/cli/internal/pkg/cli/logs_core.go
@@ -124,6 +124,19 @@ func (o *logsSharedOpts) followLogGroup(logGroupName string) error {
 }
 
 func (o *logsSharedOpts) displayEventFromChannel(channel <-chan cwl.StreamEvent) error {
+	firstEvent := <-channel
+
+	if firstEvent.Err != nil {
+		return firstEvent.Err
+	}
+	if len(firstEvent.Logs) > 0 {
+		for _, line := range firstEvent.Logs {
+			printLn(line)
+		}
+	} else {
+		printLn("There are no new logs. Please wait for new logs to show...")
+	}
+
 	for event := range channel {
 		if event.Err != nil {
 			return event.Err

--- a/packages/cli/internal/pkg/cli/logs_core.go
+++ b/packages/cli/internal/pkg/cli/logs_core.go
@@ -137,7 +137,7 @@ func (o *logsSharedOpts) displayEventFromChannel(channel <-chan cwl.StreamEvent)
 			firstEvent = false
 		} else if firstEvent {
 			firstEvent = false
-			printLn("There are no new logs. Please wait for new logs to show...")
+			printLn("There are no new logs. Please wait for the first logs to appear...")
 		} else {
 			log.Debug().Msg("No new logs")
 		}

--- a/packages/cli/internal/pkg/cli/logs_core.go
+++ b/packages/cli/internal/pkg/cli/logs_core.go
@@ -124,18 +124,7 @@ func (o *logsSharedOpts) followLogGroup(logGroupName string) error {
 }
 
 func (o *logsSharedOpts) displayEventFromChannel(channel <-chan cwl.StreamEvent) error {
-	firstEvent := <-channel
-
-	if firstEvent.Err != nil {
-		return firstEvent.Err
-	}
-	if len(firstEvent.Logs) > 0 {
-		for _, line := range firstEvent.Logs {
-			printLn(line)
-		}
-	} else {
-		printLn("There are no new logs. Please wait for new logs to show...")
-	}
+	firstEvent := true
 
 	for event := range channel {
 		if event.Err != nil {
@@ -145,10 +134,15 @@ func (o *logsSharedOpts) displayEventFromChannel(channel <-chan cwl.StreamEvent)
 			for _, line := range event.Logs {
 				printLn(line)
 			}
+			firstEvent = false
+		} else if firstEvent {
+			firstEvent = false
+			printLn("There are no new logs. Please wait for new logs to show...")
 		} else {
 			log.Debug().Msg("No new logs")
 		}
 	}
+
 	return nil
 }
 

--- a/packages/cli/internal/pkg/cli/logs_core_test.go
+++ b/packages/cli/internal/pkg/cli/logs_core_test.go
@@ -106,7 +106,7 @@ func Test_displayEventFromChannel_noLogs_showsWaitingMessage(t *testing.T) {
 	orig := printLn
 	printLn = mockFmt.LogsPrintLn
 
-	mockFmt.EXPECT().LogsPrintLn("There are no new logs. Please wait for new logs to show...").Times(1)
+	mockFmt.EXPECT().LogsPrintLn("There are no new logs. Please wait for the first logs to appear...").Times(1)
 
 	opts := logsAccessOpts{
 		logsSharedOpts: logsSharedOpts{cwlClient: cwlMock},

--- a/packages/cli/internal/pkg/cli/logs_core_test.go
+++ b/packages/cli/internal/pkg/cli/logs_core_test.go
@@ -102,11 +102,11 @@ func Test_fanInChannels_nominal(t *testing.T) {
 func Test_displayEventFromChannel_noLogs_showsWaitingMessage(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	cwlMock := awsmocks.NewMockCwlClient(ctrl)
-	mockFmt := iomocks.NewMockFormat(ctrl)
-	orig := printLn
-	printLn = mockFmt.LogsPrintLn
+	mockLogs := iomocks.NewMockLog(ctrl)
+	orig := logInfo
+	logInfo = mockLogs.Info
 
-	mockFmt.EXPECT().LogsPrintLn("There are no new logs. Please wait for the first logs to appear...").Times(1)
+	mockLogs.EXPECT().Info().Times(1)
 
 	opts := logsAccessOpts{
 		logsSharedOpts: logsSharedOpts{cwlClient: cwlMock},
@@ -118,7 +118,7 @@ func Test_displayEventFromChannel_noLogs_showsWaitingMessage(t *testing.T) {
 		close(channel)
 	}()
 	_ = opts.displayEventFromChannel(channel)
-	printLn = orig
+	logInfo = orig
 }
 
 func Test_displayEventFromChannel_oneLog_OnlyShowsMessageFromChannel(t *testing.T) {

--- a/packages/cli/internal/pkg/cli/logs_core_test.go
+++ b/packages/cli/internal/pkg/cli/logs_core_test.go
@@ -103,6 +103,7 @@ func Test_displayEventFromChannel_noLogs_showsWaitingMessage(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	cwlMock := awsmocks.NewMockCwlClient(ctrl)
 	mockFmt := iomocks.NewMockFormat(ctrl)
+	orig := printLn
 	printLn = mockFmt.LogsPrintLn
 
 	mockFmt.EXPECT().LogsPrintLn("There are no new logs. Please wait for new logs to show...").Times(1)
@@ -116,13 +117,15 @@ func Test_displayEventFromChannel_noLogs_showsWaitingMessage(t *testing.T) {
 		channel <- cwl.StreamEvent{Logs: []string{}}
 		close(channel)
 	}()
-	opts.displayEventFromChannel(channel)
+	_ = opts.displayEventFromChannel(channel)
+	printLn = orig
 }
 
 func Test_displayEventFromChannel_oneLog_OnlyShowsMessageFromChannel(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	cwlMock := awsmocks.NewMockCwlClient(ctrl)
 	mockFmt := iomocks.NewMockFormat(ctrl)
+	orig := printLn
 	printLn = mockFmt.LogsPrintLn
 
 	mockFmt.EXPECT().LogsPrintLn("hi").Return().Times(1)
@@ -136,5 +139,6 @@ func Test_displayEventFromChannel_oneLog_OnlyShowsMessageFromChannel(t *testing.
 		channel <- cwl.StreamEvent{Logs: []string{"hi"}}
 		defer close(channel)
 	}()
-	opts.displayEventFromChannel(channel)
+	_ = opts.displayEventFromChannel(channel)
+	printLn = orig
 }

--- a/packages/cli/internal/pkg/mocks/io/interfaces.go
+++ b/packages/cli/internal/pkg/mocks/io/interfaces.go
@@ -1,6 +1,10 @@
 package iomocks
 
-import "io/fs"
+import (
+	"io/fs"
+
+	"github.com/rs/zerolog"
+)
 
 type OS interface {
 	Remove(name string) error
@@ -28,4 +32,8 @@ type FileWriter interface {
 
 type Format interface {
 	LogsPrintLn(args ...interface{})
+}
+
+type Log interface {
+	Info() *zerolog.Event
 }

--- a/packages/cli/internal/pkg/mocks/io/interfaces.go
+++ b/packages/cli/internal/pkg/mocks/io/interfaces.go
@@ -25,3 +25,7 @@ type FileReader interface {
 type FileWriter interface {
 	WriteFile(filename string, data []byte, perm fs.FileMode) error
 }
+
+type Format interface {
+	LogsPrintLn(args ...interface{})
+}

--- a/packages/cli/internal/pkg/mocks/io/mock_interfaces.go
+++ b/packages/cli/internal/pkg/mocks/io/mock_interfaces.go
@@ -256,3 +256,42 @@ func (mr *MockFileWriterMockRecorder) WriteFile(filename, data, perm interface{}
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteFile", reflect.TypeOf((*MockFileWriter)(nil).WriteFile), filename, data, perm)
 }
+
+// MockFormat is a mock of Format interface.
+type MockFormat struct {
+	ctrl     *gomock.Controller
+	recorder *MockFormatMockRecorder
+}
+
+// MockFormatMockRecorder is the mock recorder for MockFormat.
+type MockFormatMockRecorder struct {
+	mock *MockFormat
+}
+
+// NewMockFormat creates a new mock instance.
+func NewMockFormat(ctrl *gomock.Controller) *MockFormat {
+	mock := &MockFormat{ctrl: ctrl}
+	mock.recorder = &MockFormatMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockFormat) EXPECT() *MockFormatMockRecorder {
+	return m.recorder
+}
+
+// LogsPrintLn mocks base method.
+func (m *MockFormat) LogsPrintLn(args ...interface{}) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{}
+	for _, a := range args {
+		varargs = append(varargs, a)
+	}
+	m.ctrl.Call(m, "LogsPrintLn", varargs...)
+}
+
+// LogsPrintLn indicates an expected call of LogsPrintLn.
+func (mr *MockFormatMockRecorder) LogsPrintLn(args ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogsPrintLn", reflect.TypeOf((*MockFormat)(nil).LogsPrintLn), args...)
+}

--- a/packages/cli/internal/pkg/mocks/io/mock_interfaces.go
+++ b/packages/cli/internal/pkg/mocks/io/mock_interfaces.go
@@ -9,6 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	zerolog "github.com/rs/zerolog"
 )
 
 // MockOS is a mock of OS interface.
@@ -294,4 +295,41 @@ func (m *MockFormat) LogsPrintLn(args ...interface{}) {
 func (mr *MockFormatMockRecorder) LogsPrintLn(args ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogsPrintLn", reflect.TypeOf((*MockFormat)(nil).LogsPrintLn), args...)
+}
+
+// MockLog is a mock of Log interface.
+type MockLog struct {
+	ctrl     *gomock.Controller
+	recorder *MockLogMockRecorder
+}
+
+// MockLogMockRecorder is the mock recorder for MockLog.
+type MockLogMockRecorder struct {
+	mock *MockLog
+}
+
+// NewMockLog creates a new mock instance.
+func NewMockLog(ctrl *gomock.Controller) *MockLog {
+	mock := &MockLog{ctrl: ctrl}
+	mock.recorder = &MockLogMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockLog) EXPECT() *MockLogMockRecorder {
+	return m.recorder
+}
+
+// Info mocks base method.
+func (m *MockLog) Info() *zerolog.Event {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Info")
+	ret0, _ := ret[0].(*zerolog.Event)
+	return ret0
+}
+
+// Info indicates an expected call of Info.
+func (mr *MockLogMockRecorder) Info() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Info", reflect.TypeOf((*MockLog)(nil).Info))
 }


### PR DESCRIPTION
Issue #, if available: NA

Description of Changes

Currently, when you run the tail logs command it can look like the command hung when it is run. This change provides some messaging to the user so that they are aware that the reason that there are no logs shows is because there aren't any new ones. This also adds back the logic to send through empty logs when no new events are sent back from Cloudwatch

NB: The current approach can show the message immediately before messages are shown if they exist since we split up the request to AWS if the number of streams is larger than the limit (greater than 100 streams). However this is unlikely and could also happen if the logs start appearing immediately after the first request is made to AWS. Since this could occur naturally anyway, would make the logic more complicated and doesn't impact the customer experience I have gone with the simpler solution.

Description of how you validated changes
Ran the commands while running workflows

$ agc logs engine -c onDemandContext -t
2021-10-29T10:53:41-07:00 𝒊  Showing engine logs for 'onDemandContext'
There are no new logs. Please wait for the first logs to appear...



**Checklist**

- [x] If this change would make any existing documentation invalid, I have included those updates within this PR
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have linted my code before raising the PR
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
