### PR TITLE
feat: Added default format flag 

### DIFF
--- a/packages/cli/cmd/application/main.go
+++ b/packages/cli/cmd/application/main.go
@@ -6,9 +6,6 @@ package main
 
 import (
 	"fmt"
-	"github.com/aws/amazon-genomics-cli/internal/pkg/cli/config"
-	"github.com/aws/amazon-genomics-cli/internal/pkg/cli/format"
-	"github.com/aws/amazon-genomics-cli/internal/pkg/storage"
 	"os"
 	"path"
 	"path/filepath"
@@ -18,7 +15,10 @@ import (
 	"github.com/aws/amazon-genomics-cli/cmd/application/template"
 	"github.com/aws/amazon-genomics-cli/internal/pkg/cli"
 	"github.com/aws/amazon-genomics-cli/internal/pkg/cli/clierror"
+	"github.com/aws/amazon-genomics-cli/internal/pkg/cli/config"
+	"github.com/aws/amazon-genomics-cli/internal/pkg/cli/format"
 	"github.com/aws/amazon-genomics-cli/internal/pkg/logging"
+	"github.com/aws/amazon-genomics-cli/internal/pkg/storage"
 	"github.com/aws/amazon-genomics-cli/internal/pkg/term/color"
 	"github.com/aws/amazon-genomics-cli/internal/pkg/version"
 	"github.com/rs/zerolog"
@@ -38,14 +38,15 @@ type mainVars struct {
 	docPath string
 }
 type formatVars struct {
-	format  string
+	format        string
 	defaultFormat string
 }
 
 type formatOpts struct {
 	configClient storage.ConfigClient
-	formatVars formatVars
+	formatVars   formatVars
 }
+
 func newFormatOpts(formatVars formatVars) (*formatOpts, error) {
 	return &formatOpts{
 		formatVars: formatVars,
@@ -152,7 +153,7 @@ func setFormatter(opts *formatOpts) {
 	formatVars := opts.formatVars
 	if formatVars.format == "" {
 		// read the default format from config
-		formatVars.format,err = configClient.GetFormat()
+		formatVars.format, err = configClient.GetFormat()
 		if err != nil {
 			log.Error().Err(err)
 		}

--- a/packages/cli/cmd/application/main_test.go
+++ b/packages/cli/cmd/application/main_test.go
@@ -1,29 +1,30 @@
 package main
 
 import (
-	"github.com/aws/amazon-genomics-cli/internal/pkg/cli/config"
-	"github.com/golang/mock/gomock"
 	"reflect"
 	"testing"
 
+	"github.com/aws/amazon-genomics-cli/internal/pkg/cli/config"
 	storagemocks "github.com/aws/amazon-genomics-cli/internal/pkg/mocks/storage"
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 )
 
 const (
 	tableFormat = "table"
 )
+
 type mockClients struct {
-	ctrl           *gomock.Controller
-	configMock     *storagemocks.MockConfigClient
+	ctrl       *gomock.Controller
+	configMock *storagemocks.MockConfigClient
 }
 
 func createMocks(t *testing.T) mockClients {
 	ctrl := gomock.NewController(t)
 
 	return mockClients{
-		ctrl:           ctrl,
-		configMock:     storagemocks.NewMockConfigClient(ctrl),
+		ctrl:       ctrl,
+		configMock: storagemocks.NewMockConfigClient(ctrl),
 	}
 }
 func TestSetFormatter(t *testing.T) {

--- a/packages/cli/cmd/application/main_test.go
+++ b/packages/cli/cmd/application/main_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"github.com/aws/amazon-genomics-cli/internal/pkg/cli/config"
+	"github.com/golang/mock/gomock"
+	"reflect"
+	"testing"
+
+	storagemocks "github.com/aws/amazon-genomics-cli/internal/pkg/mocks/storage"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	tableFormat = "table"
+)
+type mockClients struct {
+	ctrl           *gomock.Controller
+	configMock     *storagemocks.MockConfigClient
+}
+
+func createMocks(t *testing.T) mockClients {
+	ctrl := gomock.NewController(t)
+
+	return mockClients{
+		ctrl:           ctrl,
+		configMock:     storagemocks.NewMockConfigClient(ctrl),
+	}
+}
+func TestSetFormatter(t *testing.T) {
+	mocks := createMocks(t)
+	defer mocks.ctrl.Finish()
+
+	formatOpts, err := newFormatOpts(formatVars{
+		defaultFormat: tableFormat,
+	})
+	require.NoError(t, err)
+	mockedConfig := config.Config{
+		Format: config.Format{
+			Format: tableFormat,
+		},
+	}
+	formatOpts.configClient = mocks.configMock
+	setFormatter(formatOpts)
+	// check the actual config to see if it matches the config mock
+	configClient, _ := config.NewConfigClient()
+	configFormat, _ := configClient.GetFormat()
+	require.True(t, reflect.DeepEqual(configFormat, mockedConfig.Format.Format))
+}

--- a/packages/cli/internal/pkg/cli/config/config.go
+++ b/packages/cli/internal/pkg/cli/config/config.go
@@ -11,6 +11,6 @@ type Format struct {
 	Format string `yaml:"format"`
 }
 type Config struct {
-	User User `yaml:"user"`
+	User   User `yaml:"user"`
 	Format Format
 }

--- a/packages/cli/internal/pkg/cli/config/config.go
+++ b/packages/cli/internal/pkg/cli/config/config.go
@@ -7,6 +7,10 @@ type User struct {
 	Id string `yaml:"-"`
 }
 
+type Format struct {
+	Format string `yaml:"format"`
+}
 type Config struct {
 	User User `yaml:"user"`
+	Format Format
 }

--- a/packages/cli/internal/pkg/cli/config/config_client.go
+++ b/packages/cli/internal/pkg/cli/config/config_client.go
@@ -142,7 +142,10 @@ func (c Client) GetFormat() (string, error) {
 		return "", err
 	}
 	if configData.Format.Format == "" {
-		c.SetFormat(defaultFormat)
+		err:= c.SetFormat(defaultFormat)
+		if err != nil{
+			return "", err
+		}
 	}
 	return configData.Format.Format, nil
 }

--- a/packages/cli/internal/pkg/cli/config/config_client.go
+++ b/packages/cli/internal/pkg/cli/config/config_client.go
@@ -15,7 +15,7 @@ import (
 const (
 	configDirName  = ".agc"
 	configFileName = "config.yaml"
-	defaultFormat = "text"
+	defaultFormat  = "text"
 )
 
 type Client struct {
@@ -146,7 +146,7 @@ func (c Client) GetFormat() (string, error) {
 	}
 	return configData.Format.Format, nil
 }
-func (c Client) SetFormat (format string) error {
+func (c Client) SetFormat(format string) error {
 	configData, _ := c.loadFromFile()
 	configData.Format.Format = format
 	return c.storeToFile(configData)

--- a/packages/cli/internal/pkg/cli/config/config_client.go
+++ b/packages/cli/internal/pkg/cli/config/config_client.go
@@ -15,6 +15,7 @@ import (
 const (
 	configDirName  = ".agc"
 	configFileName = "config.yaml"
+	defaultFormat = "text"
 )
 
 type Client struct {
@@ -134,4 +135,19 @@ func (c Client) GetUserId() (string, error) {
 	}
 	userId := userIdFromEmailAddress(userEmailAddress)
 	return userId, nil
+}
+func (c Client) GetFormat() (string, error) {
+	configData, err := c.loadFromFile()
+	if err != nil {
+		return "", err
+	}
+	if configData.Format.Format == "" {
+		c.SetFormat(defaultFormat)
+	}
+	return configData.Format.Format, nil
+}
+func (c Client) SetFormat (format string) error {
+	configData, _ := c.loadFromFile()
+	configData.Format.Format = format
+	return c.storeToFile(configData)
 }

--- a/packages/cli/internal/pkg/cli/config/config_test.go
+++ b/packages/cli/internal/pkg/cli/config/config_test.go
@@ -23,6 +23,7 @@ var (
 		User{
 			Email: "my@email.com",
 		},
+		Format{},
 	}
 )
 

--- a/packages/cli/internal/pkg/cli/flag.go
+++ b/packages/cli/internal/pkg/cli/flag.go
@@ -3,8 +3,6 @@
 
 package cli
 
-import "github.com/aws/amazon-genomics-cli/internal/pkg/cli/format"
-
 const (
 	argsFlag            = "args"
 	argsFlagShort       = "a"
@@ -19,8 +17,11 @@ const (
 
 const (
 	FormatFlag            = "format"
-	FormatFlagDefault     = string(format.DefaultFormat)
 	FormatFlagDescription = "Format option for output. Valid options are: text, tabular"
+)
+const (
+	DefaultFormatFlag            = "defaultFormat"
+	DefaultFormatFlagDescription = "Default Format option for output. Valid options are: text, tabular"
 )
 
 const (

--- a/packages/cli/internal/pkg/mocks/storage/mock_interfaces.go
+++ b/packages/cli/internal/pkg/mocks/storage/mock_interfaces.go
@@ -161,6 +161,21 @@ func (mr *MockConfigClientMockRecorder) GetUserId() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserId", reflect.TypeOf((*MockConfigClient)(nil).GetUserId))
 }
 
+// GetFormat mocks base method.
+func (m *MockConfigClient) GetFormat() (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetFormat")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetFormat indicates an expected call of GetFormat.
+func (mr *MockConfigClientMockRecorder) GetFormat() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFormat", reflect.TypeOf((*MockConfigClient)(nil).GetFormat))
+}
+
 // Read mocks base method.
 func (m *MockConfigClient) Read() (config.Config, error) {
 	m.ctrl.T.Helper()
@@ -188,6 +203,21 @@ func (m *MockConfigClient) SetUserEmailAddress(userId string) error {
 func (mr *MockConfigClientMockRecorder) SetUserEmailAddress(userId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUserEmailAddress", reflect.TypeOf((*MockConfigClient)(nil).SetUserEmailAddress), userId)
+}
+
+
+// SetFormat mocks base method.
+func (m *MockConfigClient) SetFormat(format string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetFormat", format)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetFormat indicates an expected call of SetFormat.
+func (mr *MockConfigClientMockRecorder) SetFormat(format interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetFormat", reflect.TypeOf((*MockConfigClient)(nil).SetFormat), format)
 }
 
 // MockStorageClient is a mock of StorageClient interface.

--- a/packages/cli/internal/pkg/mocks/storage/mock_interfaces.go
+++ b/packages/cli/internal/pkg/mocks/storage/mock_interfaces.go
@@ -205,7 +205,6 @@ func (mr *MockConfigClientMockRecorder) SetUserEmailAddress(userId interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUserEmailAddress", reflect.TypeOf((*MockConfigClient)(nil).SetUserEmailAddress), userId)
 }
 
-
 // SetFormat mocks base method.
 func (m *MockConfigClient) SetFormat(format string) error {
 	m.ctrl.T.Helper()

--- a/packages/cli/internal/pkg/storage/interfaces.go
+++ b/packages/cli/internal/pkg/storage/interfaces.go
@@ -30,6 +30,6 @@ type ConfigClient interface {
 	GetUserEmailAddress() (string, error)
 	SetUserEmailAddress(userId string) error
 	GetUserId() (string, error)
-	GetFormat() (string,error)
+	GetFormat() (string, error)
 	SetFormat(format string) error
 }

--- a/packages/cli/internal/pkg/storage/interfaces.go
+++ b/packages/cli/internal/pkg/storage/interfaces.go
@@ -30,4 +30,6 @@ type ConfigClient interface {
 	GetUserEmailAddress() (string, error)
 	SetUserEmailAddress(userId string) error
 	GetUserId() (string, error)
+	GetFormat() (string,error)
+	SetFormat(format string) error
 }


### PR DESCRIPTION
<!-- Title format: type(scope): Short description (72 chars max for line) -->
<!-- `(scope)` is optional and `type` is one of: build, ci, chore, docs, feat, fix, perf, refactor, revert, style, test -->
<!-- Available types:
- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit -->

Issue #, if available: 

**Description of Changes**

[//]: #  (A description of the change that you made and the new user experience that it creates)
Implemented the default format flag option to allow the user to set a default format for output.  By setting the flag --defaultFormat, the user updates the configuration to hold this new default format. In the subsequent commands, the default format stored in the config will be used to format the output.

**Description of how you validated changes**
```
$ agc configure describe
2021-11-08T16:07:26-08:00 𝒊  Reading user specific configuration
CONFIG
FORMAT	text
USER	atahlil@amazon.com	atahlil3HYhj7
$ agc context list --defaultFormat=table
2021-11-08T16:07:41-08:00 𝒊  Listing contexts.
Name		EngineName
myContext	cromwell
spotCtx		cromwell
$ agc context list --format=text
2021-11-08T16:07:51-08:00 𝒊  Listing contexts.
CONTEXTSUMMARY	cromwell	myContext
CONTEXTSUMMARY	cromwell	spotCtx
$ agc context list
2021-11-08T16:08:00-08:00 𝒊  Listing contexts.
Name		EngineName
myContext	cromwell
spotCtx		cromwell
```

[//]: #  (A description of you validated your changes and any relevant logs that show your change works)


**Checklist**

- [x] If this change would make any existing documentation invalid, I have included those updates within this PR
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have linted my code before raising the PR
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
