### PR TITLE
fix: Using fixed java version for nextflow

### DIFF
--- a/packages/engines/nextflow/Dockerfile
+++ b/packages/engines/nextflow/Dockerfile
@@ -12,7 +12,7 @@ RUN yum update -y \
   && yum install -y \
   curl \
   hostname \
-  java \
+  "java-11-amazon-corretto-headless(x86-64)" \
   unzip \
   jq \
   && yum clean -y all


### PR DESCRIPTION
<!-- Title format: type(scope): Short description (72 chars max for line) -->
<!-- `(scope)` is optional and `type` is one of: build, ci, chore, docs, feat, fix, perf, refactor, revert, style, test -->
<!-- Available types:
- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit -->

Issue #, if available:

**Description of Changes**

Using a fixed version of java, since the latest one by default is now 17 which doesn't work for us here. I'm fixing it to the last known version that has worked

**Description of how you validated changes**

Iv'e rebuilt the image both locally and on the pipeline in my aws account, all worked.


**Checklist**

- [ ] If this change would make any existing documentation invalid, I have included those updates within this PR
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have linted my code before raising the PR
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
