### PR TITLE
fix: Increasing WES adapter lambda timeout

### DIFF
--- a/packages/cdk/lib/util/index.ts
+++ b/packages/cdk/lib/util/index.ts
@@ -124,6 +124,6 @@ export const renderPythonLambda = (
     runtime: Runtime.PYTHON_3_9,
     environment,
     role,
-    timeout: Duration.seconds(30),
+    timeout: Duration.seconds(60),
   });
 };


### PR DESCRIPTION
<!-- Title format: type(scope): Short description (72 chars max for line) -->
<!-- `(scope)` is optional and `type` is one of: build, ci, chore, docs, feat, fix, perf, refactor, revert, style, test -->
<!-- Available types:
- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit -->

Issue #, if available:

**Description of Changes**

We're currently seeing timeouts in our integration tests when calling
the Cromwell WES adapter. It seems like cold start and initializing the
connection to Cromwell on the first invocation can take longer than 30 seconds

**Description of how you validated changes**


**Checklist**

- [x] If this change would make any existing documentation invalid, I have included those updates within this PR
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have linted my code before raising the PR
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
