### PR TITLE
fix: returning default config with initial email config

### DIFF
--- a/packages/cli/internal/pkg/cli/config/config_client.go
+++ b/packages/cli/internal/pkg/cli/config/config_client.go
@@ -76,7 +76,7 @@ func (c Client) Read() (Config, error) {
 func (c Client) loadFromFile() (Config, error) {
 	configData, err := fromYaml(c.configFilePath)
 	if err != nil {
-		return Config{}, err
+		return configData, err
 	}
 	configData.User.Id = userIdFromEmailAddress(configData.User.Email)
 	return configData, nil


### PR DESCRIPTION
<!-- Title format: type(scope): Short description (72 chars max for line) -->
<!-- `(scope)` is optional and `type` is one of: build, ci, chore, docs, feat, fix, perf, refactor, revert, style, test -->
<!-- Available types:
- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit -->

Issue #, if available:

**Description of Changes**
Bug when email is initially configured using `agc email configure`. The format was not initialized properly causing an error on every agc command



```
$ agc configure email test@amazon.com
2021-11-30T09:48:38-08:00 𝒊  Setting user email address to: 'test@amazon.com'
$ agc configure email test@amazon.com
2021-11-30T09:49:10-08:00 𝒊  Setting user email address to: 'test@amazon.com'

```
config file 
```
user:
    email: test@amazon.com
format:
    name: ""
```
```
$ agc context list
invalid format type. Valid format types are 'text' and 'table'
2021-11-30T09:49:20-08:00 𝒊  Listing contexts.
CONTEXTSUMMARY	cromwell	ctx1
$ agc configure describe
invalid format type. Valid format types are 'text' and 'table'
2021-11-30T09:49:32-08:00 𝒊  Reading user specific configuration
CONFIG
FORMAT
USER	test@amazon.com	test3HYhj7
```

[//]: #  (A description of the change that you made and the new user experience that it creates)

**Description of how you validated changes**

Validates fix by running the same command

```
$ agc configure email test@amazon.com
2021-11-30T09:53:27-08:00 𝒊  Setting user email address to: 'test@amazon.com'
$ agc context list
2021-11-30T09:53:38-08:00 𝒊  Listing contexts.
CONTEXTSUMMARY	cromwell	ctx1
```
config file
```
user:
    email: test@amazon.com
format:
    name: text
```

**Checklist**

- [x] If this change would make any existing documentation invalid, I have included those updates within this PR
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have linted my code before raising the PR
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
