### PR TITLE
feat: Improved Workflow logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
           working-directory: packages/cli/
 
           # Optional: golangci-lint command line arguments.
-          # args: --issues-exit-code=0
+          args: --timeout=5m0s
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true

--- a/packages/cli/internal/pkg/cli/format/format.go
+++ b/packages/cli/internal/pkg/cli/format/format.go
@@ -2,6 +2,7 @@ package format
 
 import (
 	"bytes"
+	"io"
 	"os"
 	"text/tabwriter"
 )
@@ -20,9 +21,9 @@ func NewText() *Text {
 	return &Text{os.Stdout}
 }
 
-func NewTable() *Table {
+func NewTable(output io.Writer) *Table {
 	return &Table{
-		*tabwriter.NewWriter(os.Stdout, 0, 8, 0, tableDelimiter[0], 0),
+		*tabwriter.NewWriter(output, 0, 8, 0, tableDelimiter[0], 0),
 	}
 }
 
@@ -31,7 +32,7 @@ func SetFormatter(format FormatterType) {
 	case textFormat:
 		Default = NewText()
 	case tableFormat:
-		Default = NewTable()
+		Default = NewTable(os.Stdout)
 	}
 }
 

--- a/packages/cli/internal/pkg/cli/logs_workflow.go
+++ b/packages/cli/internal/pkg/cli/logs_workflow.go
@@ -6,12 +6,12 @@ package cli
 import (
 	"bytes"
 	"errors"
-	"github.com/aws/amazon-genomics-cli/internal/pkg/cli/format"
 
 	"github.com/aws/amazon-genomics-cli/internal/pkg/aws"
 	"github.com/aws/amazon-genomics-cli/internal/pkg/aws/batch"
 	"github.com/aws/amazon-genomics-cli/internal/pkg/cli/clierror"
 	"github.com/aws/amazon-genomics-cli/internal/pkg/cli/context"
+	"github.com/aws/amazon-genomics-cli/internal/pkg/cli/format"
 	"github.com/aws/amazon-genomics-cli/internal/pkg/cli/workflow"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"

--- a/packages/cli/internal/pkg/cli/logs_workflow_test.go
+++ b/packages/cli/internal/pkg/cli/logs_workflow_test.go
@@ -153,9 +153,9 @@ func TestLogsWorkflowOpts_Execute(t *testing.T) {
 				opts.runId = testRunId
 				opts.workflowManager.(*managermocks.MockWorkflowManager).EXPECT().
 					GetRunLog(testRunId).Return(workflow.RunLog{
-						RunId: testRunId,
-						State: "COMPLETE",
-						Tasks: []workflow.Task(nil),
+					RunId: testRunId,
+					State: "COMPLETE",
+					Tasks: []workflow.Task(nil),
 				}, nil)
 			},
 			expectedOutput: "RUNLOG\tTest Workflow Run Id\tCOMPLETE\n\n",

--- a/packages/cli/internal/pkg/cli/logs_workflow_test.go
+++ b/packages/cli/internal/pkg/cli/logs_workflow_test.go
@@ -145,7 +145,7 @@ func TestLogsWorkflowOpts_Execute(t *testing.T) {
 				opts.workflowManager.(*managermocks.MockWorkflowManager).EXPECT().
 					GetRunLog(testRunId).Return(testRunLog, nil)
 			},
-			expectedOutput: "RUNLOG\tTest Workflow Run Id\tCOMPLETE\nTASK\t0\tTest Job Id\tTest Task Name\t<nil>\t<nil>\n\n",
+			expectedOutput: "RunId: Test Workflow Run Id\nState: COMPLETE\nTasks: \n\tName\t\tJobId\t\tStartTime\tStopTimeExitCode\n\tTest Task Name\tTest Job Id\t<nil>\t\t<nil>\t0\n\t\n",
 		},
 		"runId no jobs": {
 			setupOps: func(opts *logsWorkflowOpts, cwlLopPaginator *awsmocks.MockCwlLogPaginator) {
@@ -158,7 +158,7 @@ func TestLogsWorkflowOpts_Execute(t *testing.T) {
 					Tasks: []workflow.Task(nil),
 				}, nil)
 			},
-			expectedOutput: "RUNLOG\tTest Workflow Run Id\tCOMPLETE\n\n",
+			expectedOutput: "RunId: Test Workflow Run Id\nState: COMPLETE\nTasks: No task logs available\n",
 		},
 		"runId empty cached": {
 			setupOps: func(opts *logsWorkflowOpts, cwlLopPaginator *awsmocks.MockCwlLogPaginator) {
@@ -172,7 +172,7 @@ func TestLogsWorkflowOpts_Execute(t *testing.T) {
 					Tasks: []workflow.Task{testCachedTask},
 				}, nil)
 			},
-			expectedOutput: "RUNLOG\tTest Workflow Run Id\tCOMPLETE\nTASK\t0\tXXXXX\tTest Task Name\t<nil>\t<nil>\n\n",
+			expectedOutput: "RunId: Test Workflow Run Id\nState: COMPLETE\nTasks: \n\tName\t\tJobId\tStartTime\tStopTimeExitCode\n\tTest Task Name\tXXXXX\t<nil>\t\t<nil>\t0\n\t\n",
 		},
 		"workflow name single task empty log": {
 			setupOps: func(opts *logsWorkflowOpts, cwlLopPaginator *awsmocks.MockCwlLogPaginator) {

--- a/packages/cli/internal/pkg/cli/logs_workflow_test.go
+++ b/packages/cli/internal/pkg/cli/logs_workflow_test.go
@@ -110,6 +110,12 @@ func TestLogsWorkflowOpts_Execute(t *testing.T) {
 		JobId: testJobId,
 	}
 
+	testRunLog := workflow.RunLog{
+		RunId: testRunId,
+		State: "COMPLETE",
+		Tasks: []workflow.Task{testTask},
+	}
+
 	testCachedTask := workflow.Task{
 		Name:  testTaskName,
 		JobId: cachedJobId,
@@ -136,32 +142,23 @@ func TestLogsWorkflowOpts_Execute(t *testing.T) {
 			setupOps: func(opts *logsWorkflowOpts, cwlLopPaginator *awsmocks.MockCwlLogPaginator) {
 				opts.workflowName = testWorkflowName
 				opts.runId = testRunId
-
 				opts.workflowManager.(*managermocks.MockWorkflowManager).EXPECT().
-					GetWorkflowTasks(testRunId).Return([]workflow.Task{testTask}, nil)
-				opts.batchClient.(*awsmocks.MockBatchClient).EXPECT().
-					GetJobs([]string{testJobId}).Return([]batch.Job{testJob}, nil)
-				opts.cwlClient.(*awsmocks.MockCwlClient).EXPECT().
-					GetLogsPaginated(cwl.GetLogsInput{
-						LogGroupName: testLogGroupName,
-						StartTime:    nil,
-						EndTime:      nil,
-						Filter:       "",
-						Streams:      []string{testLogStreamName},
-					}).Return(cwlLopPaginator)
-				cwlLopPaginator.EXPECT().HasMoreLogs().Return(false)
+					GetRunLog(testRunId).Return(testRunLog, nil)
 			},
-			expectedOutput: "",
+			expectedOutput: "RUNLOG\tTest Workflow Run Id\tCOMPLETE\nTASK\t0\tTest Job Id\tTest Task Name\t<nil>\t<nil>\n\n",
 		},
 		"runId no jobs": {
 			setupOps: func(opts *logsWorkflowOpts, cwlLopPaginator *awsmocks.MockCwlLogPaginator) {
 				opts.workflowName = testWorkflowName
 				opts.runId = testRunId
-
 				opts.workflowManager.(*managermocks.MockWorkflowManager).EXPECT().
-					GetWorkflowTasks(testRunId).Return([]workflow.Task(nil), nil)
+					GetRunLog(testRunId).Return(workflow.RunLog{
+						RunId: testRunId,
+						State: "COMPLETE",
+						Tasks: []workflow.Task(nil),
+				}, nil)
 			},
-			expectedOutput: "",
+			expectedOutput: "RUNLOG\tTest Workflow Run Id\tCOMPLETE\n\n",
 		},
 		"runId empty cached": {
 			setupOps: func(opts *logsWorkflowOpts, cwlLopPaginator *awsmocks.MockCwlLogPaginator) {
@@ -169,18 +166,27 @@ func TestLogsWorkflowOpts_Execute(t *testing.T) {
 				opts.runId = testRunId
 
 				opts.workflowManager.(*managermocks.MockWorkflowManager).EXPECT().
-					GetWorkflowTasks(testRunId).Return([]workflow.Task{testCachedTask}, nil)
+					GetRunLog(testRunId).Return(workflow.RunLog{
+					RunId: testRunId,
+					State: "COMPLETE",
+					Tasks: []workflow.Task{testCachedTask},
+				}, nil)
 			},
-			expectedOutput: "",
+			expectedOutput: "RUNLOG\tTest Workflow Run Id\tCOMPLETE\nTASK\t0\tXXXXX\tTest Task Name\t<nil>\t<nil>\n\n",
 		},
-		"workflow name empty log": {
+		"workflow name single task empty log": {
 			setupOps: func(opts *logsWorkflowOpts, cwlLopPaginator *awsmocks.MockCwlLogPaginator) {
 				opts.workflowName = testWorkflowName
+				opts.taskId = testJobId
 
 				opts.workflowManager.(*managermocks.MockWorkflowManager).EXPECT().
-					StatusWorkflowByName(testWorkflowName, 1).Return([]workflow.InstanceSummary{testInstanceSummary}, nil)
+					GetRunLog(testRunId).Return(workflow.RunLog{
+					RunId: testRunId,
+					State: "COMPLETE",
+					Tasks: []workflow.Task{testTask},
+				}, nil)
 				opts.workflowManager.(*managermocks.MockWorkflowManager).EXPECT().
-					GetWorkflowTasks(testRunId).Return([]workflow.Task{testTask}, nil)
+					StatusWorkflowByName(testWorkflowName, 1).Return([]workflow.InstanceSummary{testInstanceSummary}, nil)
 				opts.batchClient.(*awsmocks.MockBatchClient).EXPECT().
 					GetJobs([]string{testJobId}).Return([]batch.Job{testJob}, nil)
 				opts.cwlClient.(*awsmocks.MockCwlClient).EXPECT().
@@ -208,9 +214,14 @@ func TestLogsWorkflowOpts_Execute(t *testing.T) {
 			setupOps: func(opts *logsWorkflowOpts, cwlLopPaginator *awsmocks.MockCwlLogPaginator) {
 				opts.workflowName = testWorkflowName
 				opts.runId = testRunId
+				opts.allTasks = true
 
 				opts.workflowManager.(*managermocks.MockWorkflowManager).EXPECT().
-					GetWorkflowTasks(testRunId).Return([]workflow.Task{testTask}, nil)
+					GetRunLog(testRunId).Return(workflow.RunLog{
+					RunId: testRunId,
+					State: "COMPLETE",
+					Tasks: []workflow.Task{testTask},
+				}, nil)
 				opts.batchClient.(*awsmocks.MockBatchClient).EXPECT().
 					GetJobs([]string{testJobId}).Return([]batch.Job{testJob}, nil)
 				opts.cwlClient.(*awsmocks.MockCwlClient).EXPECT().
@@ -231,9 +242,14 @@ func TestLogsWorkflowOpts_Execute(t *testing.T) {
 			setupOps: func(opts *logsWorkflowOpts, cwlLopPaginator *awsmocks.MockCwlLogPaginator) {
 				opts.workflowName = testWorkflowName
 				opts.runId = testRunId
+				opts.allTasks = true
 
 				opts.workflowManager.(*managermocks.MockWorkflowManager).EXPECT().
-					GetWorkflowTasks(testRunId).Return([]workflow.Task{testTask}, nil)
+					GetRunLog(testRunId).Return(workflow.RunLog{
+					RunId: testRunId,
+					State: "COMPLETE",
+					Tasks: []workflow.Task{testTask},
+				}, nil)
 				opts.batchClient.(*awsmocks.MockBatchClient).EXPECT().
 					GetJobs([]string{testJobId}).Return([]batch.Job{testJob}, nil)
 				opts.cwlClient.(*awsmocks.MockCwlClient).EXPECT().

--- a/packages/cli/internal/pkg/cli/workflow/workflow_status.go
+++ b/packages/cli/internal/pkg/cli/workflow/workflow_status.go
@@ -8,6 +8,7 @@ type StatusManager interface {
 }
 
 type TasksManager interface {
+	GetRunLog(runId string) (RunLog, error)
 	GetWorkflowTasks(runId string) ([]Task, error)
 	StatusWorkflowByName(workflowName string, numInstances int) ([]InstanceSummary, error)
 }

--- a/packages/cli/internal/pkg/cli/workflow/workflow_tasks.go
+++ b/packages/cli/internal/pkg/cli/workflow/workflow_tasks.go
@@ -17,6 +17,12 @@ type Task struct {
 	ExitCode  int
 }
 
+type RunLog struct {
+	RunId string
+	State string
+	Tasks []Task
+}
+
 func (m *Manager) GetWorkflowTasks(runId string) ([]Task, error) {
 	m.readProjectSpec()
 	m.readConfig()
@@ -30,6 +36,23 @@ func (m *Manager) GetWorkflowTasks(runId string) ([]Task, error) {
 
 	return m.getTasks()
 
+}
+
+func (m *Manager) GetRunLog(runId string) (RunLog, error) {
+
+	tasks, err := m.GetWorkflowTasks(runId)
+	if err != nil {
+		return RunLog{}, err
+	} else if m.err != nil {
+		return RunLog{}, m.err
+	}
+
+	var runLog = m.taskProps.runLog
+	return RunLog{
+		RunId: runLog.RunId,
+		State: string(runLog.State),
+		Tasks: tasks,
+	}, nil
 }
 
 func (m *Manager) setContextForRun(runId string) {

--- a/packages/cli/internal/pkg/cli/workflow/workflow_tasks.go
+++ b/packages/cli/internal/pkg/cli/workflow/workflow_tasks.go
@@ -39,18 +39,18 @@ func (m *Manager) GetWorkflowTasks(runId string) ([]Task, error) {
 }
 
 func (m *Manager) GetRunLog(runId string) (RunLog, error) {
-
-	tasks, err := m.GetWorkflowTasks(runId)
-	if err != nil {
-		return RunLog{}, err
-	} else if m.err != nil {
+	if m.err != nil {
+		return RunLog{}, m.err
+	}
+	var tasks []Task
+	tasks, m.err = m.GetWorkflowTasks(runId)
+	if m.err != nil {
 		return RunLog{}, m.err
 	}
 
-	var runLog = m.taskProps.runLog
 	return RunLog{
-		RunId: runLog.RunId,
-		State: string(runLog.State),
+		RunId: m.taskProps.runLog.RunId,
+		State: string(m.taskProps.runLog.State),
 		Tasks: tasks,
 	}, nil
 }

--- a/packages/cli/internal/pkg/mocks/manager/mock_interfaces.go
+++ b/packages/cli/internal/pkg/mocks/manager/mock_interfaces.go
@@ -123,3 +123,18 @@ func (mr *MockWorkflowManagerMockRecorder) StatusWorkflowByName(workflowName, nu
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StatusWorkflowByName", reflect.TypeOf((*MockWorkflowManager)(nil).StatusWorkflowByName), workflowName, numInstances)
 }
+
+// GetRunLog mocks base method.
+func (m *MockWorkflowManager) GetRunLog(runId string) (workflow.RunLog, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRunLog", runId)
+	ret0, _ := ret[0].(workflow.RunLog)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRunLog indicates an expected call of GetRunLog.
+func (mr *MockWorkflowManagerMockRecorder) GetRunLog(runId string) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRunLog", reflect.TypeOf((*MockWorkflowManager)(nil).GetRunLog), runId)
+}


### PR DESCRIPTION
By default, workflow logs for a run will log out run status and individual task status.
Tasks logs can be emitted with `--task <taskId>` for a single task log, `--all-tasks` for all task logs, and `--failed-tasks` for failed task logs.

<!-- Title format: type(scope): Short description (72 chars max for line) -->
<!-- `(scope)` is optional and `type` is one of: build, ci, chore, docs, feat, fix, perf, refactor, revert, style, test -->
<!-- Available types:
- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit -->

Issue #, if available:

**Description of Changes**

[//]: #  (A description of the change that you made and the new user experience that it creates)

**Description of how you validated changes**
Verified commands manually 

```
$ agc logs workflow foo
2021-11-09T17:17:01-08:00 𝒊  Showing the logs for 'foo'
2021-11-09T17:17:02-08:00 𝒊  Showing logs for the latest run of the workflow. Run id: '4927d57c-5181-4505-9e9f-96a7590ea9eb'
RunId: 4927d57c-5181-4505-9e9f-96a7590ea9eb
State: COMPLETE
Tasks: 
        Name                    JobId                                   StartTime                               StopTime                                ExitCode
        hello_agc.goodbye       29fc9be3-3cc9-4e44-bbb1-50072b7be053    2021-11-09 20:21:10.118 +0000 UTC       2021-11-09 20:27:01.382 +0000 UTC       0
        hello_agc.hello         d6dad1b4-52ec-4765-8d8a-0f42093d49d2    2021-11-09 20:21:10.117 +0000 UTC       2021-11-09 20:26:31.345 +0000 UTC       0
        hello_agc.no            1764a32d-b64b-4c9f-b5a9-e86df0c1fca7    2021-11-09 20:21:10.117 +0000 UTC       2021-11-09 20:27:10.345 +0000 UTC       0
```


```
$ agc logs workflow foo --all-tasks
2021-11-09T17:17:07-08:00 𝒊  Showing the logs for 'foo'
2021-11-09T17:17:08-08:00 𝒊  Showing logs for the latest run of the workflow. Run id: '4927d57c-5181-4505-9e9f-96a7590ea9eb'
Tue, 09 Nov 2021 12:26:14 -0800 download: s3://agc-388165786712-us-west-
[...]
Tue, 09 Nov 2021 12:26:17 -0800 *** COMPLETED DELOCALIZATION ***
Tue, 09 Nov 2021 12:26:17 -0800 *** EXITING WITH RETURN CODE ***
Tue, 09 Nov 2021 12:26:17 -0800 0
```


```
$ agc logs workflow foo --failed-tasks
2021-11-09T17:17:15-08:00 𝒊  Showing the logs for 'foo'
2021-11-09T17:17:15-08:00 𝒊  Showing logs for the latest run of the workflow. Run id: '4927d57c-5181-4505-9e9f-96a7590ea9eb'
2021-11-09T17:17:16-08:00 𝒊  No logs available for run '4927d57c-5181-4505-9e9f-96a7590ea9eb'. Please try again later.
```

```
$ agc logs workflow foo --task 29fc9be3-3cc9-4e44-bbb1-50072b7be053
2021-11-09T17:17:29-08:00 𝒊  Showing the logs for 'foo'
2021-11-09T17:17:30-08:00 𝒊  Showing logs for the latest run of the workflow. Run id: '4927d57c-5181-4505-9e9f-96a7590ea9eb'
Tue, 09 Nov 2021 12:26:14 -0800 download: s3://agc-388165786712-us-west-1/scripts/69070f57f6499609f65566ed33421740 to tmp/tmp.jCuIQYqtS/batch-file-temp
Tue, 09 Nov 2021 12:26:14 -0800 *** LOCALIZING INPUTS ***
Tue, 09 Nov 2021 12:26:16 -0800 download: s3://agc-388165786712-us-west-1/project/myProject/userid/guyhawki2Xarph/context/groot/cromwell-execution/hello_agc/4927d57c-5181-4505-9e9f-96a7590ea9eb/call-goodbye/script to agc-388165786712-us-west-1/project/myProject/userid/guyhawki2Xarph/context/groot/cromwell-execution/hello_agc/4927d57c-5181-4505-9e9f-96a7590ea9eb/call-goodbye/script
Tue, 09 Nov 2021 12:26:17 -0800 *** COMPLETED LOCALIZATION ***
Tue, 09 Nov 2021 12:26:17 -0800 Hello Amazon Genomics CLI!3
Tue, 09 Nov 2021 12:26:17 -0800 *** DELOCALIZING OUTPUTS ***
Tue, 09 Nov 2021 12:26:18 -0800 upload: ./goodbye-rc.txt to s3://agc-388165786712-us-west-1/project/myProject/userid/guyhawki2Xarph/context/groot/cromwell-execution/hello_agc/4927d57c-5181-4505-9e9f-96a7590ea9eb/call-goodbye/goodbye-rc.txt
Tue, 09 Nov 2021 12:26:19 -0800 upload: ./goodbye-stderr.log to s3://agc-388165786712-us-west-1/project/myProject/userid/guyhawki2Xarph/context/groot/cromwell-execution/hello_agc/4927d57c-5181-4505-9e9f-96a7590ea9eb/call-goodbye/goodbye-stderr.log
Tue, 09 Nov 2021 12:26:20 -0800 upload: ./goodbye-stdout.log to s3://agc-388165786712-us-west-1/project/myProject/userid/guyhawki2Xarph/context/groot/cromwell-execution/hello_agc/4927d57c-5181-4505-9e9f-96a7590ea9eb/call-goodbye/goodbye-stdout.log
Tue, 09 Nov 2021 12:26:20 -0800 *** COMPLETED DELOCALIZATION ***
Tue, 09 Nov 2021 12:26:20 -0800 *** EXITING WITH RETURN CODE ***
Tue, 09 Nov 2021 12:26:20 -0800 0
```


**Checklist**

- [x] If this change would make any existing documentation invalid, I have included those updates within this PR
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have linted my code before raising the PR
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*


```
go test -race -cover -count=1 -coverprofile coverage.out ./internal...
ok      github.com/aws/amazon-genomics-cli/internal/pkg/aws     2.966s  coverage: 93.3% of statements
ok      github.com/aws/amazon-genomics-cli/internal/pkg/aws/batch       1.699s  coverage: 90.9% of statements
ok      github.com/aws/amazon-genomics-cli/internal/pkg/aws/cdk 2.415s  coverage: 68.8% of statements
ok      github.com/aws/amazon-genomics-cli/internal/pkg/aws/cfn 1.211s  coverage: 87.7% of statements
ok      github.com/aws/amazon-genomics-cli/internal/pkg/aws/cwl 0.488s  coverage: 92.2% of statements
?       github.com/aws/amazon-genomics-cli/internal/pkg/aws/ddb [no test files]
ok      github.com/aws/amazon-genomics-cli/internal/pkg/aws/ecr 0.742s  coverage: 81.8% of statements
ok      github.com/aws/amazon-genomics-cli/internal/pkg/aws/s3  2.531s  coverage: 95.9% of statements
ok      github.com/aws/amazon-genomics-cli/internal/pkg/aws/ssm 2.254s  coverage: 90.0% of statements
ok      github.com/aws/amazon-genomics-cli/internal/pkg/aws/sts 1.463s  coverage: 85.7% of statements
ok      github.com/aws/amazon-genomics-cli/internal/pkg/aws/util        0.953s  coverage: 100.0% of statements
ok      github.com/aws/amazon-genomics-cli/internal/pkg/cli     3.338s  coverage: 48.2% of statements
?       github.com/aws/amazon-genomics-cli/internal/pkg/cli/awsresources        [no test files]
ok      github.com/aws/amazon-genomics-cli/internal/pkg/cli/clierror    2.310s  coverage: 58.3% of statements
ok      github.com/aws/amazon-genomics-cli/internal/pkg/cli/clierror/actionableerror    3.023s  coverage: 100.0% of statements
ok      github.com/aws/amazon-genomics-cli/internal/pkg/cli/config      3.108s  coverage: 42.4% of statements
ok      github.com/aws/amazon-genomics-cli/internal/pkg/cli/context     2.971s  coverage: 85.5% of statements
ok      github.com/aws/amazon-genomics-cli/internal/pkg/cli/format      2.996s  coverage: 84.0% of statements
?       github.com/aws/amazon-genomics-cli/internal/pkg/cli/group       [no test files]
ok      github.com/aws/amazon-genomics-cli/internal/pkg/cli/spec        3.667s  coverage: 52.0% of statements
?       github.com/aws/amazon-genomics-cli/internal/pkg/cli/types       [no test files]
ok      github.com/aws/amazon-genomics-cli/internal/pkg/cli/workflow    3.414s  coverage: 83.7% of statements
ok      github.com/aws/amazon-genomics-cli/internal/pkg/cli/zipfile     3.528s  coverage: 86.7% of statements
?       github.com/aws/amazon-genomics-cli/internal/pkg/constants       [no test files]
?       github.com/aws/amazon-genomics-cli/internal/pkg/environment     [no test files]
?       github.com/aws/amazon-genomics-cli/internal/pkg/logging [no test files]
?       github.com/aws/amazon-genomics-cli/internal/pkg/mocks/aws       [no test files]
?       github.com/aws/amazon-genomics-cli/internal/pkg/mocks/context   [no test files]
?       github.com/aws/amazon-genomics-cli/internal/pkg/mocks/io        [no test files]
?       github.com/aws/amazon-genomics-cli/internal/pkg/mocks/manager   [no test files]
?       github.com/aws/amazon-genomics-cli/internal/pkg/mocks/storage   [no test files]
?       github.com/aws/amazon-genomics-cli/internal/pkg/mocks/wes       [no test files]
?       github.com/aws/amazon-genomics-cli/internal/pkg/mocks/workflow  [no test files]
ok      github.com/aws/amazon-genomics-cli/internal/pkg/slices  3.623s  coverage: 100.0% of statements
ok      github.com/aws/amazon-genomics-cli/internal/pkg/storage 3.700s  coverage: 75.3% of statements
ok      github.com/aws/amazon-genomics-cli/internal/pkg/term/color      3.739s  coverage: 100.0% of statements
ok      github.com/aws/amazon-genomics-cli/internal/pkg/version 3.284s  coverage: 89.8% of statements
?       github.com/aws/amazon-genomics-cli/internal/pkg/wes     [no test files]
?       github.com/aws/amazon-genomics-cli/internal/pkg/wes/option      [no test files]
(cd packages/cli; /Library/Developer/CommandLineTools/usr/bin/make build)
go build -ldflags "-X github.com/aws/amazon-genomics-cli/internal/pkg/version.Version=1.0.1-65-gdca0fdd" -o ./bin/local/agc ./cmd/application
```
