### PR TITLE
docs: Publish on release branch

### DIFF
--- a/.github/workflows/github-pages.yaml
+++ b/.github/workflows/github-pages.yaml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Deploy To Pages
         uses: peaceiris/actions-gh-pages@v3           # see https://github.com/peaceiris/actions-gh-pages for details
-        if: ${{ github.ref == 'refs/heads/main' }}    # set to 'refs/heads/main' to only deploy when the branch is main
+        if: ${{ github.ref == 'refs/heads/release' }} # set to 'refs/heads/release' to only deploy when the branch is release
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages                    # set to 'gh-pages to publish to github pages'


### PR DESCRIPTION
This needs to be merged into the release branch. At the moment, if we build from release, it's looking for main and if we build from main, it's looking for release, so no docs can be generated.

Since this is a docs-only change, I don't plan on making a new release.