### PR TITLE
docs: improve contrast in docs

### DIFF
--- a/site/content/en/_index.html
+++ b/site/content/en/_index.html
@@ -23,7 +23,7 @@ Amazon Genomics CLI is an **open source CLI** that helps customers run genomics 
 {{% /blocks/lead %}}
 
 
-{{< blocks/section >}}
+{{< blocks/section color="white" >}}
 {{% blocks/feature icon="fa fa-download" title="Download Binaries" url="https://github.com/aws/amazon-genomics-cli/releases"%}}
 Get compiled [releases](https://github.com/aws/amazon-genomics-cli/releases) of Amazon Genomics CLI
 {{% /blocks/feature %}}


### PR DESCRIPTION
fixes: #135

**Description of Changes**

The contrast on the home page of the docs in one section was well below accessibility standards. This looks to be largely an issue with how Docsy determines how to color the font in the default theme. In order to avoid any additional side effects by overriding the theme variables, I'm opting to just change the color of the section. Docsy is at least smart enough to select dark color text when the background is white.

**Description of how you validated changes**

Ran `hugo server -D` locally and confirmed contrast ratios are > 4.5*

*The link is only 2.64 normally, but 7.49 when hovered.

![Screen Shot 2021-11-05 at 1 05 14 PM](https://user-images.githubusercontent.com/8409786/140572922-d2f79fc9-8823-4fa2-acfa-0c6ce6424d0b.png)

**Checklist**

- [x] If this change would make any existing documentation invalid, I have included those updates within this PR
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have linted my code before raising the PR
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
