### PR TITLE
fix: prevent extra keys in agc-project.yaml

### DIFF
--- a/packages/cli/internal/pkg/cli/spec/io_test.go
+++ b/packages/cli/internal/pkg/cli/spec/io_test.go
@@ -244,12 +244,111 @@ contexts:
 `,
 			errMessage: "\n\t1. contexts: Additional property not-default is not allowed\n",
 		},
+		"invalidExtraProperty": {
+			yaml: `---
+name: Demo
+schemaVersion: 1
+contexts:
+    default:
+        engines:
+            - type: wdl
+              engine: cromwell
+extra: true
+`,
+			errMessage: "\n\t1. (root): Additional property extra is not allowed\n",
+		},
+		"invalidExtraContextProperty": {
+			yaml: `---
+name: Demo
+schemaVersion: 1
+contexts:
+    default:
+        extra: foo
+        engines:
+            - type: wdl
+              engine: cromwell
+`,
+			errMessage: "\n\t1. contexts.default: Additional property extra is not allowed\n",
+		},
+		"invalidExtraEngineProperty": {
+			yaml: `---
+name: Demo
+schemaVersion: 1
+contexts:
+    default:
+        engines:
+            - type: wdl
+              engine: cromwell
+              extra: foo
+`,
+			errMessage: "\n\t1. contexts.default.engines.0: Additional property extra is not allowed\n",
+		},
+		"invalidExtraDataProperty": {
+			yaml: `---
+name: Demo
+schemaVersion: 1
+contexts:
+    default:
+        engines:
+            - type: wdl
+              engine: cromwell
+data:
+    - location: s3://some-bucket
+      readOnly: true
+      extra: foo
+`,
+			errMessage: "\n\t1. data.0: Additional property extra is not allowed\n",
+		},
+		"invalidExtraWorkflowProperty": {
+			yaml: `---
+name: Demo
+schemaVersion: 1
+contexts:
+    default:
+        engines:
+            - type: wdl
+              engine: cromwell
+data:
+    - location: s3://some-bucket
+      readOnly: true
+workflows:
+    some-workflow:
+      type:
+        language: wdl
+        version: 1.0
+      sourceURL: ./somewhere
+      extra: foo
+`,
+			errMessage: "\n\t1. workflows.some-workflow: Additional property extra is not allowed\n",
+		},
+		"invalidExtraWorkflowTypeProperty": {
+			yaml: `---
+name: Demo
+schemaVersion: 1
+contexts:
+    default:
+        engines:
+            - type: wdl
+              engine: cromwell
+data:
+    - location: s3://some-bucket
+      readOnly: true
+workflows:
+    some-workflow:
+      type:
+        language: wdl
+        version: 1.0
+        extra: foo
+      sourceURL: ./somewhere
+`,
+			errMessage: "\n\t1. workflows.some-workflow.type: Additional property extra is not allowed\n",
+		},
 	}
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			err := ValidateProject([]byte(tt.yaml))
-			assert.Error(t, err, tt.errMessage)
+			assert.EqualError(t, err, tt.errMessage)
 		})
 	}
 }

--- a/packages/cli/internal/pkg/cli/spec/project_schema.json
+++ b/packages/cli/internal/pkg/cli/spec/project_schema.json
@@ -1,6 +1,7 @@
 {
   "$schema":"http://json-schema.org/draft-04/schema#",
   "type":"object",
+  "additionalProperties": false,
   "properties":{
     "name":{
       "type":"string",
@@ -20,9 +21,11 @@
           "type":[
             "object"
           ],
+          "additionalProperties": false,
           "properties":{
             "type":{
               "type": "object",
+              "additionalProperties": false,
               "properties": {
                 "language": {
                   "type": "string",
@@ -63,6 +66,7 @@
           "type":[
             "object"
           ],
+          "additionalProperties": false,
           "properties":{
             "requestSpotInstances":{
               "type":"boolean"
@@ -89,6 +93,7 @@
               "minItems": 1,
               "items": {
                 "type": "object",
+                "additionalProperties": false,
                 "properties": {
                   "type": {
                     "type": "string",
@@ -116,6 +121,7 @@
       ],
       "items":{
         "type":"object",
+        "additionalProperties": false,
         "properties":{
           "readOnly":{
             "type":"boolean"


### PR DESCRIPTION
<!-- Title format: type(scope): Short description (72 chars max for line) -->
<!-- `(scope)` is optional and `type` is one of: build, ci, chore, docs, feat, fix, perf, refactor, revert, style, test -->
<!-- Available types:
- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit -->

**Description of Changes**

Prevent extra keys or misspelled keys in project yaml files.

**Description of how you validated changes**

* `make`
* In each example project directory `agc project validate`

**Checklist**

- [ ] If this change would make any existing documentation invalid, I have included those updates within this PR
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have linted my code before raising the PR
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
