### PR TITLE
 fix: Correcting MiniWDL output location 

### DIFF
--- a/packages/cdk/lib/constructs/engines/engine.ts
+++ b/packages/cdk/lib/constructs/engines/engine.ts
@@ -4,7 +4,7 @@ import { IVpc } from "monocdk/aws-ec2";
 
 export interface EngineProps {
   readonly vpc: IVpc;
-  readonly outputBucketName: string;
+  readonly rootDirS3Uri: string;
 }
 
 export class Engine extends Construct {

--- a/packages/cdk/lib/constructs/engines/miniwdl/miniwdl-engine.ts
+++ b/packages/cdk/lib/constructs/engines/miniwdl/miniwdl-engine.ts
@@ -22,7 +22,7 @@ export class MiniWdlEngine extends Engine {
   constructor(scope: Construct, id: string, props: MiniWdlEngineProps) {
     super(scope, id);
 
-    const { vpc, outputBucketName, engineBatch, workerBatch } = props;
+    const { vpc, rootDirS3Uri, engineBatch, workerBatch } = props;
     const fileSystem = this.createFileSystem(vpc);
     const accessPoint = this.createAccessPoint(fileSystem);
 
@@ -42,7 +42,7 @@ export class MiniWdlEngine extends Engine {
           MINIWDL__AWS__FS: fileSystem.fileSystemId,
           MINIWDL__AWS__FSAP: accessPoint.accessPointId,
           MINIWDL__AWS__TASK_QUEUE: workerBatch.jobQueue.jobQueueArn,
-          MINIWDL_S3_OUTPUT_URI: `s3://${outputBucketName}/miniwdl`,
+          MINIWDL_S3_OUTPUT_URI: rootDirS3Uri,
         },
         volumes: [this.toVolume(fileSystem, accessPoint)],
         mountPoints: [this.toMountPoint("/mnt/efs")],

--- a/packages/cdk/lib/constructs/engines/nextflow/nextflow-engine.ts
+++ b/packages/cdk/lib/constructs/engines/nextflow/nextflow-engine.ts
@@ -8,7 +8,6 @@ import { Engine, EngineProps } from "../engine";
 export interface NextflowEngineProps extends EngineProps {
   readonly jobQueueArn: string;
   readonly taskRole: IRole;
-  readonly rootDir: string;
 }
 
 const NEXTFLOW_IMAGE_DESIGNATION = "nextflow";
@@ -27,8 +26,8 @@ export class NextflowEngine extends Engine {
         command: [],
         environment: {
           NF_JOB_QUEUE: props.jobQueueArn,
-          NF_WORKDIR: `${props.rootDir}/runs`,
-          NF_LOGSDIR: `${props.rootDir}/logs`,
+          NF_WORKDIR: `${props.rootDirS3Uri}/runs`,
+          NF_LOGSDIR: `${props.rootDirS3Uri}/logs`,
         },
         volumes: [],
       },

--- a/packages/cdk/lib/stacks/nested/miniwdl-engine-stack.ts
+++ b/packages/cdk/lib/stacks/nested/miniwdl-engine-stack.ts
@@ -54,7 +54,7 @@ export class MiniWdlEngineStack extends NestedEngineStack {
 
     this.miniwdlEngine = new MiniWdlEngine(this, "MiniWdlEngine", {
       vpc: props.vpc,
-      outputBucketName: params.outputBucketName,
+      rootDirS3Uri: params.getEngineBucketPath(),
       engineBatch: this.batchHead,
       workerBatch: this.batchWorkers,
     });

--- a/packages/cdk/lib/stacks/nested/miniwdl-engine-stack.ts
+++ b/packages/cdk/lib/stacks/nested/miniwdl-engine-stack.ts
@@ -1,7 +1,7 @@
 import { NestedStackProps } from "monocdk";
 import { Construct } from "constructs";
 import { IRole, PolicyDocument, PolicyStatement, Role, ServicePrincipal, ManagedPolicy } from "monocdk/aws-iam";
-import { Bucket } from "monocdk/aws-s3";
+import { Bucket, IBucket } from "monocdk/aws-s3";
 import { ApiProxy, Batch } from "../../constructs";
 import { EngineOutputs, NestedEngineStack } from "./nested-engine-stack";
 import { ILogGroup } from "monocdk/lib/aws-logs/lib/log-group";
@@ -33,12 +33,14 @@ export class MiniWdlEngineStack extends NestedEngineStack {
   public readonly miniwdlEngine: MiniWdlEngine;
   private readonly batchHead: Batch;
   private readonly batchWorkers: Batch;
+  private readonly outputBucket: IBucket;
 
   constructor(scope: Construct, id: string, props: MiniWdlEngineStackProps) {
     super(scope, id, props);
 
     const { vpc, contextParameters } = props;
     const params = props.contextParameters;
+    const rootDirS3Uri = params.getEngineBucketPath();
 
     this.batchHead = this.renderBatch("HeadBatch", vpc, contextParameters.instanceTypes, ComputeResourceType.FARGATE);
     const workerComputeType = contextParameters.requestSpotInstances ? ComputeResourceType.SPOT : ComputeResourceType.ON_DEMAND;
@@ -54,7 +56,7 @@ export class MiniWdlEngineStack extends NestedEngineStack {
 
     this.miniwdlEngine = new MiniWdlEngine(this, "MiniWdlEngine", {
       vpc: props.vpc,
-      rootDirS3Uri: params.getEngineBucketPath(),
+      rootDirS3Uri: rootDirS3Uri,
       engineBatch: this.batchHead,
       workerBatch: this.batchWorkers,
     });
@@ -74,6 +76,8 @@ export class MiniWdlEngineStack extends NestedEngineStack {
         }),
       },
     });
+    this.outputBucket = Bucket.fromBucketName(this, "OutputBucket", params.outputBucketName);
+    this.outputBucket.grantRead(adapterRole);
 
     this.batchHead.grantJobAdministration(adapterRole);
     this.batchWorkers.grantJobAdministration(this.batchHead.role);
@@ -85,6 +89,7 @@ export class MiniWdlEngineStack extends NestedEngineStack {
       role: adapterRole,
       jobQueueArn: this.batchHead.jobQueue.jobQueueArn,
       jobDefinitionArn: this.miniwdlEngine.headJobDefinition.jobDefinitionArn,
+      rootDirS3Uri: rootDirS3Uri,
     });
     this.adapterLogGroup = lambda.logGroup;
 
@@ -105,13 +110,12 @@ export class MiniWdlEngineStack extends NestedEngineStack {
   }
 
   private grantS3Permissions(contextParameters: ContextAppParameters) {
-    const { artifactBucketName, outputBucketName, readBucketArns = [], readWriteBucketArns = [] } = contextParameters;
+    const { artifactBucketName, readBucketArns = [], readWriteBucketArns = [] } = contextParameters;
 
-    const outputBucket = Bucket.fromBucketName(this, "OutputBucket", outputBucketName);
     const artifactBucket = Bucket.fromBucketName(this, "ArtifactBucket", artifactBucketName);
 
     readBucketArns.push(artifactBucket.bucketArn);
-    readWriteBucketArns.push(outputBucket.bucketArn);
+    readWriteBucketArns.push(this.outputBucket.bucketArn);
 
     const batchRoles = this.getBatchRoles();
     for (const role of batchRoles) {
@@ -135,11 +139,12 @@ export class MiniWdlEngineStack extends NestedEngineStack {
     return [this.batchHead.role, this.batchWorkers.role];
   }
 
-  private renderAdapterLambda({ vpc, role, jobQueueArn, jobDefinitionArn }) {
+  private renderAdapterLambda({ vpc, role, jobQueueArn, jobDefinitionArn, rootDirS3Uri }) {
     return renderPythonLambda(this, "MiniWDLWesAdapterLambda", vpc, role, wesAdapterSourcePath, {
       ENGINE_NAME: "miniwdl",
       JOB_QUEUE: jobQueueArn,
       JOB_DEFINITION: jobDefinitionArn,
+      OUTPUT_DIR_S3_URI: rootDirS3Uri,
     });
   }
 }

--- a/packages/cdk/lib/stacks/nested/nextflow-engine-stack.ts
+++ b/packages/cdk/lib/stacks/nested/nextflow-engine-stack.ts
@@ -40,9 +40,8 @@ export class NextflowEngineStack extends NestedEngineStack {
 
     this.nextflowEngine = new NextflowEngine(this, "NextflowEngine", {
       vpc: props.vpc,
-      outputBucketName: params.outputBucketName,
       jobQueueArn: props.jobQueue.jobQueueArn,
-      rootDir: params.getEngineBucketPath(),
+      rootDirS3Uri: params.getEngineBucketPath(),
       taskRole: engineRole,
     });
 

--- a/packages/cdk/lib/wes_adapter/requirements.txt
+++ b/packages/cdk/lib/wes_adapter/requirements.txt
@@ -1,5 +1,5 @@
 boto3
-boto3-stubs[batch,logs,resourcegroupstaggingapi]
+boto3-stubs[batch,logs,resourcegroupstaggingapi,s3]
 connexion
 docker
 flask

--- a/packages/cdk/lib/wes_adapter/rest_api/controllers/workflow_execution_service_controller.py
+++ b/packages/cdk/lib/wes_adapter/rest_api/controllers/workflow_execution_service_controller.py
@@ -25,6 +25,7 @@ ENGINE_NAME = os.getenv("ENGINE_NAME")
 JOB_QUEUE = os.getenv("JOB_QUEUE")
 JOB_DEFINITION = os.getenv("JOB_DEFINITION")
 ENGINE_LOG_GROUP = os.getenv("ENGINE_LOG_GROUP")
+OUTPUT_DIR_S3_URI = os.getenv("OUTPUT_DIR_S3_URI")
 
 if ENGINE_NAME == "nextflow":
     print("Using Nextflow adapter")
@@ -42,6 +43,7 @@ elif ENGINE_NAME == "miniwdl":
     adapter = MiniWdlWESAdapter(
         job_queue=JOB_QUEUE,
         job_definition=JOB_DEFINITION,
+        output_dir_s3_uri=OUTPUT_DIR_S3_URI,
     )
 else:
     raise Exception(f"Unknown engine name `{ENGINE_NAME}`")


### PR DESCRIPTION
Issue #, if available: https://github.com/aws/amazon-genomics-cli/issues/169, https://github.com/aws/amazon-genomics-cli/issues/170

**Description of Changes**

Previously the MiniWDL S3 output location was set to a custom S3
path in the AGC Output bucket. This does not follow the same
convention as the other two engines. This commit replaces that
custom path with the standard project/user/context prefix.

Also implements fetching from this path within the WES adapter so `workflow output` works.

**Description of how you validated changes**

ran workflow, validated that outputs are the same between cromwell and miniwdl

$ agc workflow status
2021-11-12T23:07:43Z 𝒊  Showing workflow run(s). Max Runs: 20
WORKFLOWINSTANCE	miniContext	559ba5b9-f4a7-4069-8a3a-f2965521015d	true	COMPLETE	2021-11-12T22:41:17Z	hello
WORKFLOWINSTANCE	myContext	cc05f098-ff12-482d-90a0-711a5b577dfc	true	COMPLETE	2021-11-12T21:28:02Z	hello


$ agc workflow output 559ba5b9-f4a7-4069-8a3a-f2965521015d
2021-11-12T23:08:43Z 𝒊  Obtaining final outputs for workflow runId '559ba5b9-f4a7-4069-8a3a-f2965521015d'
OUTPUT	id	559ba5b9-f4a7-4069-8a3a-f2965521015d
OUTPUT	outputs.hello_agc.hello.out	Hello Amazon Genomics CLI!
$ agc workflow output cc05f098-ff12-482d-90a0-711a5b577dfc
2021-11-12T23:08:57Z 𝒊  Obtaining final outputs for workflow runId 'cc05f098-ff12-482d-90a0-711a5b577dfc'
OUTPUT	id	cc05f098-ff12-482d-90a0-711a5b577dfc
OUTPUT	outputs.hello_agc.hello.out	Hello Amazon Genomics CLI!


**Checklist**

- [x] If this change would make any existing documentation invalid, I have included those updates within this PR
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have linted my code before raising the PR
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
