### PR TITLE
feat: add a global --silent flag (#219)

### DIFF
--- a/packages/cli/internal/pkg/aws/cdk/progress.go
+++ b/packages/cli/internal/pkg/aws/cdk/progress.go
@@ -51,19 +51,27 @@ func (p ProgressStream) DisplayProgress(description string) error {
 	return nil
 }
 
-func ShowExecution(progressStreams []ProgressStream) []Result {
+func performExecution(progressStreams []ProgressStream, showLogging bool) []Result {
 	var keyToEventMap = make(map[string]ProgressEvent)
 
 	combinedStream := combineProgressEvents(progressStreams)
 
 	for event := range combinedStream {
-		if event.LastOutput != "" {
+		if showLogging && event.LastOutput != "" {
 			log.Info().Msg(event.LastOutput)
 		}
 		keyToEventMap[event.ExecutionName] = event
 	}
 
 	return convertProgressEventsToResults(keyToEventMap, len(progressStreams))
+}
+
+func SilentExecution(progressStreams []ProgressStream) []Result {
+	return performExecution(progressStreams, false)
+}
+
+func ShowExecution(progressStreams []ProgressStream) []Result {
+	return performExecution(progressStreams, true)
 }
 
 func updateResultFromStream(stream ProgressStream, progressResult *Result, wait *sync.WaitGroup) {

--- a/packages/cli/internal/pkg/cli/context/manager.go
+++ b/packages/cli/internal/pkg/cli/context/manager.go
@@ -83,6 +83,7 @@ type ProgressResult struct {
 
 var displayProgressBar = cdk.DisplayProgressBar
 var showExecution = cdk.ShowExecution
+var silentExecution = cdk.SilentExecution
 
 func (m *Manager) getEnvironmentVars() []string {
 	var environmentVars []string
@@ -266,6 +267,8 @@ func (m *Manager) processExecution(allProgressStreams []cdk.ProgressStream, desc
 	var cdkResults []cdk.Result
 	if logging.Verbose {
 		cdkResults = showExecution(allProgressStreams)
+	} else if logging.Silent {
+		cdkResults = silentExecution(allProgressStreams)
 	} else {
 		cdkResults = displayProgressBar(description, allProgressStreams)
 	}

--- a/packages/cli/internal/pkg/cli/context/manager_test.go
+++ b/packages/cli/internal/pkg/cli/context/manager_test.go
@@ -51,3 +51,49 @@ func TestManager_ProcessExecution(t *testing.T) {
 	}
 	assert.ElementsMatch(t, expectedProgressResults, manager.progressResults)
 }
+
+func TestManager_ProcessExecutionSilent(t *testing.T) {
+	origVerbose := logging.Verbose
+	origSilent := logging.Silent
+	origSilentExecution := silentExecution
+	defer func() {
+		logging.Verbose = origVerbose
+		logging.Silent = origSilent
+		silentExecution = origSilentExecution
+	}()
+	logging.Verbose = false
+	logging.Silent = true
+
+	mockClients := createMocks(t)
+
+	silentExecution = mockClients.cdkMock.SilentExecution
+	cdkResults := []cdk.Result{{Outputs: []string{"some message"}, ExecutionName: testContextName1}, {ExecutionName: testContextName2, Err: errors.New("Some error")}}
+	progressStreams := []cdk.ProgressStream{mockClients.progressStream1, mockClients.progressStream2}
+	mockClients.cdkMock.EXPECT().SilentExecution(progressStreams).Return(cdkResults)
+	defer close(mockClients.progressStream1)
+	defer close(mockClients.progressStream2)
+
+	defer mockClients.ctrl.Finish()
+	manager := Manager{
+		Cdk:       mockClients.cdkMock,
+		Project:   mockClients.projMock,
+		Ssm:       mockClients.ssmMock,
+		Config:    mockClients.configMock,
+		Cfn:       mockClients.cfnMock,
+		baseProps: baseProps{homeDir: testHomeDir},
+	}
+
+	manager.processExecution(progressStreams, "some description")
+
+	expectedProgressResults := []ProgressResult{
+		{
+			Context: testContextName1,
+			Outputs: []string{"some message"},
+		},
+		{
+			Context: testContextName2,
+			Err:     errors.New("Some error"),
+		},
+	}
+	assert.ElementsMatch(t, expectedProgressResults, manager.progressResults)
+}

--- a/packages/cli/internal/pkg/cli/flag.go
+++ b/packages/cli/internal/pkg/cli/flag.go
@@ -16,6 +16,12 @@ const (
 )
 
 const (
+	SilentFlag            = "silent"
+	SilentFlagShort       = "s"
+	SilentFlagDescription = "Suppresses all diagnostic information."
+)
+
+const (
 	FormatFlag            = "format"
 	FormatFlagDescription = "Format option for output. Valid options are: text, table"
 )

--- a/packages/cli/internal/pkg/logging/logging.go
+++ b/packages/cli/internal/pkg/logging/logging.go
@@ -20,6 +20,7 @@ const (
 )
 
 var Verbose bool
+var Silent bool
 
 // ApplicationConsoleLogger generates a zerolog Logger that pretty prints text (not JSON) to STDERR.
 //

--- a/packages/cli/internal/pkg/mocks/aws/mock_interfaces.go
+++ b/packages/cli/internal/pkg/mocks/aws/mock_interfaces.go
@@ -114,6 +114,20 @@ func (mr *MockCdkClientMockRecorder) ShowExecution(progressEvents interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShowExecution", reflect.TypeOf((*MockCdkClient)(nil).ShowExecution), progressEvents)
 }
 
+// SilentExecution mocks base method.
+func (m *MockCdkClient) SilentExecution(progressEvents []cdk.ProgressStream) []cdk.Result {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SilentExecution", progressEvents)
+	ret0, _ := ret[0].([]cdk.Result)
+	return ret0
+}
+
+// SilentExecution indicates an expected call of SilentExecution.
+func (mr *MockCdkClientMockRecorder) SilentExecution(progressEvents interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SilentExecution", reflect.TypeOf((*MockCdkClient)(nil).SilentExecution), progressEvents)
+}
+
 // MockS3Client is a mock of S3Client interface.
 type MockS3Client struct {
 	ctrl     *gomock.Controller

--- a/site/content/en/docs/Getting started/installation.md
+++ b/site/content/en/docs/Getting started/installation.md
@@ -56,6 +56,7 @@ Commands
 Flags
       --format string   Format option for output. Valid options are: text, table (default "text")
   -h, --help            help for agc
+  -s, --silent          Suppresses all diagnostic information.
   -v, --verbose         Display verbose diagnostic information.
       --version         version for agc
 Examples
@@ -98,7 +99,7 @@ Amazon Genomics CLI can generate shell completion scripts that enable 'Tab' comp
 Command completion is optional and not required to use Amazon Genomics CLI. To generate a completion script you can use:
 
 ```shell
- agc generate <shell>
+ agc completion <shell>
 ``` 
 
 where "shell" is one of:


### PR DESCRIPTION
<!-- Title format: type(scope): Short description (72 chars max for line) -->
<!-- `(scope)` is optional and `type` is one of: build, ci, chore, docs, feat, fix, perf, refactor, revert, style, test -->
<!-- Available types:
- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit -->

Issue #, if available: https://github.com/aws/amazon-genomics-cli/issues/219

**Description of Changes**

Add a new "--silent" flag that suppresses all diagnostic information (no progress, no cdk output, no logs on success)

**Description of how you validated changes**

Test commands with and without the `--silent` flag

```
dtzeng@u787d729b615b5f:/workplace/dtzeng/amazon-genomics-cli/examples/demo-wdl-project$ ../../scripts/run-dev.sh 
Setting up CDK
Running the agc CLI
  ^C will interrupt the agc command
  To exit this script, use ^\ or ^Z
 
$ agc help
🧬 Launch and manage genomics workloads on AWS.
 
Commands 
  Getting Started 🌱
    account     Commands for AWS account setup.
                Install or remove AGC from your account.
 
  Contexts
    context     Commands for contexts.
                Contexts specify workflow engines and computational fleets to use when running a workflow.
 
  Logs
    logs        Commands for various logs.
 
  Projects
    project     Commands to interact with projects.
 
  Workflows
    workflow    Commands for workflows.
                Workflows are potentially-dynamic graphs of computational tasks to execute.
 
  Settings ⚙️
    configure   Commands for configuration.
                Configuration is stored per user.
 
Flags
      --format string   Format option for output. Valid options are: text, table
  -h, --help            help for agc
  -s, --silent          Suppresses all diagnostic information.
  -v, --verbose         Display verbose diagnostic information.
Examples
  Displays the help menu for the specified sub-command.
  `$ agc account --help`
$ agc workflow status --silent --verbose
Error: cannot use both verbose and silent flags
$ agc workflow status
2022-01-19T18:10:57-08:00 𝒊  Showing workflow run(s). Max Runs: 20
WORKFLOWINSTANCE	myContext	ee3a3093-e020-45fd-8c7d-0daf77834582	true	COMPLETE	2022-01-18T22:35:00Z	hello
$ agc workflow status --silent
WORKFLOWINSTANCE	myContext	ee3a3093-e020-45fd-8c7d-0daf77834582	true	COMPLETE	2022-01-18T22:35:00Z	hello
$ agc 
$ agc context deploy --context myContext
2022-01-19T18:11:35-08:00 𝒊  Deploying context(s)
Deploying resources for context(s) [myContext] [--o-] 54s                                                                                                                                                              2022-01-19T18:12:32-08:00 𝒊  Successfully deployed context(s) [myContext]
$ agc context deploy --context myContext --silent
$ agc 
```


**Checklist**

- [x] If this change would make any existing documentation invalid, I have included those updates within this PR
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have linted my code before raising the PR
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
