### PR TITLE
fix: Workflow status now ignores unqueryable stacks

### DIFF
--- a/packages/cli/internal/pkg/aws/cfn/stack_filters.go
+++ b/packages/cli/internal/pkg/aws/cfn/stack_filters.go
@@ -2,41 +2,44 @@ package cfn
 
 import "github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
 
-var ActiveStacksFilter = []types.StackStatus{
-	types.StackStatusCreateInProgress,
-	types.StackStatusCreateComplete,
-	types.StackStatusRollbackInProgress,
-	types.StackStatusRollbackFailed,
-	types.StackStatusRollbackComplete,
-	types.StackStatusDeleteInProgress,
-	types.StackStatusDeleteFailed,
-	types.StackStatusUpdateInProgress,
-	types.StackStatusUpdateCompleteCleanupInProgress,
-	types.StackStatusUpdateComplete,
-	types.StackStatusUpdateRollbackInProgress,
-	types.StackStatusUpdateRollbackFailed,
-	types.StackStatusUpdateRollbackCompleteCleanupInProgress,
-	types.StackStatusUpdateRollbackComplete,
-	types.StackStatusReviewInProgress,
-	types.StackStatusImportInProgress,
-	types.StackStatusImportComplete,
-	types.StackStatusImportRollbackInProgress,
-	types.StackStatusImportRollbackFailed,
-	types.StackStatusImportRollbackComplete,
+type StackOptions struct {
+	activeStack    bool
+	queryableStack bool
 }
-var QueryableStacksMap = map[types.StackStatus]bool{
-	types.StackStatusCreateComplete:                          true,
-	types.StackStatusUpdateInProgress:                        true,
-	types.StackStatusUpdateCompleteCleanupInProgress:         true,
-	types.StackStatusUpdateComplete:                          true,
-	types.StackStatusUpdateRollbackInProgress:                true,
-	types.StackStatusUpdateRollbackFailed:                    true,
-	types.StackStatusUpdateRollbackCompleteCleanupInProgress: true,
-	types.StackStatusUpdateRollbackComplete:                  true,
-	types.StackStatusReviewInProgress:                        true,
-	types.StackStatusImportInProgress:                        true,
-	types.StackStatusImportComplete:                          true,
-	types.StackStatusImportRollbackInProgress:                true,
-	types.StackStatusImportRollbackFailed:                    true,
-	types.StackStatusImportRollbackComplete:                  true,
+
+var stackDefinitions = map[types.StackStatus]StackOptions{
+	types.StackStatusCreateInProgress:                        {activeStack: true, queryableStack: false},
+	types.StackStatusCreateComplete:                          {activeStack: true, queryableStack: true},
+	types.StackStatusRollbackInProgress:                      {activeStack: true, queryableStack: false},
+	types.StackStatusRollbackFailed:                          {activeStack: true, queryableStack: false},
+	types.StackStatusRollbackComplete:                        {activeStack: true, queryableStack: false},
+	types.StackStatusDeleteInProgress:                        {activeStack: true, queryableStack: false},
+	types.StackStatusDeleteFailed:                            {activeStack: true, queryableStack: false},
+	types.StackStatusUpdateInProgress:                        {activeStack: true, queryableStack: true},
+	types.StackStatusUpdateCompleteCleanupInProgress:         {activeStack: true, queryableStack: true},
+	types.StackStatusUpdateComplete:                          {activeStack: true, queryableStack: true},
+	types.StackStatusUpdateRollbackInProgress:                {activeStack: true, queryableStack: true},
+	types.StackStatusUpdateRollbackFailed:                    {activeStack: true, queryableStack: true},
+	types.StackStatusUpdateRollbackCompleteCleanupInProgress: {activeStack: true, queryableStack: true},
+	types.StackStatusUpdateRollbackComplete:                  {activeStack: true, queryableStack: false},
+	types.StackStatusReviewInProgress:                        {activeStack: true, queryableStack: true},
+	types.StackStatusImportInProgress:                        {activeStack: true, queryableStack: true},
+	types.StackStatusImportComplete:                          {activeStack: true, queryableStack: true},
+	types.StackStatusImportRollbackInProgress:                {activeStack: true, queryableStack: true},
+	types.StackStatusImportRollbackFailed:                    {activeStack: true, queryableStack: true},
+	types.StackStatusImportRollbackComplete:                  {activeStack: true, queryableStack: true},
+}
+var ActiveStacksFilter []types.StackStatus
+var QueryableStacksMap map[types.StackStatus]bool
+
+func init() {
+	QueryableStacksMap = make(map[types.StackStatus]bool)
+	for stackStatus, stackOptions := range stackDefinitions {
+		if stackOptions.queryableStack {
+			QueryableStacksMap[stackStatus] = true
+		}
+		if stackOptions.activeStack {
+			ActiveStacksFilter = append(ActiveStacksFilter, stackStatus)
+		}
+	}
 }

--- a/packages/cli/internal/pkg/aws/cfn/stack_filters.go
+++ b/packages/cli/internal/pkg/aws/cfn/stack_filters.go
@@ -24,3 +24,20 @@ var ActiveStacksFilter = []types.StackStatus{
 	types.StackStatusImportRollbackFailed,
 	types.StackStatusImportRollbackComplete,
 }
+
+var QueryableStacksMap = map[types.StackStatus]bool{
+	types.StackStatusCreateComplete:                          true,
+	types.StackStatusUpdateInProgress:                        true,
+	types.StackStatusUpdateCompleteCleanupInProgress:         true,
+	types.StackStatusUpdateComplete:                          true,
+	types.StackStatusUpdateRollbackInProgress:                true,
+	types.StackStatusUpdateRollbackFailed:                    true,
+	types.StackStatusUpdateRollbackCompleteCleanupInProgress: true,
+	types.StackStatusUpdateRollbackComplete:                  true,
+	types.StackStatusReviewInProgress:                        true,
+	types.StackStatusImportInProgress:                        true,
+	types.StackStatusImportComplete:                          true,
+	types.StackStatusImportRollbackInProgress:                true,
+	types.StackStatusImportRollbackFailed:                    true,
+	types.StackStatusImportRollbackComplete:                  true,
+}

--- a/packages/cli/internal/pkg/aws/cfn/stack_filters.go
+++ b/packages/cli/internal/pkg/aws/cfn/stack_filters.go
@@ -35,9 +35,7 @@ var QueryableStacksMap map[types.StackStatus]bool
 func init() {
 	QueryableStacksMap = make(map[types.StackStatus]bool)
 	for stackStatus, stackOptions := range stackDefinitions {
-		if stackOptions.queryableStack {
-			QueryableStacksMap[stackStatus] = true
-		}
+		QueryableStacksMap[stackStatus] = stackOptions.queryableStack
 		if stackOptions.activeStack {
 			ActiveStacksFilter = append(ActiveStacksFilter, stackStatus)
 		}

--- a/packages/cli/internal/pkg/aws/cfn/stack_filters.go
+++ b/packages/cli/internal/pkg/aws/cfn/stack_filters.go
@@ -24,7 +24,6 @@ var ActiveStacksFilter = []types.StackStatus{
 	types.StackStatusImportRollbackFailed,
 	types.StackStatusImportRollbackComplete,
 }
-
 var QueryableStacksMap = map[types.StackStatus]bool{
 	types.StackStatusCreateComplete:                          true,
 	types.StackStatusUpdateInProgress:                        true,

--- a/packages/cli/internal/pkg/cli/workflow/manager.go
+++ b/packages/cli/internal/pkg/cli/workflow/manager.go
@@ -340,8 +340,8 @@ func (m *Manager) isContextDeployed(contextName string) bool {
 		return false
 	}
 
-	_, activeStatusFlag := cfn.QueryableStacksMap[status]
-	return activeStatusFlag
+	ok, activeStatusFlag := cfn.QueryableStacksMap[status]
+	return ok && activeStatusFlag
 }
 
 func (m *Manager) setContext(contextName string) {

--- a/packages/cli/internal/pkg/cli/workflow/manager.go
+++ b/packages/cli/internal/pkg/cli/workflow/manager.go
@@ -331,7 +331,7 @@ func (m *Manager) isContextDeployed(contextName string) bool {
 		return false
 	}
 	engineStackName := awsresources.RenderContextStackName(m.projectSpec.Name, contextName, m.userId)
-	_, err := m.Cfn.GetStackStatus(engineStackName)
+	status, err := m.Cfn.GetStackStatus(engineStackName)
 	if err != nil {
 		if errors.Is(err, cfn.StackDoesNotExistError) {
 			return false
@@ -339,7 +339,9 @@ func (m *Manager) isContextDeployed(contextName string) bool {
 		m.err = err
 		return false
 	}
-	return true
+
+	_, activeStatusFlag := cfn.QueryableStacksMap[status]
+	return activeStatusFlag
 }
 
 func (m *Manager) setContext(contextName string) {

--- a/packages/cli/internal/pkg/cli/workflow/workflow_status_test.go
+++ b/packages/cli/internal/pkg/cli/workflow/workflow_status_test.go
@@ -29,6 +29,42 @@ const (
 	testRunStatusUnknown       = "UNKNOWN"
 )
 
+var workflowInstance1 = ddb.WorkflowInstance{
+	RunId:        testRun1Id,
+	WorkflowName: testWorkflow1,
+	ContextName:  testContext1Name,
+	ProjectName:  testProjectName,
+	UserId:       testUserId,
+	CreatedTime:  testWorkflowSubmitTime1,
+}
+
+var workflowInstance2 = ddb.WorkflowInstance{
+	RunId:        testRun2Id,
+	WorkflowName: testWorkflow1,
+	ContextName:  testContext1Name,
+	ProjectName:  testProjectName,
+	UserId:       testUserId,
+	CreatedTime:  testWorkflowSubmitTime2,
+}
+
+var instanceSummary1 = InstanceSummary{
+	Id:           testRun1Id,
+	WorkflowName: testWorkflow1,
+	ContextName:  testContext1Name,
+	SubmitTime:   testWorkflowSubmitTime1,
+	InProject:    true,
+	State:        testRunStatus1,
+}
+
+var instanceSummary2 = InstanceSummary{
+	Id:           testRun2Id,
+	WorkflowName: testWorkflow1,
+	ContextName:  testContext1Name,
+	SubmitTime:   testWorkflowSubmitTime2,
+	InProject:    true,
+	State:        testRunStatus2,
+}
+
 type WorkflowStatusTestSuite struct {
 	suite.Suite
 	ctrl              *gomock.Controller
@@ -115,22 +151,8 @@ func (s *WorkflowStatusTestSuite) TestStatusWorkflowAll_InstancesSameContext() {
 	s.mockProjectClient.EXPECT().Read().Return(s.testProjSpec, nil)
 	s.mockConfigClient.EXPECT().GetUserId().Return(testUserId, nil)
 	instances := []ddb.WorkflowInstance{
-		{
-			RunId:        testRun2Id,
-			WorkflowName: testWorkflow1,
-			ContextName:  testContext1Name,
-			ProjectName:  testProjectName,
-			UserId:       testUserId,
-			CreatedTime:  testWorkflowSubmitTime2,
-		},
-		{
-			RunId:        testRun1Id,
-			WorkflowName: testWorkflow1,
-			ContextName:  testContext1Name,
-			ProjectName:  testProjectName,
-			UserId:       testUserId,
-			CreatedTime:  testWorkflowSubmitTime1,
-		},
+		workflowInstance2,
+		workflowInstance1,
 	}
 	s.mockDdb.EXPECT().ListWorkflowInstances(ctx.Background(), testProjectName, testUserId, testWorkflowInstancesLimit).Return(instances, nil)
 	s.mockCfn.EXPECT().GetStackStatus(testContext1Stack).Return(types.StackStatusCreateComplete, nil)
@@ -143,22 +165,8 @@ func (s *WorkflowStatusTestSuite) TestStatusWorkflowAll_InstancesSameContext() {
 	actualStatuses, err := s.manager.StatusWorkflowAll(testWorkflowInstancesLimit)
 	if s.Assert().NoError(err) {
 		expectedStatuses := []InstanceSummary{
-			{
-				Id:           testRun2Id,
-				WorkflowName: testWorkflow1,
-				ContextName:  testContext1Name,
-				SubmitTime:   testWorkflowSubmitTime2,
-				InProject:    true,
-				State:        testRunStatus2,
-			},
-			{
-				Id:           testRun1Id,
-				WorkflowName: testWorkflow1,
-				ContextName:  testContext1Name,
-				SubmitTime:   testWorkflowSubmitTime1,
-				InProject:    true,
-				State:        testRunStatus1,
-			},
+			instanceSummary2,
+			instanceSummary1,
 		}
 		s.Assert().Equal(expectedStatuses, actualStatuses)
 	}
@@ -169,14 +177,7 @@ func (s *WorkflowStatusTestSuite) TestStatusWorkflowAll_InstancesDifferentContex
 	s.mockProjectClient.EXPECT().Read().Return(s.testProjSpec, nil)
 	s.mockConfigClient.EXPECT().GetUserId().Return(testUserId, nil)
 	instances := []ddb.WorkflowInstance{
-		{
-			RunId:        testRun1Id,
-			WorkflowName: testWorkflow1,
-			ContextName:  testContext1Name,
-			ProjectName:  testProjectName,
-			UserId:       testUserId,
-			CreatedTime:  testWorkflowSubmitTime1,
-		},
+		workflowInstance1,
 		{
 			RunId:        testRun2Id,
 			WorkflowName: testWorkflow1,
@@ -201,14 +202,7 @@ func (s *WorkflowStatusTestSuite) TestStatusWorkflowAll_InstancesDifferentContex
 	actualStatuses, err := s.manager.StatusWorkflowAll(testWorkflowInstancesLimit)
 	if s.Assert().NoError(err) {
 		expectedStatuses := []InstanceSummary{
-			{
-				Id:           testRun1Id,
-				WorkflowName: testWorkflow1,
-				ContextName:  testContext1Name,
-				SubmitTime:   testWorkflowSubmitTime1,
-				InProject:    true,
-				State:        testRunStatus1,
-			},
+			instanceSummary1,
 			{
 				Id:           testRun2Id,
 				WorkflowName: testWorkflow1,
@@ -227,14 +221,7 @@ func (s *WorkflowStatusTestSuite) TestStatusWorkflowAll_WorkflowNotInProject() {
 	s.mockProjectClient.EXPECT().Read().Return(s.testProjSpec, nil)
 	s.mockConfigClient.EXPECT().GetUserId().Return(testUserId, nil)
 	instances := []ddb.WorkflowInstance{
-		{
-			RunId:        testRun1Id,
-			WorkflowName: testWorkflow1,
-			ContextName:  testContext1Name,
-			ProjectName:  testProjectName,
-			UserId:       testUserId,
-			CreatedTime:  testWorkflowSubmitTime1,
-		},
+		workflowInstance1,
 		{
 			RunId:        testRun2Id,
 			WorkflowName: testWorkflow2,
@@ -255,14 +242,7 @@ func (s *WorkflowStatusTestSuite) TestStatusWorkflowAll_WorkflowNotInProject() {
 	actualStatuses, err := s.manager.StatusWorkflowAll(testWorkflowInstancesLimit)
 	if s.Assert().NoError(err) {
 		expectedStatuses := []InstanceSummary{
-			{
-				Id:           testRun1Id,
-				WorkflowName: testWorkflow1,
-				ContextName:  testContext1Name,
-				SubmitTime:   testWorkflowSubmitTime1,
-				InProject:    true,
-				State:        testRunStatus1,
-			},
+			instanceSummary1,
 			{
 				Id:           testRun2Id,
 				WorkflowName: testWorkflow2,
@@ -281,22 +261,8 @@ func (s *WorkflowStatusTestSuite) TestStatusWorkflow_SomeUnknownInstance() {
 	s.mockProjectClient.EXPECT().Read().Return(s.testProjSpec, nil)
 	s.mockConfigClient.EXPECT().GetUserId().Return(testUserId, nil)
 	instances := []ddb.WorkflowInstance{
-		{
-			RunId:        testRun1Id,
-			WorkflowName: testWorkflow1,
-			ContextName:  testContext1Name,
-			ProjectName:  testProjectName,
-			UserId:       testUserId,
-			CreatedTime:  testWorkflowSubmitTime1,
-		},
-		{
-			RunId:        testRun2Id,
-			WorkflowName: testWorkflow1,
-			ContextName:  testContext1Name,
-			ProjectName:  testProjectName,
-			UserId:       testUserId,
-			CreatedTime:  testWorkflowSubmitTime2,
-		},
+		workflowInstance1,
+		workflowInstance2,
 	}
 	s.mockDdb.EXPECT().ListWorkflowInstances(ctx.Background(), testProjectName, testUserId, testWorkflowInstancesLimit).Return(instances, nil)
 	s.mockCfn.EXPECT().GetStackStatus(testContext1Stack).Return(types.StackStatusCreateComplete, nil)
@@ -309,14 +275,7 @@ func (s *WorkflowStatusTestSuite) TestStatusWorkflow_SomeUnknownInstance() {
 	actualStatuses, err := s.manager.StatusWorkflowAll(testWorkflowInstancesLimit)
 	if s.Assert().NoError(err) {
 		expectedStatuses := []InstanceSummary{
-			{
-				Id:           testRun2Id,
-				WorkflowName: testWorkflow1,
-				ContextName:  testContext1Name,
-				SubmitTime:   testWorkflowSubmitTime2,
-				InProject:    true,
-				State:        testRunStatus2,
-			},
+			instanceSummary2,
 		}
 		s.Assert().Equal(expectedStatuses, actualStatuses)
 	}
@@ -327,14 +286,7 @@ func (s *WorkflowStatusTestSuite) TestStatusWorkflow_AllUnknownInstance() {
 	s.mockProjectClient.EXPECT().Read().Return(s.testProjSpec, nil)
 	s.mockConfigClient.EXPECT().GetUserId().Return(testUserId, nil)
 	instances := []ddb.WorkflowInstance{
-		{
-			RunId:        testRun1Id,
-			WorkflowName: testWorkflow1,
-			ContextName:  testContext1Name,
-			ProjectName:  testProjectName,
-			UserId:       testUserId,
-			CreatedTime:  testWorkflowSubmitTime1,
-		},
+		workflowInstance1,
 	}
 	s.mockDdb.EXPECT().ListWorkflowInstances(ctx.Background(), testProjectName, testUserId, testWorkflowInstancesLimit).Return(instances, nil)
 	s.mockCfn.EXPECT().GetStackStatus(testContext1Stack).Return(types.StackStatusCreateComplete, nil)
@@ -354,14 +306,7 @@ func (s *WorkflowStatusTestSuite) TestStatusWorkflow_ErrorStatusContexts() {
 	s.mockProjectClient.EXPECT().Read().Return(s.testProjSpec, nil)
 	s.mockConfigClient.EXPECT().GetUserId().Return(testUserId, nil)
 	instances := []ddb.WorkflowInstance{
-		{
-			RunId:        testRun1Id,
-			WorkflowName: testWorkflow1,
-			ContextName:  testContext1Name,
-			ProjectName:  testProjectName,
-			UserId:       testUserId,
-			CreatedTime:  testWorkflowSubmitTime1,
-		},
+		workflowInstance1,
 		{
 			RunId:        testRun2Id,
 			WorkflowName: testWorkflow1,
@@ -382,14 +327,7 @@ func (s *WorkflowStatusTestSuite) TestStatusWorkflow_ErrorStatusContexts() {
 	actualStatuses, err := s.manager.StatusWorkflowAll(testWorkflowInstancesLimit)
 	if s.Assert().NoError(err) {
 		expectedStatuses := []InstanceSummary{
-			{
-				Id:           testRun1Id,
-				WorkflowName: testWorkflow1,
-				ContextName:  testContext1Name,
-				SubmitTime:   testWorkflowSubmitTime1,
-				InProject:    true,
-				State:        testRunStatus1,
-			},
+			instanceSummary1,
 		}
 		s.Assert().Equal(expectedStatuses, actualStatuses)
 	}
@@ -400,14 +338,7 @@ func (s *WorkflowStatusTestSuite) TestStatusWorkflow_NonActiveContexts() {
 	s.mockProjectClient.EXPECT().Read().Return(s.testProjSpec, nil)
 	s.mockConfigClient.EXPECT().GetUserId().Return(testUserId, nil)
 	instances := []ddb.WorkflowInstance{
-		{
-			RunId:        testRun1Id,
-			WorkflowName: testWorkflow1,
-			ContextName:  testContext1Name,
-			ProjectName:  testProjectName,
-			UserId:       testUserId,
-			CreatedTime:  testWorkflowSubmitTime1,
-		},
+		workflowInstance1,
 		{
 			RunId:        testRun2Id,
 			WorkflowName: testWorkflow1,
@@ -428,14 +359,7 @@ func (s *WorkflowStatusTestSuite) TestStatusWorkflow_NonActiveContexts() {
 	actualStatuses, err := s.manager.StatusWorkflowAll(testWorkflowInstancesLimit)
 	if s.Assert().NoError(err) {
 		expectedStatuses := []InstanceSummary{
-			{
-				Id:           testRun1Id,
-				WorkflowName: testWorkflow1,
-				ContextName:  testContext1Name,
-				SubmitTime:   testWorkflowSubmitTime1,
-				InProject:    true,
-				State:        testRunStatus1,
-			},
+			instanceSummary1,
 		}
 		s.Assert().Equal(expectedStatuses, actualStatuses)
 	}
@@ -473,14 +397,7 @@ func (s *WorkflowStatusTestSuite) TestStatusWorkflow_CfnFailed1() {
 	s.mockProjectClient.EXPECT().Read().Return(s.testProjSpec, nil)
 	s.mockConfigClient.EXPECT().GetUserId().Return(testUserId, nil)
 	instances := []ddb.WorkflowInstance{
-		{
-			RunId:        testRun1Id,
-			WorkflowName: testWorkflow1,
-			ContextName:  testContext1Name,
-			ProjectName:  testProjectName,
-			UserId:       testUserId,
-			CreatedTime:  testWorkflowSubmitTime1,
-		},
+		workflowInstance1,
 	}
 	s.mockDdb.EXPECT().ListWorkflowInstances(ctx.Background(), testProjectName, testUserId, testWorkflowInstancesLimit).Return(instances, nil)
 	s.mockCfn.EXPECT().GetStackStatus(testContext1Stack).Return(types.StackStatusCreateComplete, nil)
@@ -499,14 +416,7 @@ func (s *WorkflowStatusTestSuite) TestStatusWorkflow_CfnFailed2() {
 	s.mockProjectClient.EXPECT().Read().Return(s.testProjSpec, nil)
 	s.mockConfigClient.EXPECT().GetUserId().Return(testUserId, nil)
 	instances := []ddb.WorkflowInstance{
-		{
-			RunId:        testRun1Id,
-			WorkflowName: testWorkflow1,
-			ContextName:  testContext1Name,
-			ProjectName:  testProjectName,
-			UserId:       testUserId,
-			CreatedTime:  testWorkflowSubmitTime1,
-		},
+		workflowInstance1,
 	}
 	s.mockDdb.EXPECT().ListWorkflowInstances(ctx.Background(), testProjectName, testUserId, testWorkflowInstancesLimit).Return(instances, nil)
 	s.mockCfn.EXPECT().GetStackStatus(testContext1Stack).Return(types.StackStatus(""), errors.New(errorMessage))
@@ -524,14 +434,7 @@ func (s *WorkflowStatusTestSuite) TestStatusWorkflow_WesFailed() {
 	s.mockProjectClient.EXPECT().Read().Return(s.testProjSpec, nil)
 	s.mockConfigClient.EXPECT().GetUserId().Return(testUserId, nil)
 	instances := []ddb.WorkflowInstance{
-		{
-			RunId:        testRun1Id,
-			WorkflowName: testWorkflow1,
-			ContextName:  testContext1Name,
-			ProjectName:  testProjectName,
-			UserId:       testUserId,
-			CreatedTime:  testWorkflowSubmitTime1,
-		},
+		workflowInstance1,
 	}
 	s.mockDdb.EXPECT().ListWorkflowInstances(ctx.Background(), testProjectName, testUserId, testWorkflowInstancesLimit).Return(instances, nil)
 	s.mockCfn.EXPECT().GetStackStatus(testContext1Stack).Return(types.StackStatusCreateComplete, nil)
@@ -552,22 +455,8 @@ func (s *WorkflowStatusTestSuite) TestStatusWorkflowByContext_Nominal() {
 	s.mockProjectClient.EXPECT().Read().Return(s.testProjSpec, nil)
 	s.mockConfigClient.EXPECT().GetUserId().Return(testUserId, nil)
 	instances := []ddb.WorkflowInstance{
-		{
-			RunId:        testRun2Id,
-			WorkflowName: testWorkflow1,
-			ContextName:  testContext1Name,
-			ProjectName:  testProjectName,
-			UserId:       testUserId,
-			CreatedTime:  testWorkflowSubmitTime2,
-		},
-		{
-			RunId:        testRun1Id,
-			WorkflowName: testWorkflow1,
-			ContextName:  testContext1Name,
-			ProjectName:  testProjectName,
-			UserId:       testUserId,
-			CreatedTime:  testWorkflowSubmitTime1,
-		},
+		workflowInstance2,
+		workflowInstance1,
 	}
 	s.mockDdb.EXPECT().ListWorkflowInstancesByContext(ctx.Background(), testProjectName, testUserId, testContext1Name, testWorkflowInstancesLimit).Return(instances, nil)
 	s.mockCfn.EXPECT().GetStackStatus(testContext1Stack).Return(types.StackStatusCreateComplete, nil)
@@ -580,22 +469,8 @@ func (s *WorkflowStatusTestSuite) TestStatusWorkflowByContext_Nominal() {
 	actualStatuses, err := s.manager.StatusWorkflowByContext(testContext1Name, testWorkflowInstancesLimit)
 	if s.Assert().NoError(err) {
 		expectedStatuses := []InstanceSummary{
-			{
-				Id:           testRun2Id,
-				WorkflowName: testWorkflow1,
-				ContextName:  testContext1Name,
-				SubmitTime:   testWorkflowSubmitTime2,
-				InProject:    true,
-				State:        testRunStatus2,
-			},
-			{
-				Id:           testRun1Id,
-				WorkflowName: testWorkflow1,
-				ContextName:  testContext1Name,
-				SubmitTime:   testWorkflowSubmitTime1,
-				InProject:    true,
-				State:        testRunStatus1,
-			},
+			instanceSummary2,
+			instanceSummary1,
 		}
 		s.Assert().Equal(expectedStatuses, actualStatuses)
 	}
@@ -606,22 +481,8 @@ func (s *WorkflowStatusTestSuite) TestStatusWorkflowByName_Nominal() {
 	s.mockProjectClient.EXPECT().Read().Return(s.testProjSpec, nil)
 	s.mockConfigClient.EXPECT().GetUserId().Return(testUserId, nil)
 	instances := []ddb.WorkflowInstance{
-		{
-			RunId:        testRun2Id,
-			WorkflowName: testWorkflow1,
-			ContextName:  testContext1Name,
-			ProjectName:  testProjectName,
-			UserId:       testUserId,
-			CreatedTime:  testWorkflowSubmitTime2,
-		},
-		{
-			RunId:        testRun1Id,
-			WorkflowName: testWorkflow1,
-			ContextName:  testContext1Name,
-			ProjectName:  testProjectName,
-			UserId:       testUserId,
-			CreatedTime:  testWorkflowSubmitTime1,
-		},
+		workflowInstance2,
+		workflowInstance1,
 	}
 	s.mockDdb.EXPECT().ListWorkflowInstancesByName(ctx.Background(), testProjectName, testUserId, testWorkflow1, testWorkflowInstancesLimit).Return(instances, nil)
 	s.mockCfn.EXPECT().GetStackStatus(testContext1Stack).Return(types.StackStatusCreateComplete, nil)
@@ -634,22 +495,8 @@ func (s *WorkflowStatusTestSuite) TestStatusWorkflowByName_Nominal() {
 	actualStatuses, err := s.manager.StatusWorkflowByName(testWorkflow1, testWorkflowInstancesLimit)
 	if s.Assert().NoError(err) {
 		expectedStatuses := []InstanceSummary{
-			{
-				Id:           testRun2Id,
-				WorkflowName: testWorkflow1,
-				ContextName:  testContext1Name,
-				SubmitTime:   testWorkflowSubmitTime2,
-				InProject:    true,
-				State:        testRunStatus2,
-			},
-			{
-				Id:           testRun1Id,
-				WorkflowName: testWorkflow1,
-				ContextName:  testContext1Name,
-				SubmitTime:   testWorkflowSubmitTime1,
-				InProject:    true,
-				State:        testRunStatus1,
-			},
+			instanceSummary2,
+			instanceSummary1,
 		}
 		s.Assert().Equal(expectedStatuses, actualStatuses)
 	}
@@ -659,15 +506,7 @@ func (s *WorkflowStatusTestSuite) TestStatusWorkflowByInstanceId_Nominal() {
 	defer s.ctrl.Finish()
 	s.mockProjectClient.EXPECT().Read().Return(s.testProjSpec, nil)
 	s.mockConfigClient.EXPECT().GetUserId().Return(testUserId, nil)
-	instance := ddb.WorkflowInstance{
-		RunId:        testRun1Id,
-		WorkflowName: testWorkflow1,
-		ContextName:  testContext1Name,
-		ProjectName:  testProjectName,
-		UserId:       testUserId,
-		CreatedTime:  testWorkflowSubmitTime1,
-	}
-	s.mockDdb.EXPECT().GetWorkflowInstanceById(ctx.Background(), testProjectName, testUserId, testRun1Id).Return(instance, nil)
+	s.mockDdb.EXPECT().GetWorkflowInstanceById(ctx.Background(), testProjectName, testUserId, testRun1Id).Return(workflowInstance1, nil)
 	s.mockCfn.EXPECT().GetStackStatus(testContext1Stack).Return(types.StackStatusCreateComplete, nil)
 	s.mockCfn.EXPECT().GetStackInfo(testContext1Stack).Return(cfn.StackInfo{
 		Outputs: map[string]string{"WesUrl": testWes1Url},
@@ -677,14 +516,7 @@ func (s *WorkflowStatusTestSuite) TestStatusWorkflowByInstanceId_Nominal() {
 	actualStatuses, err := s.manager.StatusWorkflowByInstanceId(testRun1Id)
 	if s.Assert().NoError(err) {
 		expectedStatuses := []InstanceSummary{
-			{
-				Id:           testRun1Id,
-				WorkflowName: testWorkflow1,
-				ContextName:  testContext1Name,
-				SubmitTime:   testWorkflowSubmitTime1,
-				InProject:    true,
-				State:        testRunStatus1,
-			},
+			instanceSummary1,
 		}
 		s.Assert().Equal(expectedStatuses, actualStatuses)
 	}


### PR DESCRIPTION
Issue #, if available: NA

**Description of Changes**

Whenever a customer runs `agc workflow status` while a stack is actively being destroyed or has been destroyed, AGC will still try to query WES to determine the status of workflows that have been ran. This change removes stacks that are currently being removed so that it follows the same logic as stacks that have been removed since we can't trust the status of those stacks.

**Description of how you validated changes**

1. Deployed two contexts
2. Ran two workflows on each of the contexts
3. Waited for the workflows to finish
4. Destroyed one of the contexts and while it was being destroyed, ran `agc workflow status`

```
$ agc workflow status
2021-11-02T09:24:16-07:00 𝒊  Showing workflow run(s). Max Runs: 20
WORKFLOWINSTANCE	spotContext	05a40f99-9f88-4ebd-ab73-730dd4cb3861	true	COMPLETE	2021-11-02T03:57:33Z	hello
```

**Checklist**

- [x] If this change would make any existing documentation invalid, I have included those updates within this PR
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have linted my code before raising the PR
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
