### PR TITLE
fix: nest batch artifacts and disable bucket clean up

### DIFF
--- a/packages/cdk/apps/core/app.ts
+++ b/packages/cdk/apps/core/app.ts
@@ -37,7 +37,7 @@ new CoreStack(app, `${PRODUCT_NAME}-Core`, {
     },
     {
       name: "installed-artifacts/s3-root-url",
-      value: `s3://${bucketName}/batch-artifacts`,
+      value: `s3://${bucketName}/artifacts/batch-artifacts`,
       description: "S3 root url for batch assets",
     },
   ],

--- a/packages/cdk/lib/stacks/core-stack.ts
+++ b/packages/cdk/lib/stacks/core-stack.ts
@@ -73,6 +73,8 @@ export class CoreStack extends Stack {
     new BucketDeployment(this, "BatchArtifacts", {
       sources: [Source.asset(path.join(__dirname, "../artifacts"))],
       destinationBucket: this.bucket,
+      destinationKeyPrefix: "artifacts",
+      prune: false,
       metadata: {
         "idempotency-key": props.idempotencyKey,
       },


### PR DESCRIPTION
**Description of Changes**

[//]: #  (A description of the change that you made and the new user experience that it creates)
The construct we use to upload batch artifacts prunes the target bucket by default. I have disabled that functionality and also moved the artifacts one level deeper in the parent bucket. This will keep the root folder clean and allow us to reenable pruning if we ever need since it won't target the whole bucket.

**Description of how you validated changes**

[//]: #  (A description of you validated your changes and any relevant logs that show your change works)
`agc account activate` and ran hello workflows for cromwell and miniwdl contexts to verify they still run successfully.

**Checklist**

- [x] If this change would make any existing documentation invalid, I have included those updates within this PR
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have linted my code before raising the PR
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
