### PR TITLE
feat: stop discarding un-actionable deployment errors

### DIFF
--- a/packages/cli/internal/pkg/cli/context_deploy.go
+++ b/packages/cli/internal/pkg/cli/context_deploy.go
@@ -118,12 +118,12 @@ func (o *deployContextOpts) deployContexts() error {
 			var actionableError *actionableerror.Error
 			if errors.As(failedDeployment.Err, &actionableError) {
 				log.Error().Err(actionableError.Cause).Msgf(actionableError.Error())
-				aggregateSuggestions = append(aggregateSuggestions, fmt.Sprintf("To resolve failure %d, try: %s", i + 1, actionableError.SuggestedAction))
+				aggregateSuggestions = append(aggregateSuggestions, fmt.Sprintf("To resolve failure %d, try: %s", i+1, actionableError.SuggestedAction))
 			} else {
 				// An error occurred that we don't know how to deal with
 				// already. We can't swallow it or it will be impossible for
 				// the user to report or fix.
-				aggregateSuggestions = append(aggregateSuggestions, fmt.Sprintf("To resolve failure %d, determine the cause of: %v", i + 1, failedDeployment.Err))
+				aggregateSuggestions = append(aggregateSuggestions, fmt.Sprintf("To resolve failure %d, determine the cause of: %v", i+1, failedDeployment.Err))
 			}
 		}
 

--- a/packages/cli/internal/pkg/cli/context_deploy.go
+++ b/packages/cli/internal/pkg/cli/context_deploy.go
@@ -118,11 +118,16 @@ func (o *deployContextOpts) deployContexts() error {
 			var actionableError *actionableerror.Error
 			if errors.As(failedDeployment.Err, &actionableError) {
 				log.Error().Err(actionableError.Cause).Msgf(actionableError.Error())
-				aggregateSuggestions = append(aggregateSuggestions, actionableError.SuggestedAction)
+				aggregateSuggestions = append(aggregateSuggestions, fmt.Sprintf("To resolve failure %d, try: %s", i + 1, actionableError.SuggestedAction))
+			} else {
+				// An error occurred that we don't know how to deal with
+				// already. We can't swallow it or it will be impossible for
+				// the user to report or fix.
+				aggregateSuggestions = append(aggregateSuggestions, fmt.Sprintf("To resolve failure %d, determine the cause of: %v", i + 1, failedDeployment.Err))
 			}
 		}
 
-		return actionableerror.New(fmt.Errorf("one or more contexts failed to deploy"), strings.Join(aggregateSuggestions, ", "))
+		return actionableerror.New(fmt.Errorf("%d context deployment failures", failedDeploymentsLength), strings.Join(aggregateSuggestions, "\n"))
 	}
 
 	return nil


### PR DESCRIPTION
<!-- Title format: type(scope): Short description (72 chars max for line) -->
<!-- `(scope)` is optional and `type` is one of: build, ci, chore, docs, feat, fix, perf, refactor, revert, style, test -->
<!-- Available types:
- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit -->

Issue #, if available:

**Description of Changes**

[//]: #  (A description of the change that you made and the new user experience that it creates)

Not having a Docker repository exist was a non-actionable error, and so it
would result in a message saying that contexts failed to deploy because one or
more contexts failed to deploy.

This should aggregate even non-actionable errors into something that might, in
fact, be actionable.

**Description of how you validated changes**

[//]: #  (A description of you validated your changes and any relevant logs that show your change works)

Validated by re-running a failing deployment and noting that an error message was printed referring to the underlying error.

**Checklist**

- [X] If this change would make any existing documentation invalid, I have included those updates within this PR
- [ ] I have added unit tests that prove my fix is effective or that my feature works
  I haven't done this; none of this UI stuff appears to be under test at the moment, so there's no test to edit to match the new output.
- [X] I have linted my code before raising the PR
- [X] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
