### PR TITLE
docs: Use brew --prefix over /usr/local

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ need to use a newer version of sed to ensure script compatibility.
 
 ```bash
 brew install gnu-sed
-echo 'export PATH="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH"' >> ~/.bashrc
+echo 'export PATH="$(brew --prefix gnu-sed)/libexec/gnubin:$PATH"' >> ~/.bashrc
 source ~/.bashrc
 ```
 


### PR DESCRIPTION
Brew prefix may not necessarily be set to `/usr/local/`

<!-- Title format: docs(scope): Short description (72 chars max for line) -->
<!-- `(scope)` is optional and `type` is one of: build, ci, chore, docs, feat, fix, perf, refactor, revert, style, test -->
<!-- Available types:
- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit -->

Issue #, if available:

**Description of Changes**

[//]: #  (A description of the change that you made and the new user experience that it creates)

Move from MacOS suggestion of prepending `"/usr/local/opt/gnu-sed/libexec/gnubin"` to `PATH` env var to instead - `"$(brew --prefix gnu-sed)/libexec/gnubin"`


**Description of how you validated changes**

[//]: #  (A description of you validated your changes and any relevant logs that show your change works)
```
ls "$(brew --prefix gnu-sed)/libexec/gnubin"
sed
```

**Checklist**

- [x] If this change would make any existing documentation invalid, I have included those updates within this PR
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have linted my code before raising the PR
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
