### PR TITLE
docs: improve manifest and source url docs (#214)

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -1,5 +1,5 @@
 publishDir = "../docs"
-baseURL = "/amazon-genomics-cli"
+baseURL = "https://aws.github.io/amazon-genomics-cli/"
 title = "Amazon Genomics CLI"
 
 enableRobotsTXT = true

--- a/site/content/en/docs/Concepts/engines.md
+++ b/site/content/en/docs/Concepts/engines.md
@@ -15,13 +15,25 @@ to Amazon Genomics CLI through which it will submit workflows and workflow comma
 
 Currently, Amazon Genomics CLI's officially supported engines can be used to run the following workflows:
 
-| Engine | Language | Language Versions |
-----------|---------|-------------------|
-| [Cromwell](https://cromwell.readthedocs.io/en/stable/) | [WDL](https://openwdl.org) | All versions up to 1.0 |
-| [Nextflow](https://www.nextflow.io) | [Nextflow DSL](https://www.nextflow.io/docs/latest/script.html) | Standard and DSL 2 |
+| Engine                                                 | Language                                                        | Language Versions                                                                                                       | Run Mode     |
+|--------------------------------------------------------|-----------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------|--------------|
+| [Cromwell](https://cromwell.readthedocs.io/en/stable/) | [WDL](https://openwdl.org)                                      | All versions up to 1.0                                                                                                  | Server       |
+| [Nextflow](https://www.nextflow.io)                    | [Nextflow DSL](https://www.nextflow.io/docs/latest/script.html) | Standard and DSL 2                                                                                                      | Head Process |
+| [miniwdl](https://miniwdl.readthedocs.io/en/latest/)   | [WDL](https://openwdl.org)                                      | [documented here](https://miniwdl.readthedocs.io/en/latest/runner_reference.html?highlight=errata#wdl-interoperability) | Head Process |
 
 Overtime we plan to add additional engine and language support and provide the ability for third party developers to 
 develop engine plugins.
+
+### Run Mode
+
+#### Server
+
+In server mode the engine runs as a long-running process that exists for the lifetime of the context. All workflow instances sent to the context are handled by that server. The server resides on on-demand instances to prevent Spot interruption even if the workflow tasks are run on Spot instances
+
+#### Head Process
+
+Head process engines are run when a workflow is submitted, manage a single workflow and only run for the lifetime of the workflow. If multiple workflows are submitted to a context in parallel then multiple head processes are spawned. The head processes always run on on-demand resources to prevent Spot interruption even if the workflow tasks are run on Spot instances. 
+
 
 ## Engine Definition
 

--- a/site/content/en/docs/Concepts/workflows.md
+++ b/site/content/en/docs/Concepts/workflows.md
@@ -6,15 +6,14 @@ weight: 40
 description: >
     A Workflow is a series of steps or tasks to be executed as part of an analysis.
 ---
-
 A Workflow is a series of steps or tasks to be executed as part of an analysis. To run a workflow using Amazon Genomics CLI, first you must
 have deployed a context with suitable compute resources and with a workflow engine that can interpret the language of
 the workflow.
 
 ## Specification in Project YAML
 
-In an Amazon Genomics CLI project you can specify multiple workflows in a YAML map. The following example defines four WDL version 1.0 
-workflows. The `sourceURL` property defines the location of the workflow file. If the location is relative then the 
+In an Amazon Genomics CLI project you can specify multiple workflows in a YAML map. The following example defines four WDL version 1.0
+workflows. The `sourceURL` property defines the location of the workflow file. If the location is relative then the
 relevant file is assumed to be relative to the location of the project YAML file. Absolute file locations are also possible
 although this may reduce the portability of a project if it is intended to be shared. Web URLS are supported as locations
 of the workflow definition file.
@@ -52,22 +51,23 @@ workflows:
 ### Multi-file Workflows
 
 Some workflow languages allow for the import of other workflows. To accommodate this, Amazon Genomics CLI supports using a directory as
-a source URL. When a directory is supplied as the `sourceURL`, Amazon Genomics CLI uses the following rules to determine the name of 
+a source URL. When a directory is supplied as the `sourceURL`, Amazon Genomics CLI uses the following rules to determine the name of
 the main workflow file and any supporting files:
 
 1. If the source URL resolves to a single non-zipped file, then the file is assumed to be a workflow file. Dependent resources (if any) are hardcoded in the file and must be resolvable by the Wes adapter or implicitly the workflow engine (e.g the Wes adapter figures out if the engine can resolve them and if not it resolves them itself).
 2. The source URL resolves to a zipped file (`.zip`).  The zip may contain a manifest.
-    1. If the zip file does *not* contain a file named `MANIFEST.json`:
-        1. The zip file must contain one workflow file with the prefix main followed by the conventional suffix for the workflow, e.g. `main.wdl`
-        2. Any subworkflows or tasks referenced by the main workflow must either be in the zip at the appropriate relative path or they must be referenced by URLs that are resolvable by the workflow engine. The WesAdapter may attempt to resolve them for the engine but this is a convenience and not required.
-        3. Any variables not defined in the workflows must be provided in an inputs file named with the prefix inputs and the conventional suffix for the workflow engine (e.g `inputs.json`). For workflow engines that support multiple input files an index suffix must be provided (e.g. inputs_a.json or inputs_1.json) if there is more than one inputs file.
-        4. A workflow options file may be included and must be named with the options prefix followed by the conventional suffix of the workflow. The WesAdapter may chose to make use of this depending on the context of the workflow engine. It may also choose to pass this to the workflow engine or pass a modified copy to the workflow engine.
-    2. If the zip file *does* contain a manifest:
-        1. The manifest must contain a parameter called mainWorkflowURL. If it does then the value of the parameter must either be a URL, including the relevant protocol, or the name of a file present in the zip archive. Any subworkflows or tasks imported by the main workflow must either be referenced as URLs in the workflow or be present in the archive as described above.
-        2. The manifest may contain an array of URLs to inputs files called inputFileURLs. The WesAdapter must decide if it should resolve these or let the workflow engine resolve them.
-        3. The manifest may contain a URL reference to an options files name optionFileURL. The WesAdapter may chose to make use of this depending on the context of the workflow engine. It may also choose to pass this to the workflow engine or pass a modified copy to the workflow engine.
+   1. If the zip file does *not* contain a file named `MANIFEST.json`:
+      1. The zip file must contain one workflow file with the prefix main followed by the conventional suffix for the workflow, e.g. `main.wdl`
+      2. Any sub-workflows or tasks referenced by the main workflow must either be in the zip at the appropriate relative path or they must be referenced by URLs that are resolvable by the workflow engine. The WesAdapter may attempt to resolve them for the engine but this is a convenience and not required.
+      3. Any variables not defined in the workflows must be provided in an inputs file named with the prefix inputs and the conventional suffix for the workflow engine (e.g `inputs.json`). For workflow engines that support multiple input files an index suffix must be provided (e.g. inputs_a.json or inputs_1.json) if there is more than one inputs file.
+      4. A workflow options file may be included and must be named with the options prefix followed by the conventional suffix of the workflow. The WesAdapter may chose to make use of this depending on the context of the workflow engine. It may also choose to pass this to the workflow engine or pass a modified copy to the workflow engine.
+   2. If the zip file *does* contain a manifest:
+      1. The manifest must contain a parameter called mainWorkflowURL. If it does then the value of the parameter must either be a URL, including the relevant protocol, or the name of a file present in the zip archive. Any subworkflows or tasks imported by the main workflow must either be referenced as URLs in the workflow or be present in the archive as described above.
+      2. The manifest may contain an array of URLs to inputs files called inputFileURLs. The WesAdapter must decide if it should resolve these or let the workflow engine resolve them.
+      3. The manifest may contain a URL reference to an options files name optionFileURL. The WesAdapter may choose to make use of this depending on the context of the workflow engine. It may also choose to pass this to the workflow engine or pass a modified copy to the workflow engine.
+3. If the source URL points to a directory then Amazon Genomics CLI will zip the directory before uploading it. The directory must follow the same conventions stated above for zip files.
 
-The following snippet demonstrates the declaration of a mutlifile workflow:
+The following snippet demonstrates a possible declaration of a multi-file workflow:
 
 ```yaml
 workflows:
@@ -90,12 +90,24 @@ The following snippet demonstrates a valid `MANIFEST.json` file:
 }
 ```
 
+#### `MANIFEST.json` Structure
+
+The following keys are allowed in the `MANIFEST.json`
+
+
+| Key               | Required | Purpose                                                                                                                                                                                                                                                                                                                                                                             |
+|-------------------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `mainWorkflowURL` | Yes      | Points to the workflow definition that is the main entrypoint of the workflow.                                                                                                                                                                                                                                                                                                      |
+| `inputFileURLs`   | No       | An array of URLs to one or more JSON files that define the inputs to the workflow in the format expected by the relevant engine. inputFile URLs are resolved relative to the location of the `MANIFEST.json`.                                                                                                                                                                       |
+| `optionFileURL`   | No       | A URL pointing to a JSON file containing engine options applied to a workflow instance. This is only used when engines run in [server mode]( {{< relref "../Concepts/engines#run-mode" >}} ). Options are interpreted by the engine and so must be in the form expected by the engine. The URL is resolved relative to the location of the `MANIFEST.json`.                         |
+| `engineOptions`   | No       | A string appended to the command line of the engine's run command. The string may contain any flags or parameters relevant to the engine of the context used to run the workflow. It should not be used to declare inputs (use `inputFileURLS` instead). This parameter is only relevant for engines that run as [head processes]( {{< relref "../Concepts/engines#run-mode" >}} ). |
+
 ## Engine Selection
 
 When a workflow is submitted to run, Amazon Genomics CLI will match the workflow type with the map of engines in the context. For example,
 if the workflow `type` is `wdl` Amazon Genomics CLI will attempt to identify and engine designated as the engine for that type. There
 may only be one engine per type. If no suitable engine is found in the context an error will be reported.
- 
+
 ## Workflow Instances
 
 Any defined project workflow can be run multiple times. Each run is called an instance and assigned a unique instance ID.
@@ -119,7 +131,7 @@ unique ID of that workflow instance run will be returned if the submission is su
 #### `workflow arguments`
 
 Workflow arguments such as options files can be specified at submission time using the `a` or `--args` flag. For
-example: 
+example:
 
 ```shell
 agc workflow run my-workflow --args inputs.json
@@ -134,14 +146,14 @@ The `agc workflow list` command can be used to list all workflows that are speci
 
 ### `describe`
 
-The `agc workflow describe <workflow-name>` command will return detailed information about the named workflow based on 
+The `agc workflow describe <workflow-name>` command will return detailed information about the named workflow based on
 the specification in the current project YAML file.
 
 ### `status`
 
 To find out the status of workflow instances that are running, or have been run you can use the `agc workflow status` command.
 This will display details on 20 recent workflows from the project, to display more, or fewer you can use the `--limit number` flag
-where the `number` may be as many as 1000. 
+where the `number` may be as many as 1000.
 
 To list the status of workflows run or running in a specific context use the `--context-name` flag and provide the name
 of one of the contexts of the project.
@@ -150,11 +162,10 @@ You may get the status of workflow instances by workflow name using the `--workf
 
 To display the status of a specific workflow instance you can provide the id of the desired workflow instance with the `--instance-id` flag.
 
-
 ### `stop`
 
 A running workflow *instance* can be stopped at any time using the `agc workflow stop <instance-id>` command. When issued,
-Amazon Genomics CLI will look up the appropriate context and engine using the `instance-id` of the workflow and instruct the engine to 
+Amazon Genomics CLI will look up the appropriate context and engine using the `instance-id` of the workflow and instruct the engine to
 stop the workflow. What happens next depends on the actual workflow engine. For example, in the case of the Cromwell WDL
 engine, any currently executing tasks will halt, any pending tasks will be removed from the work queue and no further
 tasks will be started for that workflow instance.
@@ -189,5 +200,5 @@ of the spot instances will be determined by the rules governing spot instance ch
 
 ### Tags
 
-Resources used by Amazon Genomics CLI are tagged including the username, project name and the context name. Currently, tagging is *not* 
+Resources used by Amazon Genomics CLI are tagged including the username, project name and the context name. Currently, tagging is *not*
 possible at the level of an individual workflow.


### PR DESCRIPTION
Cherry pick of doc update from main

* Improved documentation of MANIFEST, directories and engines.

* Use root URL recommended in Hugo documentation (https://gohugo.io/hosting-and-deployment/hosting-on-github/)

* updated go.mod

(cherry picked from commit a0a43dbbb9834497f283b9833a1b0e55ab3ee69a)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
