### PR TITLE
fix: Asserts order deterministically

### DIFF
--- a/packages/cli/internal/pkg/aws/cwl/get_logs_test.go
+++ b/packages/cli/internal/pkg/aws/cwl/get_logs_test.go
@@ -79,12 +79,18 @@ func TestClient_GetLogs(t *testing.T) {
 	logs, err := output.NextLogs()
 	assert.False(t, output.HasMoreLogs())
 	assert.NoError(t, err)
-	assert.Equal(t, []string{
-		fmt.Sprintf("%s\tHello", eventTime1.Format(time.RFC1123Z)),
-		fmt.Sprintf("%s\tworld!", eventTime2.Format(time.RFC1123Z)),
-		fmt.Sprintf("%s\tHola", eventTime1.Format(time.RFC1123Z)),
-		fmt.Sprintf("%s\tmundo!", eventTime2.Format(time.RFC1123Z)),
+
+	englishHelloLog, spanishHelloLog := fmt.Sprintf("%s\tHello", eventTime1.Format(time.RFC1123Z)), fmt.Sprintf("%s\tHola", eventTime1.Format(time.RFC1123Z))
+	englishWorldLog, spanishWorldLog := fmt.Sprintf("%s\tworld!", eventTime2.Format(time.RFC1123Z)), fmt.Sprintf("%s\tmundo!", eventTime2.Format(time.RFC1123Z))
+	assert.ElementsMatch(t, []string{
+		englishHelloLog,
+		englishWorldLog,
+		spanishHelloLog,
+		spanishWorldLog,
 	}, logs)
+
+	assert.Contains(t, []string{englishHelloLog, spanishHelloLog}, logs[0])
+	assert.Contains(t, []string{englishHelloLog, spanishHelloLog}, logs[2])
 }
 
 func TestClient_GetLogs_Error(t *testing.T) {


### PR DESCRIPTION
**Description of Changes**

[//]: #  (A description of the change that you made and the new user experience that it creates)
The current test for "TestClient_GetLogs" is not deterministic. This change fixes that

[//]: #  (A description of you validated your changes and any relevant logs that show your change works)

Changed the check of the array to be a contains (deterministic) and validated the split of the logs by location by checking the first element in each section to be the "hello" keyword.

if others know if we can validate them better (I wasn't a fan of an else for checking the order) or has a different preference, I can update them to use that style instead.

**Checklist**

- [x] If this change would make any existing documentation invalid, I have included those updates within this PR
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have linted my code before raising the PR
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
