### PR TITLE
fix: fixing monocdk imports

### DIFF
--- a/packages/cdk/lib/stacks/core-stack.ts
+++ b/packages/cdk/lib/stacks/core-stack.ts
@@ -1,11 +1,10 @@
 import { CfnOutput, RemovalPolicy, Stack, StackProps } from "monocdk";
 import { AttributeType, BillingMode, ITable, ProjectionType, Table } from "monocdk/aws-dynamodb";
-import { StringParameter } from "monocdk/aws-ssm";
+import { StringParameter, IParameter } from "monocdk/aws-ssm";
 import { GatewayVpcEndpointAwsService, InterfaceVpcEndpointService, IVpc, Vpc } from "monocdk/aws-ec2";
 import { Bucket, BucketEncryption, IBucket } from "monocdk/aws-s3";
 import { Construct } from "constructs";
 import { PRODUCT_NAME, APP_NAME, VPC_PARAMETER_NAME } from "../constants";
-import { IParameter } from "monocdk/lib/aws-ssm/lib/parameter";
 
 export interface ParameterProps {
   /**

--- a/packages/cdk/lib/stacks/engines/cromwell-engine-construct.ts
+++ b/packages/cdk/lib/stacks/engines/cromwell-engine-construct.ts
@@ -8,8 +8,7 @@ import { createEcrImage, renderPythonLambda, renderServiceWithTaskDefinition } f
 import { Bucket } from "monocdk/aws-s3";
 import { FileSystem } from "monocdk/aws-efs";
 import { EngineOptions, ServiceContainer } from "../../types";
-import { ILogGroup } from "monocdk/lib/aws-logs/lib/log-group";
-import { LogGroup } from "monocdk/aws-logs";
+import { LogGroup, ILogGroup } from "monocdk/aws-logs";
 import { EngineOutputs, EngineConstruct } from "./engine-construct";
 import { CromwellEngineRole } from "../../roles/cromwell-engine-role";
 import { CromwellAdapterRole } from "../../roles/cromwell-adapter-role";

--- a/packages/cdk/lib/stacks/engines/engine-construct.ts
+++ b/packages/cdk/lib/stacks/engines/engine-construct.ts
@@ -1,5 +1,5 @@
 import { CfnOutput, Stack, Construct } from "monocdk";
-import { ILogGroup } from "monocdk/lib/aws-logs/lib/log-group";
+import { ILogGroup } from "monocdk/aws-logs";
 
 export interface EngineOutputs {
   accessLogGroup: ILogGroup;

--- a/packages/cdk/lib/stacks/engines/miniwdl-engine-construct.ts
+++ b/packages/cdk/lib/stacks/engines/miniwdl-engine-construct.ts
@@ -3,7 +3,7 @@ import { Bucket, IBucket } from "monocdk/aws-s3";
 import { ApiProxy, Batch } from "../../constructs";
 import { EngineOutputs, EngineConstruct } from "./engine-construct";
 import { IRole, PolicyDocument, PolicyStatement, Role, ServicePrincipal, ManagedPolicy } from "monocdk/aws-iam";
-import { ILogGroup } from "monocdk/lib/aws-logs/lib/log-group";
+import { ILogGroup } from "monocdk/aws-logs";
 import { MiniWdlEngine } from "../../constructs/engines/miniwdl/miniwdl-engine";
 import { InstanceType, IVpc } from "monocdk/aws-ec2";
 import { LAUNCH_TEMPLATE } from "../../constants";

--- a/packages/cdk/lib/stacks/engines/nextflow-engine-construct.ts
+++ b/packages/cdk/lib/stacks/engines/nextflow-engine-construct.ts
@@ -5,7 +5,7 @@ import { EngineOptions } from "../../types";
 import { Bucket } from "monocdk/aws-s3";
 import { ApiProxy } from "../../constructs";
 import { EngineOutputs, EngineConstruct } from "./engine-construct";
-import { ILogGroup } from "monocdk/lib/aws-logs/lib/log-group";
+import { ILogGroup } from "monocdk/aws-logs";
 import { IJobQueue } from "monocdk/aws-batch";
 import { NextflowEngineRole } from "../../roles/nextflow-engine-role";
 import { NextflowAdapterRole } from "../../roles/nextflow-adapter-role";

--- a/packages/cdk/lib/util/index.ts
+++ b/packages/cdk/lib/util/index.ts
@@ -9,7 +9,7 @@ import { Protocol } from "monocdk/aws-elasticloadbalancingv2";
 import { IVpc } from "monocdk/aws-ec2";
 import { IRole } from "monocdk/aws-iam";
 import { LogConfiguration, LogDriver as BatchLogDriver } from "monocdk/aws-batch";
-import { ILogGroup } from "monocdk/lib/aws-logs/lib/log-group";
+import { ILogGroup } from "monocdk/aws-logs";
 import { PythonFunction } from "monocdk/aws-lambda-python";
 import { Runtime } from "monocdk/aws-lambda";
 import { Duration } from "monocdk";


### PR DESCRIPTION
fix: fixing monocdk imports

**Description of Changes**

[//]: #  one of the recent monocdk npm packages have restructured the file tree inside the package, changing the import calls from our code to be agnostic of that change.

**Description of how you validated changes**

[//]: #  Ran `npm run build` to verify the new import calls are working fine


**Checklist**

- [ ] If this change would make any existing documentation invalid, I have included those updates within this PR
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have linted my code before raising the PR
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
