### PR TITLE
fix: Respect maxVCpus in miniwdl contexts

### DIFF
--- a/packages/cdk/lib/stacks/engines/miniwdl-engine-construct.ts
+++ b/packages/cdk/lib/stacks/engines/miniwdl-engine-construct.ts
@@ -31,9 +31,9 @@ export class MiniwdlEngineConstruct extends EngineConstruct {
     const params = props.contextParameters;
     const rootDirS3Uri = params.getEngineBucketPath();
 
-    this.batchHead = this.renderBatch("HeadBatch", vpc, contextParameters.instanceTypes, ComputeResourceType.FARGATE);
+    this.batchHead = this.renderBatch("HeadBatch", vpc, contextParameters, ComputeResourceType.FARGATE);
     const workerComputeType = contextParameters.requestSpotInstances ? ComputeResourceType.SPOT : ComputeResourceType.ON_DEMAND;
-    this.batchWorkers = this.renderBatch("TaskBatch", vpc, contextParameters.instanceTypes, workerComputeType);
+    this.batchWorkers = this.renderBatch("TaskBatch", vpc, contextParameters, workerComputeType);
 
     this.batchHead.role.attachInlinePolicy(new HeadJobBatchPolicy(this, "HeadJobBatchPolicy"));
     this.batchHead.role.addToPrincipalPolicy(
@@ -113,11 +113,12 @@ export class MiniwdlEngineConstruct extends EngineConstruct {
     }
   }
 
-  private renderBatch(id: string, vpc: IVpc, instanceTypes?: InstanceType[], computeType?: ComputeResourceType): Batch {
+  private renderBatch(id: string, vpc: IVpc, appParams: ContextAppParameters, computeType?: ComputeResourceType): Batch {
     return new Batch(this, id, {
       vpc,
-      instanceTypes,
       computeType,
+      instanceTypes: appParams.instanceTypes,
+      maxVCpus: appParams.maxVCpus,
       launchTemplateData: LAUNCH_TEMPLATE,
       awsPolicyNames: ["AmazonSSMManagedInstanceCore", "CloudWatchAgentServerPolicy"],
       resourceTags: Stack.of(this).tags.tagValues(),

--- a/packages/cdk/lib/stacks/engines/miniwdl-engine-construct.ts
+++ b/packages/cdk/lib/stacks/engines/miniwdl-engine-construct.ts
@@ -5,7 +5,7 @@ import { EngineOutputs, EngineConstruct } from "./engine-construct";
 import { IRole, PolicyDocument, PolicyStatement, Role, ServicePrincipal, ManagedPolicy } from "monocdk/aws-iam";
 import { ILogGroup } from "monocdk/aws-logs";
 import { MiniWdlEngine } from "../../constructs/engines/miniwdl/miniwdl-engine";
-import { InstanceType, IVpc } from "monocdk/aws-ec2";
+import { IVpc } from "monocdk/aws-ec2";
 import { LAUNCH_TEMPLATE } from "../../constants";
 import { ComputeResourceType } from "monocdk/aws-batch";
 import { BucketOperations } from "../../../common/BucketOperations";


### PR DESCRIPTION
We currently don't set the maxVCpus from the contextParameters when
creating MiniWDL Batch resources. This commit ensures that we do.
This is possible because the code instantiating these resources is
duplicated. A refactor to remove this duplication will be done in a
subsequent commit, so as not to pollute the patch release.

fixes #184 

**Description of how you validated changes**

Deployed context with maxVcpu set, the value is now respected.

**Checklist**

- [x] If this change would make any existing documentation invalid, I have included those updates within this PR
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have linted my code before raising the PR
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
