### PR TITLE
fix: updates context describe to be consistent with context destroy

### DIFF
--- a/packages/cli/internal/pkg/cli/context_describe.go
+++ b/packages/cli/internal/pkg/cli/context_describe.go
@@ -4,6 +4,8 @@
 package cli
 
 import (
+	"fmt"
+
 	"github.com/aws/amazon-genomics-cli/internal/pkg/cli/clierror"
 	"github.com/aws/amazon-genomics-cli/internal/pkg/cli/context"
 	"github.com/aws/amazon-genomics-cli/internal/pkg/cli/format"
@@ -28,7 +30,17 @@ func newDescribeContextOpts(vars describeContextVars) (*describeContextOpts, err
 	}, nil
 }
 
-func (o *describeContextOpts) Validate() error {
+func (o *describeContextOpts) Validate(args []string) error {
+	if len(args) == 0 && o.ContextName == "" {
+		return fmt.Errorf("a context must be provided")
+	} else if len(args) == 1 && o.ContextName != "" {
+		return fmt.Errorf("either the '-c' flag or a contexts must be provided, but not both")
+	}
+
+	if len(args) == 1 {
+		o.ContextName = args[0]
+	}
+
 	return nil
 }
 
@@ -69,19 +81,16 @@ func BuildContextDescribeCommand() *cobra.Command {
 ` + DescribeOutput(types.Context{}),
 		Example: `
 /code agc context describe myCtx`,
-		Args: cobra.ExactArgs(1),
+		Args: cobra.ArbitraryArgs,
 		RunE: runCmdE(func(cmd *cobra.Command, args []string) error {
-			if len(args) > 0 {
-				vars.ContextName = args[0]
-			}
 			opts, err := newDescribeContextOpts(vars)
 			if err != nil {
 				return err
 			}
-			log.Info().Msgf("Describing context '%s'", opts.ContextName)
-			if err := opts.Validate(); err != nil {
+			if err := opts.Validate(args); err != nil {
 				return err
 			}
+			log.Info().Msgf("Describing context '%s'", opts.ContextName)
 			ctx, err := opts.Execute()
 			if err != nil {
 				return clierror.New("context describe", vars, err)
@@ -90,5 +99,6 @@ func BuildContextDescribeCommand() *cobra.Command {
 			return nil
 		}),
 	}
+	cmd.Flags().StringVarP(&vars.ContextName, contextFlag, contextFlagShort, "", deployContextDescription)
 	return cmd
 }

--- a/packages/cli/internal/pkg/cli/context_describe.go
+++ b/packages/cli/internal/pkg/cli/context_describe.go
@@ -34,7 +34,7 @@ func (o *describeContextOpts) Validate(args []string) error {
 	if len(args) == 0 && o.ContextName == "" {
 		return fmt.Errorf("a context must be provided")
 	} else if len(args) == 1 && o.ContextName != "" {
-		return fmt.Errorf("either the '-c' flag or a contexts must be provided, but not both")
+		return fmt.Errorf("either the '-c' flag or a context must be provided, but not both")
 	}
 
 	if len(args) == 1 {

--- a/packages/cli/internal/pkg/cli/context_describe_test.go
+++ b/packages/cli/internal/pkg/cli/context_describe_test.go
@@ -92,7 +92,7 @@ func TestDescribeContextOpts_Validate(t *testing.T) {
 		"both context and context arg throws error": {
 			contextName:     testContextName1,
 			contextNameArgs: []string{testContextName2},
-			expectedErr:     fmt.Errorf("either the '-c' flag or a contexts must be provided, but not both"),
+			expectedErr:     fmt.Errorf("either the '-c' flag or a context must be provided, but not both"),
 		},
 		"no contexts supplied": {
 			expectedErr: fmt.Errorf("a context must be provided"),

--- a/packages/cli/internal/pkg/cli/context_describe_test.go
+++ b/packages/cli/internal/pkg/cli/context_describe_test.go
@@ -71,3 +71,52 @@ func TestDescribeContextOpts_Execute(t *testing.T) {
 		})
 	}
 }
+
+func TestDescribeContextOpts_Validate(t *testing.T) {
+	testCases := map[string]struct {
+		contextName     string
+		expectedContext string
+		contextNameArgs []string
+		expectedErr     error
+	}{
+		"valid single context name": {
+			contextName:     testContextName1,
+			expectedContext: testContextName1,
+			expectedErr:     nil,
+		},
+		"valid single context arg": {
+			contextNameArgs: []string{testContextName2},
+			expectedContext: testContextName2,
+			expectedErr:     nil,
+		},
+		"both context and context arg throws error": {
+			contextName:     testContextName1,
+			contextNameArgs: []string{testContextName2},
+			expectedErr:     fmt.Errorf("either the '-c' flag or a contexts must be provided, but not both"),
+		},
+		"no contexts supplied": {
+			expectedErr: fmt.Errorf("a context must be provided"),
+		},
+	}
+
+	for name, tt := range testCases {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			mockCtxManager := contextmocks.NewMockContextManager(ctrl)
+			opts := &describeContextOpts{
+				ctxManager:          mockCtxManager,
+				describeContextVars: describeContextVars{tt.contextName},
+			}
+
+			err := opts.Validate(tt.contextNameArgs)
+
+			if tt.expectedErr != nil {
+				assert.EqualError(t, err, tt.expectedErr.Error())
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedContext, opts.ContextName)
+			}
+		})
+	}
+}

--- a/site/content/en/docs/Tutorials/walkthrough.md
+++ b/site/content/en/docs/Tutorials/walkthrough.md
@@ -89,7 +89,7 @@ agc context deploy --all
 Contexts have read-write access to a context specific prefix in the S3 bucket Amazon Genomics CLI creates during account activation. You can check this for the `myContext` context with:
 
 ```shell
-agc context describe -c myContext
+agc context describe myContext
 ```
 
 You should see something like:


### PR DESCRIPTION
Issue #, if available: NA

**Description of Changes**

Currently, the command `agc context describe` does not allow a context to be passed in as an argument via `-c` while context destroy/deploy which breaks the consistency for that high level command. Our documentation also refers to requiring `-c` which currently isn't supported. This change updates the documentation to remove the `-c` command and allows the command to accept the context via the `-c` argument.

**Description of how you validated changes**

```
$ agc context describe spotCtx -c myContext
Error: either the '-c' flag or a contexts must be provided, but not both
$ agc context describe
Error: a context must be provided
$ agc context describe spotCtx
2021-11-04T12:06:27-07:00 𝒊  Describing context 'spotCtx'
CONTEXT	256	spotCtx	true	NOT_STARTED
OUTPUTLOCATION	s3://agc-383881756834-us-east-1/project/Demo/userid/elliotsm3WJrU7/context/spotCtx
$ agc context describe -c myContext
2021-11-04T12:06:40-07:00 𝒊  Describing context 'myContext'
CONTEXT	256	myContext	false	STARTED
OUTPUTLOCATION	s3://agc-383881756834-us-east-1/project/Demo/userid/elliotsm3WJrU7/context/myContext
```


**Checklist**

- [x] If this change would make any existing documentation invalid, I have included those updates within this PR
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have linted my code before raising the PR
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
