### PR TITLE
fix: use proper assertion in order to avoid sporadic unit test failures

### DIFF
--- a/packages/cli/internal/pkg/aws/cwl/stream_logs_test.go
+++ b/packages/cli/internal/pkg/aws/cwl/stream_logs_test.go
@@ -54,7 +54,7 @@ func TestClient_StreamLogs(t *testing.T) {
 	cancel()
 	stream := client.StreamLogs(ctx, testLogGroupName)
 	event := <-stream
-	assert.Equal(t, []string{
+	assert.ElementsMatch(t, []string{
 		fmt.Sprintf("%s\tHello", someTime1.Format(time.RFC1123Z)),
 		fmt.Sprintf("%s\tworld!", someTime2.Format(time.RFC1123Z)),
 		fmt.Sprintf("%s\tHola", someTime1.Format(time.RFC1123Z)),

--- a/packages/cli/internal/pkg/aws/cwl/stream_logs_test.go
+++ b/packages/cli/internal/pkg/aws/cwl/stream_logs_test.go
@@ -68,6 +68,9 @@ func TestClient_StreamLogs(t *testing.T) {
 	}
 	assert.True(t, eventToIndexMap[logStream1Event1] < eventToIndexMap[logStream1Event2], "events in correct order in logs stream 1")
 	assert.True(t, eventToIndexMap[logStream2Event1] < eventToIndexMap[logStream2Event2], "events in correct order in logs stream 2")
+	assert.Equal(t, 1, eventToIndexMap[logStream1Event2]-eventToIndexMap[logStream1Event1], "distance between event from the same log stream")
+	assert.Equal(t, 1, eventToIndexMap[logStream2Event2]-eventToIndexMap[logStream2Event1], "distance between event from the same log stream")
+
 	_, isOpen := <-stream
 	assert.False(t, isOpen)
 }


### PR DESCRIPTION
<!-- Title format: type(scope): Short description (72 chars max for line) -->
<!-- `(scope)` is optional and `type` is one of: build, ci, chore, docs, feat, fix, perf, refactor, revert, style, test -->
<!-- Available types:
- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit -->

Issue #, if available:

**Description of Changes**

[//]: #  (A description of the change that you made and the new user experience that it creates)

Events are accumulated in a map with key being log stream name. Order of keys in map is not guaranteed by the implementation. In unit test we cannot require particular order, or it will cause sporadic unit test failures. 

**Description of how you validated changes**

[//]: #  (A description of you validated your changes and any relevant logs that show your change works)

- make
- unit test is back to stable

**Checklist**

- [x] If this change would make any existing documentation invalid, I have included those updates within this PR
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have linted my code before raising the PR
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
