### PR TITLE
fix: Pinned running of rnaseq to version 3.4 (closes #246)

### DIFF
--- a/examples/nf-core-project/workflows/rnaseq/MANIFEST.json
+++ b/examples/nf-core-project/workflows/rnaseq/MANIFEST.json
@@ -1,7 +1,5 @@
 {
   "mainWorkflowURL": "https://github.com/nf-core/rnaseq.git",
-  "inputFileURLs": [
-    "inputs.json"
-  ],
-  "engineOptions": "-resume"
+  "inputFileURLs": ["inputs.json"],
+  "engineOptions": "-resume -r 3.4"
 }


### PR DESCRIPTION
<!-- Title format: type(scope): Short description (72 chars max for line) -->
<!-- `(scope)` is optional and `type` is one of: build, ci, chore, docs, feat, fix, perf, refactor, revert, style, test -->
<!-- Available types:
- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit -->

Issue #, if available:

**Description of Changes**

[//]: #  (A description of the change that you made and the new user experience that it creates)

Modify the rnaseq of nf-core to a pinned version compatible w/ our shipped version of nextflow

**Description of how you validated changes**

[//]: #  (A description of you validated your changes and any relevant logs that show your change works)

1. Ran example without `-r 3.4`. Failed with `EXECUTOR_ERROR`
2. Ran example with `-r 3.4`. Recieved `SUCCEEDED`. 


**Checklist**

- [Y] If this change would make any existing documentation invalid, I have included those updates within this PR
- [Y] I have added unit tests that prove my fix is effective or that my feature works
- [Y] I have linted my code before raising the PR
- [Y] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
