### PR TITLE
fix: Remove Chdir when looking for project files

### DIFF
--- a/packages/cli/internal/pkg/cli/workflow/manager.go
+++ b/packages/cli/internal/pkg/cli/workflow/manager.go
@@ -205,7 +205,7 @@ func (m *Manager) packWorkflowFiles() {
 		return
 	}
 	projectLocation := m.Project.GetLocation()
-	workflowPath :=  m.parsedSourceURL.Path
+	workflowPath := m.parsedSourceURL.Path
 	path := filepath.Join(projectLocation, workflowPath)
 	m.packPath, m.err = compressToTmp(path)
 }

--- a/packages/cli/internal/pkg/cli/workflow/manager.go
+++ b/packages/cli/internal/pkg/cli/workflow/manager.go
@@ -42,7 +42,6 @@ var (
 		}
 		return f.Name(), nil
 	}
-	chdir = os.Chdir
 )
 
 //nolint:structcheck
@@ -173,13 +172,6 @@ func (m *Manager) validateContextIsDeployed(contextName string) {
 	}
 }
 
-func (m *Manager) chdirIntoProject() {
-	if m.err != nil {
-		return
-	}
-	m.err = chdir(m.Project.GetLocation())
-}
-
 func (m *Manager) setWorkflowSpec(workflowName string) {
 	if m.err != nil {
 		return
@@ -212,7 +204,10 @@ func (m *Manager) packWorkflowFiles() {
 	if m.err != nil {
 		return
 	}
-	m.packPath, m.err = compressToTmp(m.parsedSourceURL.Path)
+	projectLocation := m.Project.GetLocation()
+	workflowPath :=  m.parsedSourceURL.Path
+	path := filepath.Join(projectLocation, workflowPath)
+	m.packPath, m.err = compressToTmp(path)
 }
 
 func (m *Manager) setOutputBucket() {

--- a/packages/cli/internal/pkg/cli/workflow/workflow_run.go
+++ b/packages/cli/internal/pkg/cli/workflow/workflow_run.go
@@ -4,7 +4,6 @@ import "fmt"
 
 func (m *Manager) RunWorkflow(contextName, workflowName, argumentsUrl string) (string, error) {
 	m.readProjectSpec()
-	m.chdirIntoProject()
 	m.setWorkflowSpec(workflowName)
 	m.readConfig()
 	m.setContext(contextName)

--- a/packages/cli/internal/pkg/cli/workflow/workflow_run_test.go
+++ b/packages/cli/internal/pkg/cli/workflow/workflow_run_test.go
@@ -74,7 +74,6 @@ type WorkflowRunTestSuite struct {
 	mockTmp           *iomocks.MockTmp
 	mockWes           *wesmocks.MockWesClient
 	origRemoveFile    func(name string) error
-	origChdir         func(name string) error
 	origCompressToTmp func(srcPath string) (string, error)
 	origWriteToTmp    func(namePattern, content string) (string, error)
 

--- a/packages/cli/internal/pkg/cli/workflow/workflow_run_test.go
+++ b/packages/cli/internal/pkg/cli/workflow/workflow_run_test.go
@@ -77,11 +77,11 @@ type WorkflowRunTestSuite struct {
 	origCompressToTmp func(srcPath string) (string, error)
 	origWriteToTmp    func(namePattern, content string) (string, error)
 
-	testProjSpec    spec.Project
-	absDataFilePath string
+	testProjSpec         spec.Project
+	absDataFilePath      string
 	localWorkflowAbsPath string
-	wfInstance      ddb.WorkflowInstance
-	testStackInfo   cfn.StackInfo
+	wfInstance           ddb.WorkflowInstance
+	testStackInfo        cfn.StackInfo
 
 	manager *Manager
 }

--- a/packages/cli/internal/pkg/cli/workflow/workflow_run_test.go
+++ b/packages/cli/internal/pkg/cli/workflow/workflow_run_test.go
@@ -80,10 +80,11 @@ type WorkflowRunTestSuite struct {
 
 	testProjSpec    spec.Project
 	absDataFilePath string
+	localWorkflowAbsPath string
 	wfInstance      ddb.WorkflowInstance
 	testStackInfo   cfn.StackInfo
 
-	manager *Manager
+	manager              *Manager
 }
 
 func (s *WorkflowRunTestSuite) BeforeTest(_, _ string) {
@@ -103,12 +104,12 @@ func (s *WorkflowRunTestSuite) BeforeTest(_, _ string) {
 	s.origRemoveFile, removeFile = removeFile, s.mockOs.Remove
 	s.origCompressToTmp, compressToTmp = compressToTmp, s.mockZip.CompressToTmp
 	s.origWriteToTmp, writeToTmp = writeToTmp, s.mockTmp.Write
-	s.origChdir, chdir = chdir, s.mockOs.Chdir
 
 	// data file path is relative to inputs file (usually the workflow folder)
 	absDataFilePath, err := filepath.Abs(filepath.Join(filepath.Dir(testArgumentsPath), testDataFileLocalUrl))
 	require.NoError(s.T(), err)
 	s.absDataFilePath = absDataFilePath
+	s.localWorkflowAbsPath = filepath.Join(testProjectFileDir, testWorkflowLocalUrl)
 
 	s.manager = &Manager{
 		Project:    s.mockProjectClient,
@@ -165,17 +166,14 @@ func (s *WorkflowRunTestSuite) BeforeTest(_, _ string) {
 func (s *WorkflowRunTestSuite) AfterTest(_, _ string) {
 	removeFile = s.origRemoveFile
 	compressToTmp = s.origCompressToTmp
-	chdir = s.origChdir
 }
 
 func (s *WorkflowRunTestSuite) TestRunWorkflow_LocalFile_WithS3Args() {
-	defer s.ctrl.Finish()
 	s.mockConfigClient.EXPECT().GetUserId().Return(testUserId, nil)
 	s.mockCfn.EXPECT().GetStackStatus(testContext1Stack).Return(types.StackStatusCreateComplete, nil)
 	s.mockProjectClient.EXPECT().Read().Return(s.testProjSpec, nil)
 	s.mockProjectClient.EXPECT().GetLocation().Return(testProjectFileDir)
-	s.mockOs.EXPECT().Chdir(testProjectFileDir).Return(nil)
-	s.mockZip.EXPECT().CompressToTmp(testWorkflowLocalUrl).Return(testCompressedTmpPath, nil)
+	s.mockZip.EXPECT().CompressToTmp(s.localWorkflowAbsPath).Return(testCompressedTmpPath, nil)
 	s.mockSsmClient.EXPECT().GetOutputBucket().Return(testOutputBucket, nil)
 	uploadCall := s.mockS3Client.EXPECT().UploadFile(testOutputBucket, testWorkflowKey, testCompressedTmpPath).Return(nil)
 	s.mockStorageClient.EXPECT().ReadAsBytes(testArgumentsPath).Return([]byte(testInputS3), nil)
@@ -193,13 +191,11 @@ func (s *WorkflowRunTestSuite) TestRunWorkflow_LocalFile_WithS3Args() {
 }
 
 func (s *WorkflowRunTestSuite) TestRunWorkflow_LocalFile_WithLocalArgs() {
-	defer s.ctrl.Finish()
 	s.mockConfigClient.EXPECT().GetUserId().Return(testUserId, nil)
 	s.mockCfn.EXPECT().GetStackStatus(testContext1Stack).Return(types.StackStatusCreateComplete, nil)
 	s.mockProjectClient.EXPECT().Read().Return(s.testProjSpec, nil)
 	s.mockProjectClient.EXPECT().GetLocation().Return(testProjectFileDir)
-	s.mockOs.EXPECT().Chdir(testProjectFileDir).Return(nil)
-	s.mockZip.EXPECT().CompressToTmp(testWorkflowLocalUrl).Return(testCompressedTmpPath, nil)
+	s.mockZip.EXPECT().CompressToTmp(s.localWorkflowAbsPath).Return(testCompressedTmpPath, nil)
 	s.mockSsmClient.EXPECT().GetOutputBucket().Return(testOutputBucket, nil)
 	uploadCall := s.mockS3Client.EXPECT().UploadFile(testOutputBucket, testWorkflowKey, testCompressedTmpPath).Return(nil)
 	s.mockStorageClient.EXPECT().ReadAsBytes(testArgumentsPath).Return([]byte(testInputLocal), nil)
@@ -218,13 +214,11 @@ func (s *WorkflowRunTestSuite) TestRunWorkflow_LocalFile_WithLocalArgs() {
 }
 
 func (s *WorkflowRunTestSuite) TestRunWorkflow_LocalFile_NoArgs() {
-	defer s.ctrl.Finish()
 	s.mockConfigClient.EXPECT().GetUserId().Return(testUserId, nil)
 	s.mockCfn.EXPECT().GetStackStatus(testContext1Stack).Return(types.StackStatusCreateComplete, nil)
 	s.mockProjectClient.EXPECT().Read().Return(s.testProjSpec, nil)
 	s.mockProjectClient.EXPECT().GetLocation().Return(testProjectFileDir)
-	s.mockOs.EXPECT().Chdir(testProjectFileDir).Return(nil)
-	s.mockZip.EXPECT().CompressToTmp(testWorkflowLocalUrl).Return(testCompressedTmpPath, nil)
+	s.mockZip.EXPECT().CompressToTmp(s.localWorkflowAbsPath).Return(testCompressedTmpPath, nil)
 	s.mockSsmClient.EXPECT().GetOutputBucket().Return(testOutputBucket, nil)
 	uploadCall := s.mockS3Client.EXPECT().UploadFile(testOutputBucket, testWorkflowKey, testCompressedTmpPath).Return(nil)
 	s.mockCfn.EXPECT().GetStackInfo(testContext1Stack).Return(s.testStackInfo, nil)
@@ -239,12 +233,9 @@ func (s *WorkflowRunTestSuite) TestRunWorkflow_LocalFile_NoArgs() {
 }
 
 func (s *WorkflowRunTestSuite) TestRunWorkflow_S3Object_WithLocalArgs() {
-	defer s.ctrl.Finish()
 	s.mockConfigClient.EXPECT().GetUserId().Return(testUserId, nil)
 	s.mockCfn.EXPECT().GetStackStatus(testContext1Stack).Return(types.StackStatusCreateComplete, nil)
 	s.mockProjectClient.EXPECT().Read().Return(s.testProjSpec, nil)
-	s.mockProjectClient.EXPECT().GetLocation().Return(testProjectFileDir)
-	s.mockOs.EXPECT().Chdir(testProjectFileDir).Return(nil)
 	s.mockSsmClient.EXPECT().GetOutputBucket().Return(testOutputBucket, nil)
 	s.mockStorageClient.EXPECT().ReadAsBytes(testArgumentsPath).Return([]byte(testInputLocal), nil)
 	s.mockTmp.EXPECT().Write(testArgsFileName+"_*", testInputLocalToS3).Return(testTmpAttachmentPath, nil)
@@ -262,12 +253,9 @@ func (s *WorkflowRunTestSuite) TestRunWorkflow_S3Object_WithLocalArgs() {
 }
 
 func (s *WorkflowRunTestSuite) TestRunWorkflow_S3Object_NoArgs() {
-	defer s.ctrl.Finish()
 	s.mockConfigClient.EXPECT().GetUserId().Return(testUserId, nil)
 	s.mockCfn.EXPECT().GetStackStatus(testContext1Stack).Return(types.StackStatusCreateComplete, nil)
 	s.mockProjectClient.EXPECT().Read().Return(s.testProjSpec, nil)
-	s.mockProjectClient.EXPECT().GetLocation().Return(testProjectFileDir)
-	s.mockOs.EXPECT().Chdir(testProjectFileDir).Return(nil)
 	s.mockSsmClient.EXPECT().GetOutputBucket().Return(testOutputBucket, nil)
 	s.mockCfn.EXPECT().GetStackInfo(testContext1Stack).Return(s.testStackInfo, nil)
 	s.mockWes.EXPECT().RunWorkflow(context.Background(), gomock.Any()).Return(testRun1Id, nil)
@@ -280,7 +268,6 @@ func (s *WorkflowRunTestSuite) TestRunWorkflow_S3Object_NoArgs() {
 }
 
 func (s *WorkflowRunTestSuite) TestRunWorkflow_ReadProjectSpecFailure() {
-	defer s.ctrl.Finish()
 	errorMessage := "failed to read project specification"
 	s.mockProjectClient.EXPECT().Read().Return(spec.Project{}, errors.New(errorMessage))
 
@@ -292,10 +279,7 @@ func (s *WorkflowRunTestSuite) TestRunWorkflow_ReadProjectSpecFailure() {
 }
 
 func (s *WorkflowRunTestSuite) TestRunWorkflow_MissingWorkflowSpec() {
-	defer s.ctrl.Finish()
 	s.mockProjectClient.EXPECT().Read().Return(s.testProjSpec, nil)
-	s.mockProjectClient.EXPECT().GetLocation().Return(testProjectFileDir)
-	s.mockOs.EXPECT().Chdir(testProjectFileDir).Return(nil)
 
 	actualId, err := s.manager.RunWorkflow(testContext1Name, "dummy", "")
 	if s.Assert().Error(err) {
@@ -305,12 +289,9 @@ func (s *WorkflowRunTestSuite) TestRunWorkflow_MissingWorkflowSpec() {
 }
 
 func (s *WorkflowRunTestSuite) TestRunWorkflow_InvalidWorkflowDefinitionUrl() {
-	defer s.ctrl.Finish()
 	s.mockConfigClient.EXPECT().GetUserId().Return(testUserId, nil)
 	s.mockCfn.EXPECT().GetStackStatus(testContext1Stack).Return(types.StackStatusCreateComplete, nil)
 	s.mockProjectClient.EXPECT().Read().Return(s.testProjSpec, nil)
-	s.mockProjectClient.EXPECT().GetLocation().Return(testProjectFileDir)
-	s.mockOs.EXPECT().Chdir(testProjectFileDir).Return(nil)
 	s.mockSsmClient.EXPECT().GetOutputBucket().Return(testOutputBucket, nil)
 
 	actualId, err := s.manager.RunWorkflow(testContext1Name, testInvalidWorkflowName, "")
@@ -321,15 +302,13 @@ func (s *WorkflowRunTestSuite) TestRunWorkflow_InvalidWorkflowDefinitionUrl() {
 }
 
 func (s *WorkflowRunTestSuite) TestRunWorkflow_CompressionFailed() {
-	defer s.ctrl.Finish()
 	s.mockConfigClient.EXPECT().GetUserId().Return(testUserId, nil)
 	s.mockCfn.EXPECT().GetStackStatus(testContext1Stack).Return(types.StackStatusCreateComplete, nil)
 	errorMessage := "cannot compress file"
 	s.mockProjectClient.EXPECT().Read().Return(s.testProjSpec, nil)
 	s.mockProjectClient.EXPECT().GetLocation().Return(testProjectFileDir)
-	s.mockOs.EXPECT().Chdir(testProjectFileDir).Return(nil)
 	s.mockSsmClient.EXPECT().GetOutputBucket().Return(testOutputBucket, nil)
-	s.mockZip.EXPECT().CompressToTmp(testWorkflowLocalUrl).Return("", errors.New(errorMessage))
+	s.mockZip.EXPECT().CompressToTmp(s.localWorkflowAbsPath).Return("", errors.New(errorMessage))
 
 	actualId, err := s.manager.RunWorkflow(testContext1Name, testLocalWorkflowName, "")
 	if s.Assert().Error(err) {
@@ -339,13 +318,10 @@ func (s *WorkflowRunTestSuite) TestRunWorkflow_CompressionFailed() {
 }
 
 func (s *WorkflowRunTestSuite) TestRunWorkflow_SSMClientFailed() {
-	defer s.ctrl.Finish()
 	s.mockConfigClient.EXPECT().GetUserId().Return(testUserId, nil)
 	s.mockCfn.EXPECT().GetStackStatus(testContext1Stack).Return(types.StackStatusCreateComplete, nil)
 	errorMessage := "cannot connect to SSM"
 	s.mockProjectClient.EXPECT().Read().Return(s.testProjSpec, nil)
-	s.mockProjectClient.EXPECT().GetLocation().Return(testProjectFileDir)
-	s.mockOs.EXPECT().Chdir(testProjectFileDir).Return(nil)
 	s.mockSsmClient.EXPECT().GetOutputBucket().Return("", errors.New(errorMessage))
 
 	actualId, err := s.manager.RunWorkflow(testContext1Name, testLocalWorkflowName, "")
@@ -356,14 +332,12 @@ func (s *WorkflowRunTestSuite) TestRunWorkflow_SSMClientFailed() {
 }
 
 func (s *WorkflowRunTestSuite) TestRunWorkflow_UploadToS3Failed() {
-	defer s.ctrl.Finish()
 	s.mockConfigClient.EXPECT().GetUserId().Return(testUserId, nil)
 	s.mockCfn.EXPECT().GetStackStatus(testContext1Stack).Return(types.StackStatusCreateComplete, nil)
 	errorMessage := "cannot upload to S3"
 	s.mockProjectClient.EXPECT().Read().Return(s.testProjSpec, nil)
 	s.mockProjectClient.EXPECT().GetLocation().Return(testProjectFileDir)
-	s.mockOs.EXPECT().Chdir(testProjectFileDir).Return(nil)
-	s.mockZip.EXPECT().CompressToTmp(testWorkflowLocalUrl).Return(testCompressedTmpPath, nil)
+	s.mockZip.EXPECT().CompressToTmp(s.localWorkflowAbsPath).Return(testCompressedTmpPath, nil)
 	s.mockSsmClient.EXPECT().GetOutputBucket().Return(testOutputBucket, nil)
 	s.mockS3Client.EXPECT().UploadFile(testOutputBucket, testWorkflowKey, testCompressedTmpPath).Return(errors.New(errorMessage))
 	s.mockOs.EXPECT().Remove(testCompressedTmpPath).Return(nil)
@@ -376,14 +350,12 @@ func (s *WorkflowRunTestSuite) TestRunWorkflow_UploadToS3Failed() {
 }
 
 func (s *WorkflowRunTestSuite) TestRunWorkflow_ReadArgsFailed() {
-	defer s.ctrl.Finish()
 	s.mockConfigClient.EXPECT().GetUserId().Return(testUserId, nil)
 	s.mockCfn.EXPECT().GetStackStatus(testContext1Stack).Return(types.StackStatusCreateComplete, nil)
 	errorMessage := "cannot read input"
 	s.mockProjectClient.EXPECT().Read().Return(s.testProjSpec, nil)
 	s.mockProjectClient.EXPECT().GetLocation().Return(testProjectFileDir)
-	s.mockOs.EXPECT().Chdir(testProjectFileDir).Return(nil)
-	s.mockZip.EXPECT().CompressToTmp(testWorkflowLocalUrl).Return(testCompressedTmpPath, nil)
+	s.mockZip.EXPECT().CompressToTmp(s.localWorkflowAbsPath).Return(testCompressedTmpPath, nil)
 	s.mockSsmClient.EXPECT().GetOutputBucket().Return(testOutputBucket, nil)
 	s.mockS3Client.EXPECT().UploadFile(testOutputBucket, testWorkflowKey, testCompressedTmpPath).Return(nil)
 	s.mockStorageClient.EXPECT().ReadAsBytes(testArgumentsPath).Return([]byte{}, errors.New(errorMessage))
@@ -397,15 +369,12 @@ func (s *WorkflowRunTestSuite) TestRunWorkflow_ReadArgsFailed() {
 }
 
 func (s *WorkflowRunTestSuite) TestRunWorkflow_UploadInputFailed() {
-	defer s.ctrl.Finish()
 	s.mockConfigClient.EXPECT().GetUserId().Return(testUserId, nil)
 	s.mockCfn.EXPECT().GetStackStatus(testContext1Stack).Return(types.StackStatusCreateComplete, nil)
 	errorMessage := "cannot upload input"
-	defer s.ctrl.Finish()
 	s.mockProjectClient.EXPECT().Read().Return(s.testProjSpec, nil)
 	s.mockProjectClient.EXPECT().GetLocation().Return(testProjectFileDir)
-	s.mockOs.EXPECT().Chdir(testProjectFileDir).Return(nil)
-	s.mockZip.EXPECT().CompressToTmp(testWorkflowLocalUrl).Return(testCompressedTmpPath, nil)
+	s.mockZip.EXPECT().CompressToTmp(s.localWorkflowAbsPath).Return(testCompressedTmpPath, nil)
 	s.mockSsmClient.EXPECT().GetOutputBucket().Return(testOutputBucket, nil)
 	s.mockS3Client.EXPECT().UploadFile(testOutputBucket, testWorkflowKey, testCompressedTmpPath).Return(nil)
 	s.mockStorageClient.EXPECT().ReadAsBytes(testArgumentsPath).Return([]byte(testInputLocal), nil)
@@ -420,14 +389,12 @@ func (s *WorkflowRunTestSuite) TestRunWorkflow_UploadInputFailed() {
 }
 
 func (s *WorkflowRunTestSuite) TestRunWorkflow_CfnFailed() {
-	defer s.ctrl.Finish()
 	s.mockConfigClient.EXPECT().GetUserId().Return(testUserId, nil)
 	s.mockCfn.EXPECT().GetStackStatus(testContext1Stack).Return(types.StackStatusCreateComplete, nil)
 	errorMessage := "cannot call CFN"
 	s.mockProjectClient.EXPECT().Read().Return(s.testProjSpec, nil)
 	s.mockProjectClient.EXPECT().GetLocation().Return(testProjectFileDir)
-	s.mockOs.EXPECT().Chdir(testProjectFileDir).Return(nil)
-	s.mockZip.EXPECT().CompressToTmp(testWorkflowLocalUrl).Return(testCompressedTmpPath, nil)
+	s.mockZip.EXPECT().CompressToTmp(s.localWorkflowAbsPath).Return(testCompressedTmpPath, nil)
 	s.mockSsmClient.EXPECT().GetOutputBucket().Return(testOutputBucket, nil)
 	s.mockS3Client.EXPECT().UploadFile(testOutputBucket, testWorkflowKey, testCompressedTmpPath).Return(nil)
 	s.mockCfn.EXPECT().GetStackInfo(testContext1Stack).Return(cfn.StackInfo{}, errors.New(errorMessage))
@@ -441,14 +408,12 @@ func (s *WorkflowRunTestSuite) TestRunWorkflow_CfnFailed() {
 }
 
 func (s *WorkflowRunTestSuite) TestRunWorkflow_CfnMissingWesUrlFailed() {
-	defer s.ctrl.Finish()
 	s.mockConfigClient.EXPECT().GetUserId().Return(testUserId, nil)
 	s.mockCfn.EXPECT().GetStackStatus(testContext1Stack).Return(types.StackStatusCreateComplete, nil)
 	errorMessage := "wes endpoint for workflow type 'TypeLanguage' is missing in engine stack 'TestStackId'"
 	s.mockProjectClient.EXPECT().Read().Return(s.testProjSpec, nil)
 	s.mockProjectClient.EXPECT().GetLocation().Return(testProjectFileDir)
-	s.mockOs.EXPECT().Chdir(testProjectFileDir).Return(nil)
-	s.mockZip.EXPECT().CompressToTmp(testWorkflowLocalUrl).Return(testCompressedTmpPath, nil)
+	s.mockZip.EXPECT().CompressToTmp(s.localWorkflowAbsPath).Return(testCompressedTmpPath, nil)
 	s.mockSsmClient.EXPECT().GetOutputBucket().Return(testOutputBucket, nil)
 	s.mockS3Client.EXPECT().UploadFile(testOutputBucket, testWorkflowKey, testCompressedTmpPath).Return(nil)
 	stackInfo := cfn.StackInfo{
@@ -466,14 +431,12 @@ func (s *WorkflowRunTestSuite) TestRunWorkflow_CfnMissingWesUrlFailed() {
 }
 
 func (s *WorkflowRunTestSuite) TestRunWorkflow_WesFailed() {
-	defer s.ctrl.Finish()
 	s.mockConfigClient.EXPECT().GetUserId().Return(testUserId, nil)
 	s.mockCfn.EXPECT().GetStackStatus(testContext1Stack).Return(types.StackStatusCreateComplete, nil)
 	errorMessage := "cannot call WES"
 	s.mockProjectClient.EXPECT().Read().Return(s.testProjSpec, nil)
 	s.mockProjectClient.EXPECT().GetLocation().Return(testProjectFileDir)
-	s.mockOs.EXPECT().Chdir(testProjectFileDir).Return(nil)
-	s.mockZip.EXPECT().CompressToTmp(testWorkflowLocalUrl).Return(testCompressedTmpPath, nil)
+	s.mockZip.EXPECT().CompressToTmp(s.localWorkflowAbsPath).Return(testCompressedTmpPath, nil)
 	s.mockSsmClient.EXPECT().GetOutputBucket().Return(testOutputBucket, nil)
 	s.mockS3Client.EXPECT().UploadFile(testOutputBucket, testWorkflowKey, testCompressedTmpPath).Return(nil)
 	s.mockCfn.EXPECT().GetStackInfo(testContext1Stack).Return(s.testStackInfo, nil)
@@ -488,12 +451,9 @@ func (s *WorkflowRunTestSuite) TestRunWorkflow_WesFailed() {
 }
 
 func (s *WorkflowRunTestSuite) TestRunWorkflow_DeployValidationFailed() {
-	defer s.ctrl.Finish()
 	s.mockConfigClient.EXPECT().GetUserId().Return(testUserId, nil)
 	errorMessage := "context 'TestContext1' is not deployed"
 	s.mockProjectClient.EXPECT().Read().Return(s.testProjSpec, nil)
-	s.mockProjectClient.EXPECT().GetLocation().Return(testProjectFileDir)
-	s.mockOs.EXPECT().Chdir(testProjectFileDir).Return(nil)
 	s.mockCfn.EXPECT().GetStackStatus(testContext1Stack).Return(types.StackStatusCreateComplete, cfn.StackDoesNotExistError)
 
 	actualId, err := s.manager.RunWorkflow(testContext1Name, testLocalWorkflowName, "")
@@ -504,12 +464,9 @@ func (s *WorkflowRunTestSuite) TestRunWorkflow_DeployValidationFailed() {
 }
 
 func (s *WorkflowRunTestSuite) TestRunWorkflow_DeployValidationCfnFailed() {
-	defer s.ctrl.Finish()
 	s.mockConfigClient.EXPECT().GetUserId().Return(testUserId, nil)
 	errorMessage := "some cfn error"
 	s.mockProjectClient.EXPECT().Read().Return(s.testProjSpec, nil)
-	s.mockProjectClient.EXPECT().GetLocation().Return(testProjectFileDir)
-	s.mockOs.EXPECT().Chdir(testProjectFileDir).Return(nil)
 	s.mockCfn.EXPECT().GetStackStatus(testContext1Stack).Return(types.StackStatusCreateComplete, errors.New(errorMessage))
 
 	actualId, err := s.manager.RunWorkflow(testContext1Name, testLocalWorkflowName, "")

--- a/packages/cli/internal/pkg/cli/workflow/workflow_run_test.go
+++ b/packages/cli/internal/pkg/cli/workflow/workflow_run_test.go
@@ -83,7 +83,7 @@ type WorkflowRunTestSuite struct {
 	wfInstance      ddb.WorkflowInstance
 	testStackInfo   cfn.StackInfo
 
-	manager              *Manager
+	manager *Manager
 }
 
 func (s *WorkflowRunTestSuite) BeforeTest(_, _ string) {


### PR DESCRIPTION
We currently search for the agc-project.yaml file and chdir into the
project directory in case AGC is run from a folder below the top-level
project folder. This means that when looking for files in the args command,
the CLI is not looking in the users current directory, meaning they must
specify --args files relative to the project.yaml rather than their
working directory. This commit changes AGC to prepend the project directory
to any workflow lookups, so the working directory remains the same as the users.

fixes #83 

**Description of how you validated changes**

Able to run `read` and `words-with-vowels` workflows
* from within `demo-wdl-project/workflows/read`: `agc workflow run read --args read.inputs.json -c miniContext`
* from within `demo-wdl-project`: `agc workflow run read --args workflows/read/read.inputs.json -c miniContext`
* from within `demo-wdl-project/workflows/words`: `agc workflow run words-with-vowels -c miniContext --args words-with-vowels.inputs.json`
* from within `demo-wdl-project/workflows/words`, using the MANIFEST.json: `agc workflow run words-with-vowels -c miniContext`


**Checklist**

- [x] If this change would make any existing documentation invalid, I have included those updates within this PR
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have linted my code before raising the PR
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
