### PR TITLE
build: Move release files one folder down

### DIFF
--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-RELEASE_DIR="dist"
+RELEASE_DIR="dist/amazon-genomics-cli"
 
 mkdir -p ${RELEASE_DIR}
 cp ./{LICENSE,THIRD-PARTY,CHANGELOG.md} ${RELEASE_DIR}


### PR DESCRIPTION
fixes: #136

**Description of Changes**

Moving the release files one folder down to avoid bombing cwd.

**Description of how you validated changes**

Ran in forked build pipeline, confirmed it works.

**Checklist**

- [x] If this change would make any existing documentation invalid, I have included those updates within this PR
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have linted my code before raising the PR
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
