### PR TITLE
fix: fixed arg validation for format

### DIFF
--- a/packages/cli/internal/pkg/cli/configure_format.go
+++ b/packages/cli/internal/pkg/cli/configure_format.go
@@ -30,8 +30,8 @@ func newFormatContextOpts(vars formatContextVars) (*formatContextOpts, error) {
 	}, nil
 }
 
-func (o *formatContextOpts) Validate() error {
-	if o.formatContextVars.format == "" {
+func (o *formatContextOpts) Validate(args []string) error {
+	if len(args) == 0 {
 		return fmt.Errorf("format value must be provided")
 	}
 	format := format.FormatterType(o.formatContextVars.format)
@@ -61,7 +61,7 @@ func BuildConfigureFormatCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if err := opts.Validate(); err != nil {
+			if err := opts.Validate(args); err != nil {
 				return err
 			}
 			configClient, err := config.NewConfigClient()

--- a/packages/cli/internal/pkg/cli/configure_format.go
+++ b/packages/cli/internal/pkg/cli/configure_format.go
@@ -31,8 +31,8 @@ func newFormatContextOpts(vars formatContextVars) (*formatContextOpts, error) {
 }
 
 func (o *formatContextOpts) Validate(args []string) error {
-	if len(args) == 0 {
-		return fmt.Errorf("format value must be provided")
+	if len(args) != 1 {
+		return fmt.Errorf("a single format value must be provided")
 	}
 	format := format.FormatterType(o.formatContextVars.format)
 	if err := format.ValidateFormatter(); err != nil {

--- a/packages/cli/internal/pkg/cli/configure_format.go
+++ b/packages/cli/internal/pkg/cli/configure_format.go
@@ -56,7 +56,6 @@ func BuildConfigureFormatCommand() *cobra.Command {
 		Short: "Sets default format option for output display of AGC commands. Valid format options are 'text' and 'table'",
 		Args:  cobra.ArbitraryArgs,
 		RunE: runCmdE(func(cmd *cobra.Command, args []string) error {
-			vars.format = args[0]
 			opts, err := newFormatContextOpts(vars)
 			if err != nil {
 				return err
@@ -64,6 +63,7 @@ func BuildConfigureFormatCommand() *cobra.Command {
 			if err := opts.Validate(args); err != nil {
 				return err
 			}
+			vars.format = args[0]
 			configClient, err := config.NewConfigClient()
 			if err != nil {
 				return clierror.New(configureFormatCommand, vars, err)

--- a/packages/cli/internal/pkg/cli/configure_format_test.go
+++ b/packages/cli/internal/pkg/cli/configure_format_test.go
@@ -36,7 +36,7 @@ func TestFormatContextOpts_Validate_InvalidFormat(t *testing.T) {
 	require.NoError(t, err)
 
 	formatContextOpts.configClient = mocks.configMock
-	err = formatContextOpts.Validate()
+	err = formatContextOpts.Validate([]string{invalidFormat})
 	require.Error(t, err)
 }
 
@@ -50,6 +50,6 @@ func TestFormatContextOpts_Validate_ValidFormat(t *testing.T) {
 	require.NoError(t, err)
 
 	formatContextOpts.configClient = mocks.configMock
-	err = formatContextOpts.Validate()
+	err = formatContextOpts.Validate([]string{textFormat})
 	require.NoError(t, err)
 }


### PR DESCRIPTION
<!-- Title format: type(scope): Short description (72 chars max for line) -->
<!-- `(scope)` is optional and `type` is one of: build, ci, chore, docs, feat, fix, perf, refactor, revert, style, test -->
<!-- Available types:
- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit -->

Issue #, if available:

**Description of Changes**
Argument checks for `agc configure format` was not handled gracefully. This caused stack error to output into the console.
```
$ agc configure format
panic: runtime error: index out of range [0] with length 0
```

[//]: #  (A description of the change that you made and the new user experience that it creates)

**Description of how you validated changes**
```
$ agc configure format
Error: format value must be provided
```
[//]: #  (A description of you validated your changes and any relevant logs that show your change works)


**Checklist**

- [x] If this change would make any existing documentation invalid, I have included those updates within this PR
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have linted my code before raising the PR
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
