### PR TITLE
fix: temporary folder potential leak in some error scenarios. unit test for cdk command execution

### DIFF
--- a/packages/cli/internal/pkg/aws/cdk/deploy_app.go
+++ b/packages/cli/internal/pkg/aws/cdk/deploy_app.go
@@ -18,8 +18,6 @@ func (client Client) DeployApp(appDir string, context []string) (ProgressStream,
 		"--output", tmpDir,
 	}
 	cmdArgs = appendContextArguments(cmdArgs, context)
-
 	progressStream, err := executeCdkCommandAndCleanupDirectory(appDir, cmdArgs, tmpDir)
-
 	return progressStream, actionableerror.FindSuggestionForError(err, actionableerror.AwsErrorMessageToSuggestedActionMap)
 }

--- a/packages/cli/internal/pkg/aws/cdk/execute_cdk_test.go
+++ b/packages/cli/internal/pkg/aws/cdk/execute_cdk_test.go
@@ -76,7 +76,7 @@ func (s *ExecuteCdkCommandTestSuite) TestExecuteCdkCommand_Success() {
 	s.Assert().Equal(testExecuteCommandProgressLine, event1.Outputs[0])
 	event2 := <-progressStream
 	s.Assert().NoError(event2.Err)
-	waitForChanToClos(progressStream)
+	waitForChanToClose(progressStream)
 }
 
 func (s *ExecuteCdkCommandTestSuite) TestExecuteCdkCommandAndCleanupDirectory_Success() {
@@ -90,7 +90,7 @@ func (s *ExecuteCdkCommandTestSuite) TestExecuteCdkCommandAndCleanupDirectory_Su
 	s.Assert().Equal(testExecuteCommandProgressLine, event1.Outputs[0])
 	event2 := <-progressStream
 	s.Assert().NoError(event2.Err)
-	waitForChanToClos(progressStream)
+	waitForChanToClose(progressStream)
 }
 
 func (s *ExecuteCdkCommandTestSuite) TestExecuteCdkCommandAndCleanupDirectory_Failure() {
@@ -102,7 +102,7 @@ func (s *ExecuteCdkCommandTestSuite) TestExecuteCdkCommandAndCleanupDirectory_Fa
 	s.Assert().Equal(testExecuteCommandFailureArg, event1.Outputs[0])
 	event2 := <-progressStream
 	s.Assert().Error(event2.Err)
-	waitForChanToClos(progressStream)
+	waitForChanToClose(progressStream)
 }
 
 func (s *ExecuteCdkCommandTestSuite) TestExecuteCdkCommandAndCleanupDirectory_FailToExecute() {
@@ -122,7 +122,7 @@ func (s *ExecuteCdkCommandTestSuite) TestExecuteCdkCommand_Failure() {
 	s.Assert().Equal(testExecuteCommandFailureArg, event1.Outputs[0])
 	event2 := <-progressStream
 	s.Assert().Error(event2.Err)
-	waitForChanToClos(progressStream)
+	waitForChanToClose(progressStream)
 }
 
 func TestHelperProcess(t *testing.T) {
@@ -161,9 +161,7 @@ func TestHelperProcess(t *testing.T) {
 	}
 }
 
-func waitForChanToClos(channel ProgressStream) {
-	select {
-	case <-channel:
-		return
+func waitForChanToClose(channel ProgressStream) {
+	for range channel {
 	}
 }

--- a/packages/cli/internal/pkg/aws/cdk/execute_cdk_test.go
+++ b/packages/cli/internal/pkg/aws/cdk/execute_cdk_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 )
 
 const (
@@ -26,57 +27,102 @@ func fakeExecCommand(command string, args ...string) *exec.Cmd {
 	return cmd
 }
 
-func TestExecuteCdkCommand_Success(t *testing.T) {
-	execCommand = fakeExecCommand
-	defer func() { execCommand = exec.Command }()
+type ExecuteCdkCommandTestSuite struct {
+	suite.Suite
 
-	ctrl := gomock.NewController(t)
-	mockOs := iomocks.NewMockOS(ctrl)
-	osRemoveAll = mockOs.RemoveAll
-	mockOs.EXPECT().RemoveAll(gomock.Any()).Return(nil).Times(0)
+	osRemoveAllOrig func(string) error
+	execCommandOrig func(command string, args ...string) *exec.Cmd
 
-	progressStream, _ := executeCdkCommand(t.TempDir(), []string{testExecuteCommandSuccessArg})
-	event1 := <-progressStream
-	assert.Equal(t, 3, event1.CurrentStep)
-	assert.Equal(t, 10, event1.TotalSteps)
-	assert.Equal(t, testExecuteCommandProgressLine, event1.Outputs[0])
-	event2 := <-progressStream
-	assert.NoError(t, event2.Err)
+	ctrl   *gomock.Controller
+	mockOs *iomocks.MockOS
+	appDir string
+	tmpDir string
 }
 
-func TestExecuteCdkCommandAndCleanupDirectory_Success(t *testing.T) {
-	execCommand = fakeExecCommand
-	defer func() { execCommand = exec.Command }()
-	tempDirectory := "/my/directory"
-
-	ctrl := gomock.NewController(t)
-	mockOs := iomocks.NewMockOS(ctrl)
-	osRemoveAll = mockOs.RemoveAll
-	mockOs.EXPECT().RemoveAll(tempDirectory).Return(nil).Times(1)
-
-	progressStream, _ := executeCdkCommandAndCleanupDirectory(t.TempDir(), []string{testExecuteCommandSuccessArg}, tempDirectory)
-	event1 := <-progressStream
-	assert.Equal(t, 3, event1.CurrentStep)
-	assert.Equal(t, 10, event1.TotalSteps)
-	assert.Equal(t, testExecuteCommandProgressLine, event1.Outputs[0])
-	event2 := <-progressStream
-	assert.NoError(t, event2.Err)
+func TestExecuteCdkCommandTestSuite(t *testing.T) {
+	suite.Run(t, new(ExecuteCdkCommandTestSuite))
 }
 
-func TestExecuteCdkCommand_Failure(t *testing.T) {
+func (s *ExecuteCdkCommandTestSuite) SetupTest() {
+	s.ctrl = gomock.NewController(s.T())
+	s.mockOs = iomocks.NewMockOS(s.ctrl)
+	s.osRemoveAllOrig = osRemoveAll
+	s.execCommandOrig = execCommand
+
+	osRemoveAll = s.mockOs.RemoveAll
 	execCommand = fakeExecCommand
-	defer func() { execCommand = exec.Command }()
 
-	ctrl := gomock.NewController(t)
-	mockOs := iomocks.NewMockOS(ctrl)
-	osRemoveAll = mockOs.RemoveAll
-	mockOs.EXPECT().RemoveAll(gomock.Any()).Return(nil).Times(0)
+	s.appDir = s.T().TempDir()
+	s.tmpDir = "/test/tmp/dir"
+}
 
-	progressStream, _ := executeCdkCommand(t.TempDir(), []string{testExecuteCommandFailureArg})
+func (s *ExecuteCdkCommandTestSuite) AfterTest(_, _ string) {
+	s.ctrl.Finish()
+}
+
+func (s *ExecuteCdkCommandTestSuite) TearDownTest() {
+	osRemoveAll = s.osRemoveAllOrig
+	execCommand = s.execCommandOrig
+}
+
+func (s *ExecuteCdkCommandTestSuite) TestExecuteCdkCommand_Success() {
+	s.mockOs.EXPECT().RemoveAll(gomock.Any()).Return(nil).Times(0)
+
+	progressStream, err := executeCdkCommand(s.appDir, []string{testExecuteCommandSuccessArg})
+	s.Require().NoError(err)
 	event1 := <-progressStream
-	assert.Equal(t, testExecuteCommandFailureArg, event1.Outputs[0])
+	s.Assert().Equal(3, event1.CurrentStep)
+	s.Assert().Equal(10, event1.TotalSteps)
+	s.Assert().Equal(testExecuteCommandProgressLine, event1.Outputs[0])
 	event2 := <-progressStream
-	assert.Error(t, event2.Err)
+	s.Assert().NoError(event2.Err)
+	waitForChanToClos(progressStream)
+}
+
+func (s *ExecuteCdkCommandTestSuite) TestExecuteCdkCommandAndCleanupDirectory_Success() {
+	s.mockOs.EXPECT().RemoveAll(s.tmpDir).Return(nil).Times(1)
+
+	progressStream, err := executeCdkCommandAndCleanupDirectory(s.appDir, []string{testExecuteCommandSuccessArg}, s.tmpDir)
+	s.Require().NoError(err)
+	event1 := <-progressStream
+	s.Assert().Equal(3, event1.CurrentStep)
+	s.Assert().Equal(10, event1.TotalSteps)
+	s.Assert().Equal(testExecuteCommandProgressLine, event1.Outputs[0])
+	event2 := <-progressStream
+	s.Assert().NoError(event2.Err)
+	waitForChanToClos(progressStream)
+}
+
+func (s *ExecuteCdkCommandTestSuite) TestExecuteCdkCommandAndCleanupDirectory_Failure() {
+	s.mockOs.EXPECT().RemoveAll(s.tmpDir).Return(nil).Times(1)
+
+	progressStream, err := executeCdkCommandAndCleanupDirectory(s.appDir, []string{testExecuteCommandFailureArg}, s.tmpDir)
+	s.Require().NoError(err)
+	event1 := <-progressStream
+	s.Assert().Equal(testExecuteCommandFailureArg, event1.Outputs[0])
+	event2 := <-progressStream
+	s.Assert().Error(event2.Err)
+	waitForChanToClos(progressStream)
+}
+
+func (s *ExecuteCdkCommandTestSuite) TestExecuteCdkCommandAndCleanupDirectory_FailToExecute() {
+	s.mockOs.EXPECT().RemoveAll(s.tmpDir).Return(nil).Times(1)
+
+	progressStream, err := executeCdkCommandAndCleanupDirectory("foo/bar", []string{testExecuteCommandFailureArg}, s.tmpDir)
+	s.Assert().Error(err)
+	s.Assert().Nil(progressStream)
+}
+
+func (s *ExecuteCdkCommandTestSuite) TestExecuteCdkCommand_Failure() {
+	s.mockOs.EXPECT().RemoveAll(gomock.Any()).Return(nil).Times(0)
+
+	progressStream, err := executeCdkCommand(s.appDir, []string{testExecuteCommandFailureArg})
+	s.Require().NoError(err)
+	event1 := <-progressStream
+	s.Assert().Equal(testExecuteCommandFailureArg, event1.Outputs[0])
+	event2 := <-progressStream
+	s.Assert().Error(event2.Err)
+	waitForChanToClos(progressStream)
 }
 
 func TestHelperProcess(t *testing.T) {
@@ -112,5 +158,12 @@ func TestHelperProcess(t *testing.T) {
 	default:
 		fmt.Fprint(os.Stderr, "Unknown failure")
 		os.Exit(1)
+	}
+}
+
+func waitForChanToClos(channel ProgressStream) {
+	select {
+	case <-channel:
+		return
 	}
 }

--- a/packages/cli/internal/pkg/cli/config/config_client.go
+++ b/packages/cli/internal/pkg/cli/config/config_client.go
@@ -40,7 +40,7 @@ func NewConfigClient() (*Client, error) {
 	return &Client{configFilePath: configFilePath}, nil
 }
 
-// DetermineHomeDir returns the file system directory where the AGC files live.
+// DetermineHomeDir returns the current user's home directory. In case of error an actionable error will be returned.
 func DetermineHomeDir() (string, error) {
 	dir, err := osUserHomeDir()
 	if err != nil {


### PR DESCRIPTION
<!-- Title format: type(scope): Short description (72 chars max for line) -->
<!-- `(scope)` is optional and `type` is one of: build, ci, chore, docs, feat, fix, perf, refactor, revert, style, test -->
<!-- Available types:
- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit -->

Issue #, if available:

**Description of Changes**

[//]: #  (A description of the change that you made and the new user experience that it creates)

1. In case when cdk command cannot be executed the temporary directory is not cleaned up
1. Unit tests for cdk command execution don't check returned error, expected call to mocked methods, etc
1. Unit tests contain a lot of duplicated boilerplate code that clutter the test logic

**Description of how you validated changes**

[//]: #  (A description of you validated your changes and any relevant logs that show your change works)

1. build
1. unit tests
1. manual test

**Checklist**

- [x] If this change would make any existing documentation invalid, I have included those updates within this PR
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have linted my code before raising the PR
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/



----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
