### PR TITLE
fix: updates how the logs are shown from cloudwatch

### DIFF
--- a/packages/cli/internal/pkg/aws/cwl/get_logs.go
+++ b/packages/cli/internal/pkg/aws/cwl/get_logs.go
@@ -51,9 +51,14 @@ func (c Client) GetLogsPaginated(input GetLogsInput) LogPaginator {
 }
 
 func formatEvents(events []types.FilteredLogEvent) []string {
-	logs := make([]string, len(events))
-	for i, event := range events {
-		logs[i] = formatEvent(event)
+	logsByStream := make(map[string][]string)
+	for _, event := range events {
+		logsByStream[*event.LogStreamName] = append(logsByStream[*event.LogStreamName], formatEvent(event))
+	}
+
+	var logs []string
+	for _, retrievedLogs := range logsByStream {
+		logs = append(logs, retrievedLogs...)
 	}
 	return logs
 }

--- a/packages/cli/internal/pkg/aws/cwl/get_logs.go
+++ b/packages/cli/internal/pkg/aws/cwl/get_logs.go
@@ -51,14 +51,22 @@ func (c Client) GetLogsPaginated(input GetLogsInput) LogPaginator {
 }
 
 func formatEvents(events []types.FilteredLogEvent) []string {
-	logsByStream := make(map[string][]string)
-	for _, event := range events {
-		logsByStream[*event.LogStreamName] = append(logsByStream[*event.LogStreamName], formatEvent(event))
+	logsByStream := make(map[string][]*types.FilteredLogEvent)
+	for index, _ := range events {
+		event := events[index]
+		logsByStream[*event.LogStreamName] = append(logsByStream[*event.LogStreamName], &event)
 	}
 
-	var logs []string
-	for _, retrievedLogs := range logsByStream {
-		logs = append(logs, retrievedLogs...)
+	return convertStreamLogsToLogs(logsByStream, len(events))
+}
+
+func convertStreamLogsToLogs(logsByStream map[string][]*types.FilteredLogEvent, eventSize int) []string {
+	logs, index := make([]string, eventSize), 0
+	for _, eventList := range logsByStream {
+		for _, event := range eventList {
+			logs[index] = formatEvent(*event)
+			index++
+		}
 	}
 	return logs
 }

--- a/packages/cli/internal/pkg/aws/cwl/get_logs.go
+++ b/packages/cli/internal/pkg/aws/cwl/get_logs.go
@@ -52,7 +52,7 @@ func (c Client) GetLogsPaginated(input GetLogsInput) LogPaginator {
 
 func formatEvents(events []types.FilteredLogEvent) []string {
 	logsByStream := make(map[string][]*types.FilteredLogEvent)
-	for index, _ := range events {
+	for index := range events {
 		event := events[index]
 		logsByStream[*event.LogStreamName] = append(logsByStream[*event.LogStreamName], &event)
 	}

--- a/packages/cli/internal/pkg/aws/cwl/get_logs_test.go
+++ b/packages/cli/internal/pkg/aws/cwl/get_logs_test.go
@@ -48,10 +48,24 @@ func TestClient_GetLogs(t *testing.T) {
 			Timestamp:     aws.Int64(eventTime1.UnixNano() / 1000000),
 		},
 		{
+			EventId:       aws.String("some-id-2"),
+			IngestionTime: aws.Int64(eventTime1.UnixNano() / 1000000),
+			LogStreamName: aws.String("log-stream-2"),
+			Message:       aws.String("Hola"),
+			Timestamp:     aws.Int64(eventTime1.UnixNano() / 1000000),
+		},
+		{
 			EventId:       aws.String("some-other-id"),
 			IngestionTime: aws.Int64(eventTime2.UnixNano() / 1000000),
 			LogStreamName: aws.String("log-stream-1"),
 			Message:       aws.String("world!"),
+			Timestamp:     aws.Int64(eventTime2.UnixNano() / 1000000),
+		},
+		{
+			EventId:       aws.String("some-other-id-2"),
+			IngestionTime: aws.Int64(eventTime2.UnixNano() / 1000000),
+			LogStreamName: aws.String("log-stream-2"),
+			Message:       aws.String("mundo!"),
 			Timestamp:     aws.Int64(eventTime2.UnixNano() / 1000000),
 		},
 	}}, nil)
@@ -65,7 +79,12 @@ func TestClient_GetLogs(t *testing.T) {
 	logs, err := output.NextLogs()
 	assert.False(t, output.HasMoreLogs())
 	assert.NoError(t, err)
-	assert.Equal(t, []string{fmt.Sprintf("%s\tHello", eventTime1.Format(time.RFC1123Z)), fmt.Sprintf("%s\tworld!", eventTime2.Format(time.RFC1123Z))}, logs)
+	assert.Equal(t, []string{
+		fmt.Sprintf("%s\tHello", eventTime1.Format(time.RFC1123Z)),
+		fmt.Sprintf("%s\tworld!", eventTime2.Format(time.RFC1123Z)),
+		fmt.Sprintf("%s\tHola", eventTime1.Format(time.RFC1123Z)),
+		fmt.Sprintf("%s\tmundo!", eventTime2.Format(time.RFC1123Z)),
+	}, logs)
 }
 
 func TestClient_GetLogs_Error(t *testing.T) {

--- a/packages/cli/internal/pkg/aws/cwl/get_logs_test.go
+++ b/packages/cli/internal/pkg/aws/cwl/get_logs_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
 
 const (
@@ -86,25 +85,6 @@ func TestClient_GetLogs(t *testing.T) {
 		fmt.Sprintf("%s\tHola", eventTime1.Format(time.RFC1123Z)),
 		fmt.Sprintf("%s\tmundo!", eventTime2.Format(time.RFC1123Z)),
 	}, logs)
-}
-
-func TestClient_StreamLogs_EmptyLog(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	client := NewMockClient()
-	client.cwl.(*CwlMock).On("FilterLogEvents", ctx, mock.Anything).
-		Return(&cloudwatchlogs.FilterLogEventsOutput{
-			NextToken: aws.String("Token"),
-			Events:    []types.FilteredLogEvent{}}, nil)
-	cancel()
-	stream := client.StreamLogs(ctx, testLogGroupName)
-	event := <-stream
-
-	var expectedLogs []string
-	assert.Equal(t, expectedLogs, event.Logs)
-	assert.NoError(t, event.Err)
-	cancel()
-	_, isOpen := <-stream
-	assert.False(t, isOpen)
 }
 
 func TestClient_GetLogs_Error(t *testing.T) {

--- a/packages/cli/internal/pkg/aws/cwl/get_logs_test.go
+++ b/packages/cli/internal/pkg/aws/cwl/get_logs_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 const (
@@ -85,6 +86,25 @@ func TestClient_GetLogs(t *testing.T) {
 		fmt.Sprintf("%s\tHola", eventTime1.Format(time.RFC1123Z)),
 		fmt.Sprintf("%s\tmundo!", eventTime2.Format(time.RFC1123Z)),
 	}, logs)
+}
+
+func TestClient_StreamLogs_EmptyLog(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	client := NewMockClient()
+	client.cwl.(*CwlMock).On("FilterLogEvents", ctx, mock.Anything).
+		Return(&cloudwatchlogs.FilterLogEventsOutput{
+			NextToken: aws.String("Token"),
+			Events:    []types.FilteredLogEvent{}}, nil)
+	cancel()
+	stream := client.StreamLogs(ctx, testLogGroupName)
+	event := <-stream
+
+	var expectedLogs []string
+	assert.Equal(t, expectedLogs, event.Logs)
+	assert.NoError(t, event.Err)
+	cancel()
+	_, isOpen := <-stream
+	assert.False(t, isOpen)
 }
 
 func TestClient_GetLogs_Error(t *testing.T) {

--- a/packages/cli/internal/pkg/aws/cwl/stream_logs.go
+++ b/packages/cli/internal/pkg/aws/cwl/stream_logs.go
@@ -55,7 +55,7 @@ func (c Client) StreamLogs(ctx context.Context, logGroupName string, streams ...
 
 func parseEventLogs(events []types.FilteredLogEvent, latestTimestamp *int64) []string {
 	logsByStream := make(map[string][]*types.FilteredLogEvent)
-	for index, _ := range events {
+	for index := range events {
 		event := events[index]
 		if aws.ToInt64(event.Timestamp) > aws.ToInt64(latestTimestamp) {
 			latestTimestamp = event.Timestamp

--- a/packages/cli/internal/pkg/aws/cwl/stream_logs.go
+++ b/packages/cli/internal/pkg/aws/cwl/stream_logs.go
@@ -54,12 +54,17 @@ func (c Client) StreamLogs(ctx context.Context, logGroupName string, streams ...
 }
 
 func parseEventLogs(events []types.FilteredLogEvent, latestTimestamp *int64) []string {
-	logs := make([]string, len(events))
-	for i, event := range events {
+	logsByStream := make(map[string][]string)
+	for _, event := range events {
 		if aws.ToInt64(event.Timestamp) > aws.ToInt64(latestTimestamp) {
 			latestTimestamp = event.Timestamp
 		}
-		logs[i] = formatEvent(event)
+		logsByStream[*event.LogStreamName] = append(logsByStream[*event.LogStreamName], formatEvent(event))
+	}
+
+	var logs []string
+	for _, retrievedLogs := range logsByStream {
+		logs = append(logs, retrievedLogs...)
 	}
 	return logs
 }

--- a/packages/cli/internal/pkg/aws/cwl/stream_logs.go
+++ b/packages/cli/internal/pkg/aws/cwl/stream_logs.go
@@ -54,17 +54,14 @@ func (c Client) StreamLogs(ctx context.Context, logGroupName string, streams ...
 }
 
 func parseEventLogs(events []types.FilteredLogEvent, latestTimestamp *int64) []string {
-	logsByStream := make(map[string][]string)
-	for _, event := range events {
+	logsByStream := make(map[string][]*types.FilteredLogEvent)
+	for index, _ := range events {
+		event := events[index]
 		if aws.ToInt64(event.Timestamp) > aws.ToInt64(latestTimestamp) {
 			latestTimestamp = event.Timestamp
 		}
-		logsByStream[*event.LogStreamName] = append(logsByStream[*event.LogStreamName], formatEvent(event))
+		logsByStream[*event.LogStreamName] = append(logsByStream[*event.LogStreamName], &event)
 	}
 
-	var logs []string
-	for _, retrievedLogs := range logsByStream {
-		logs = append(logs, retrievedLogs...)
-	}
-	return logs
+	return convertStreamLogsToLogs(logsByStream, len(events))
 }

--- a/packages/cli/internal/pkg/aws/cwl/stream_logs_test.go
+++ b/packages/cli/internal/pkg/aws/cwl/stream_logs_test.go
@@ -14,7 +14,8 @@ import (
 )
 
 func TestClient_StreamLogs(t *testing.T) {
-	someTime := time.Unix(0, 773391600000000000)
+	someTime1 := time.Unix(0, 773391600000000000)
+	someTime2 := time.Unix(0, 773391600000000000)
 	ctx, cancel := context.WithCancel(context.Background())
 	client := NewMockClient()
 	client.cwl.(*CwlMock).On("FilterLogEvents", ctx, mock.Anything).
@@ -22,17 +23,43 @@ func TestClient_StreamLogs(t *testing.T) {
 			NextToken: aws.String("Token"),
 			Events: []types.FilteredLogEvent{
 				{
-					EventId:       aws.String("ID"),
-					IngestionTime: aws.Int64(someTime.UnixNano() / 1000000),
+					EventId:       aws.String("some-id"),
+					IngestionTime: aws.Int64(someTime1.UnixNano() / 1000000),
 					LogStreamName: aws.String("log-stream-1"),
-					Message:       aws.String("Hello!"),
-					Timestamp:     aws.Int64(someTime.UnixNano() / 1000000),
+					Message:       aws.String("Hello"),
+					Timestamp:     aws.Int64(someTime1.UnixNano() / 1000000),
+				},
+				{
+					EventId:       aws.String("some-id-2"),
+					IngestionTime: aws.Int64(someTime1.UnixNano() / 1000000),
+					LogStreamName: aws.String("log-stream-2"),
+					Message:       aws.String("Hola"),
+					Timestamp:     aws.Int64(someTime1.UnixNano() / 1000000),
+				},
+				{
+					EventId:       aws.String("some-other-id"),
+					IngestionTime: aws.Int64(someTime2.UnixNano() / 1000000),
+					LogStreamName: aws.String("log-stream-1"),
+					Message:       aws.String("world!"),
+					Timestamp:     aws.Int64(someTime2.UnixNano() / 1000000),
+				},
+				{
+					EventId:       aws.String("some-other-id-2"),
+					IngestionTime: aws.Int64(someTime2.UnixNano() / 1000000),
+					LogStreamName: aws.String("log-stream-2"),
+					Message:       aws.String("mundo!"),
+					Timestamp:     aws.Int64(someTime2.UnixNano() / 1000000),
 				},
 			}}, nil)
 	cancel()
 	stream := client.StreamLogs(ctx, testLogGroupName)
 	event := <-stream
-	assert.Equal(t, []string{fmt.Sprintf("%s\tHello!", someTime.Format(time.RFC1123Z))}, event.Logs)
+	assert.Equal(t, []string{
+		fmt.Sprintf("%s\tHello", someTime1.Format(time.RFC1123Z)),
+		fmt.Sprintf("%s\tworld!", someTime2.Format(time.RFC1123Z)),
+		fmt.Sprintf("%s\tHola", someTime1.Format(time.RFC1123Z)),
+		fmt.Sprintf("%s\tmundo!", someTime2.Format(time.RFC1123Z)),
+	}, event.Logs)
 	assert.NoError(t, event.Err)
 	cancel()
 	_, isOpen := <-stream


### PR DESCRIPTION
Issue #, if available: NA

**Description of Changes**

Currently, logs are shown directly as configured from Cloudwatch. This can end up causing logs to be interleaved with one another which can be confusing. This PR forces the logs to be grouped together by the log group.

API Source: https://github.com/aws/aws-sdk-go-v2/blob/service/cloudwatchlogs/v1.8.0/service/cloudwatchlogs/api_op_FilterLogEvents.go#L68

Example
```
[Wed, 27 Oct 2021 14:54:30 -0700	nxf-scratch-dir ip-10-0-135-228.us-west-2.compute.internal:/tmp/nxf.tI8K4PhVO2]
[Wed, 27 Oct 2021 14:54:32 -0700	.command.sh: line 2: unexpected EOF while looking for matching `'']
[Wed, 27 Oct 2021 14:54:58 -0700	nxf-scratch-dir ip-10-0-135-228.us-west-2.compute.internal:/tmp/nxf.qRSZYD5f7u]
[Wed, 27 Oct 2021 14:54:58 -0700	nxf-scratch-dir ip-10-0-135-228.us-west-2.compute.internal:/tmp/nxf.wXU7ENtNpY]
[Wed, 27 Oct 2021 14:55:00 -0700	Bonjour world!]
[Wed, 27 Oct 2021 14:55:00 -0700	Ciao world!]
[Wed, 27 Oct 2021 14:55:28 -0700	nxf-scratch-dir ip-10-0-135-228.us-west-2.compute.internal:/tmp/nxf.NblfrDAKd0]
[Wed, 27 Oct 2021 14:55:28 -0700	nxf-scratch-dir ip-10-0-135-228.us-west-2.compute.internal:/tmp/nxf.ka1s4aXbVw]
[Wed, 27 Oct 2021 14:55:31 -0700	Hello world!]
[Wed, 27 Oct 2021 14:55:31 -0700	Hola world!]
```

**Description of how you validated changes**

[//]: #  (A description of you validated your changes and any relevant logs that show your change works)

Ran the command locally several times with several different workflows

```
$ agc logs workflow hello2
2021-11-03T15:08:16-07:00 𝒊  Showing the logs for 'hello2'
2021-11-03T15:08:19-07:00 𝒊  Showing logs for the latest run of the workflow. Run id: '7c963370-839d-468e-9b8c-7d9062dd103c'
Wed, 03 Nov 2021 15:03:09 -0700	nxf-scratch-dir ip-10-0-131-26.us-west-2.compute.internal:/tmp/nxf.dgrbFgUXRX
Wed, 03 Nov 2021 15:03:10 -0700	Hola world!
Wed, 03 Nov 2021 15:03:36 -0700	nxf-scratch-dir ip-10-0-131-26.us-west-2.compute.internal:/tmp/nxf.pemb5ihjMK
Wed, 03 Nov 2021 15:03:37 -0700	Ciao world!
Wed, 03 Nov 2021 15:04:07 -0700	nxf-scratch-dir ip-10-0-131-26.us-west-2.compute.internal:/tmp/nxf.GV7sQnIWrw
Wed, 03 Nov 2021 15:04:08 -0700	Bonjour world!
Wed, 03 Nov 2021 15:04:37 -0700	nxf-scratch-dir ip-10-0-131-26.us-west-2.compute.internal:/tmp/nxf.VXDhjxcCQM
Wed, 03 Nov 2021 15:04:39 -0700	.command.sh: line 2: unexpected EOF while looking for matching `''
Wed, 03 Nov 2021 15:05:07 -0700	nxf-scratch-dir ip-10-0-131-26.us-west-2.compute.internal:/tmp/nxf.zuMwk0cQe9
Wed, 03 Nov 2021 15:05:08 -0700	Hello world!
```

**Checklist**

- [x] If this change would make any existing documentation invalid, I have included those updates within this PR
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have linted my code before raising the PR
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
