### PR TITLE
fix: Increasing WES adapter lambda timeout (#180)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file. See [standa
 * progress bar doesn't show any progress ([#166](https://github.com/aws/amazon-genomics-cli/issues/166)) ([5b4a5b4](https://github.com/aws/amazon-genomics-cli/commit/5b4a5b4c81cf4ef99d82a146b378c66936ff7be4))
 * Return timezone information in RunLog ([#174](https://github.com/aws/amazon-genomics-cli/issues/174)) ([37b33a7](https://github.com/aws/amazon-genomics-cli/commit/37b33a753d96010a581588c8734d482163ad1161))
 * unique project name ([#171](https://github.com/aws/amazon-genomics-cli/issues/171)) ([a464f81](https://github.com/aws/amazon-genomics-cli/commit/a464f81d86575f1f3c0c95b1161f0474681537ac))
+* Increasing WES adapter lambda timeout ([#180](https://github.com/aws/amazon-genomics-cli/issues/180)) ([20cd77d](https://github.com/aws/amazon-genomics-cli/commit/20cd77dac1def4414f0159509caa8dfe853d62bb))
 
 ## 1.1.0 (2021-11-11)
 

--- a/packages/cdk/lib/util/index.ts
+++ b/packages/cdk/lib/util/index.ts
@@ -124,6 +124,6 @@ export const renderPythonLambda = (
     runtime: Runtime.PYTHON_3_9,
     environment,
     role,
-    timeout: Duration.seconds(30),
+    timeout: Duration.seconds(60),
   });
 };


### PR DESCRIPTION
We're currently seeing timeouts in our integration tests when calling
the Cromwell WES adapter. It seems like cold start and initializing the
connection to Cromwell on the first invocation can take longer than 30 seconds

<!-- Title format: type(scope): Short description (72 chars max for line) -->
<!-- `(scope)` is optional and `type` is one of: build, ci, chore, docs, feat, fix, perf, refactor, revert, style, test -->
<!-- Available types:
- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit -->

Issue #, if available:

**Description of Changes**

[//]: #  (A description of the change that you made and the new user experience that it creates)

**Description of how you validated changes**

[//]: #  (A description of you validated your changes and any relevant logs that show your change works)


**Checklist**

- [ ] If this change would make any existing documentation invalid, I have included those updates within this PR
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have linted my code before raising the PR
- [ ] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
