### PR TITLE
fix: Fixes execution order for the Launch Template

### DIFF
--- a/packages/cdk/lib/constants.ts
+++ b/packages/cdk/lib/constants.ts
@@ -103,11 +103,11 @@ runcmd:
 
 # Setup ecs additions
 - cd /opt
-- /opt/ecs-additions/provision.sh
 - aws s3 sync \${INSTALLED_ARTIFACTS_S3_ROOT_URL}/ecs-additions/ ./ecs-additions && chmod a+x /opt/ecs-additions/provision.sh  
 - test -f ./ecs-additions/fetch_and_run.sh || sleep 5 || aws s3 sync \${INSTALLED_ARTIFACTS_S3_ROOT_URL}/ecs-additions/ ./ecs-additions && chmod a+x /opt/ecs-additions/provision.sh    
 - test -f ./ecs-additions/fetch_and_run.sh || sleep 10 || aws s3 sync \${INSTALLED_ARTIFACTS_S3_ROOT_URL}/ecs-additions/ ./ecs-additions && chmod a+x /opt/ecs-additions/provision.sh    
 - test -f ./ecs-additions/fetch_and_run.sh || shutdown -P now
+- /opt/ecs-additions/provision.sh
 
 - echo "successfully initiated"
 --==MYBOUNDARY==--


### PR DESCRIPTION
**Description of Changes**

This change fixes the order of operations for the launch template script as it currently tries to execute a script that doesn't exist yet.

**Description of how you validated changes**

agc account activate && agc context deploy --all


**Checklist**

- [ ] If this change would make any existing documentation invalid, I have included those updates within this PR
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have linted my code before raising the PR
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
