### PR TITLE
fix: copy instead of move input

### DIFF
--- a/examples/gatk-best-practices-project/gatk4-basic-joint-genotyping/gatk4-basic-joint-genotyping.wdl
+++ b/examples/gatk-best-practices-project/gatk4-basic-joint-genotyping/gatk4-basic-joint-genotyping.wdl
@@ -139,7 +139,7 @@ task RenameAndIndexFile {
 	command {
 		set -euo pipefail
 
-		mv ~{input_file} ~{new_name}
+		cp ~{input_file} ~{new_name}
 
 		~{gatk_path} --java-options "-Xmx~{command_mem_gb}G ~{java_opt}" \
 		IndexFeatureFile \


### PR DESCRIPTION


<!-- Title format: type(scope): Short description (72 chars max for line) -->
<!-- `(scope)` is optional and `type` is one of: build, ci, chore, docs, feat, fix, perf, refactor, revert, style, test -->
<!-- Available types:
- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit -->

Issue #, if available:

**Description of Changes**

[//]: #  (A description of the change that you made and the new user experience that it creates)

Best practice is to avoid mutation of inputs to a workflow. Further miniwdl prevents it. Therefore use copy instead of moving the input file.

**Description of how you validated changes**

[//]: #  (A description of you validated your changes and any relevant logs that show your change works)

`agc workflow run basic-joint-genotyping -c spotCtx

**Checklist**

- [ ] If this change would make any existing documentation invalid, I have included those updates within this PR
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have linted my code before raising the PR
- [*] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
