### PR TITLE
fix: Return timezone information in RunLog

### DIFF
--- a/packages/cdk/lib/wes_adapter/amazon_genomics/tests/test_BatchAdapter.py
+++ b/packages/cdk/lib/wes_adapter/amazon_genomics/tests/test_BatchAdapter.py
@@ -196,7 +196,7 @@ def test_get_run_log_in_progress(aws_batch: BatchClient, adapter: StubBatchAdapt
                 name="agc-run-workflow|xyz",
                 cmd=test_command,
                 stdout=log_stream,
-                start_time="1970-01-01T00:00:01",
+                start_time="1970-01-01T00:00:01+00:00",
             ),
             task_logs=[
                 Log(
@@ -231,8 +231,8 @@ def test_get_run_log_completed(aws_batch: BatchClient, adapter: StubBatchAdapter
                 name="agc-run-workflow|xyz",
                 cmd=test_command,
                 stdout=log_stream,
-                start_time="1970-01-01T00:00:01",
-                end_time="1970-01-01T00:00:02",
+                start_time="1970-01-01T00:00:01+00:00",
+                end_time="1970-01-01T00:00:02+00:00",
             ),
             task_logs=[
                 Log(

--- a/packages/cdk/lib/wes_adapter/amazon_genomics/wes/adapters/BatchAdapter.py
+++ b/packages/cdk/lib/wes_adapter/amazon_genomics/wes/adapters/BatchAdapter.py
@@ -244,4 +244,4 @@ class BatchAdapter(AbstractWESAdapter):
 def to_iso(epoch: Optional[int]) -> Optional[str]:
     if not epoch:
         return None
-    return datetime.utcfromtimestamp(epoch / 1000.0).isoformat()
+    return datetime.utcfromtimestamp(epoch / 1000.0).astimezone().isoformat()


### PR DESCRIPTION
Issue #, if available:

**Description of Changes**

Currently the CLI and WES adapter are using different ISO time formats.
The CLI expects a timezone, and the Batch WES adapter is not returning one.
This commit adds timezone information to the returned timestamps so the CLI
can parse them.

**Description of how you validated changes**

Workflow logs command now parses the timestamps appropriately.

Old
```
$ agc logs workflow hello-3 -r 140ce218-aa39-478f-8b4e-0696dbf386a1 -v
2021-11-12T23:53:30Z ↓  Checking AGC version...
2021-11-12T23:53:30Z 𝒊  Showing the logs for 'hello-3'
2021-11-12T23:53:30Z ↓  Showing logs for workflow run '140ce218-aa39-478f-8b4e-0696dbf386a1'
2021-11-12T23:53:30Z ↓  GetRunLog '140ce218-aa39-478f-8b4e-0696dbf386a1'
2021-11-12T23:53:30Z ↓  EstablishWesConnection(https://c7o36wty80.execute-api.us-west-2.amazonaws.com/prod/ga4gh/wes/v1)
2021-11-12T23:53:30Z ↓  Ping WES endpoint until we get an answer:
2021-11-12T23:53:30Z ↓  Attempt 1 of 3
2021-11-12T23:53:30Z ↓  Connected to WES endpoint
2021-11-12T23:53:30Z ↓  getRunLog '140ce218-aa39-478f-8b4e-0696dbf386a1'
2021-11-12T23:53:31Z ↓  Unable to parse log time '2021-11-12T23:52:31.844000' to ISO 8601, skipping
2021-11-12T23:53:31Z ↓  Unable to parse log time '2021-11-12T23:52:32.021000' to ISO 8601, skipping
RunId: 140ce218-aa39-478f-8b4e-0696dbf386a1
State: COMPLETE
Tasks:
	Name		JobId					StartTime			StopTime			ExitCode
	hello-zrseaye7	c1d3ade0-2cea-47ce-8f5f-085998ce18a7	0001-01-01 00:00:00 +0000 UTC	0001-01-01 00:00:00 +0000 UTC	0
```

New:

```
$ agc logs workflow hello-3 -r 140ce218-aa39-478f-8b4e-0696dbf386a1 -v
2021-11-13T00:10:43Z ↓  Checking AGC version...
2021-11-13T00:10:43Z 𝒊  Showing the logs for 'hello-3'
2021-11-13T00:10:43Z ↓  Showing logs for workflow run '140ce218-aa39-478f-8b4e-0696dbf386a1'
2021-11-13T00:10:43Z ↓  GetRunLog '140ce218-aa39-478f-8b4e-0696dbf386a1'
2021-11-13T00:10:43Z ↓  EstablishWesConnection(https://c7o36wty80.execute-api.us-west-2.amazonaws.com/prod/ga4gh/wes/v1)
2021-11-13T00:10:43Z ↓  Ping WES endpoint until we get an answer:
2021-11-13T00:10:43Z ↓  Attempt 1 of 3
2021-11-13T00:10:43Z ↓  Connected to WES endpoint
2021-11-13T00:10:43Z ↓  getRunLog '140ce218-aa39-478f-8b4e-0696dbf386a1'
RunId: 140ce218-aa39-478f-8b4e-0696dbf386a1
State: COMPLETE
Tasks:
	Name		JobId					StartTime			StopTime			ExitCode
	hello-zrseaye7	c1d3ade0-2cea-47ce-8f5f-085998ce18a7	2021-11-12 23:52:31 +0000 UTC	2021-11-12 23:52:32 +0000 UTC	0
```

**Checklist**

- [x] If this change would make any existing documentation invalid, I have included those updates within this PR
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have linted my code before raising the PR
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
