### PR TITLE
fix: correctly handle missing return code from Cromwell executions

### DIFF
--- a/packages/cdk/lib/wes_adapter/amazon_genomics/wes/adapters/CromwellWESAdapter.py
+++ b/packages/cdk/lib/wes_adapter/amazon_genomics/wes/adapters/CromwellWESAdapter.py
@@ -339,7 +339,7 @@ class CromwellWESAdapter(AbstractWESAdapter):  # inherit from ABC to enforce int
                     "end_time": task.get("end"),
                     "stdout": task.get("stdout"),
                     "stderr": task.get("stderr"),
-                    "exit_code": task.get("returnCode"),
+                    "exit_code": ("" if task.get("returnCode") == None else str(task.get("returnCode"))),
                 }
                 task_logs.append(log)
 

--- a/packages/cli/internal/pkg/cli/logs_workflow.go
+++ b/packages/cli/internal/pkg/cli/logs_workflow.go
@@ -183,7 +183,7 @@ func (o *logsWorkflowOpts) getJobIds(tasks []workflow.Task) ([]string, error) {
 
 	var jobIds []string
 	for _, task := range tasks {
-		if o.failedTasks && task.ExitCode == 0 {
+		if o.failedTasks && task.ExitCode == "0" {
 			log.Debug().Msgf("skipping successful task '%s' ('%s')", task.Name, task.JobId)
 			continue
 		}

--- a/packages/cli/internal/pkg/cli/logs_workflow_test.go
+++ b/packages/cli/internal/pkg/cli/logs_workflow_test.go
@@ -145,7 +145,7 @@ func TestLogsWorkflowOpts_Execute(t *testing.T) {
 				opts.workflowManager.(*managermocks.MockWorkflowManager).EXPECT().
 					GetRunLog(testRunId).Return(testRunLog, nil)
 			},
-			expectedOutput: "RunId: Test Workflow Run Id\nState: COMPLETE\nTasks: \n\tName\t\tJobId\t\tStartTime\tStopTimeExitCode\n\tTest Task Name\tTest Job Id\t<nil>\t\t<nil>\t0\n\t\n",
+			expectedOutput: "RunId: Test Workflow Run Id\nState: COMPLETE\nTasks: \n\tName\t\tJobId\t\tStartTime\tStopTimeExitCode\n\tTest Task Name\tTest Job Id\t<nil>\t\t<nil>\t\n\t\n",
 		},
 		"runId no jobs": {
 			setupOps: func(opts *logsWorkflowOpts, cwlLopPaginator *awsmocks.MockCwlLogPaginator) {
@@ -172,7 +172,7 @@ func TestLogsWorkflowOpts_Execute(t *testing.T) {
 					Tasks: []workflow.Task{testCachedTask},
 				}, nil)
 			},
-			expectedOutput: "RunId: Test Workflow Run Id\nState: COMPLETE\nTasks: \n\tName\t\tJobId\tStartTime\tStopTimeExitCode\n\tTest Task Name\tXXXXX\t<nil>\t\t<nil>\t0\n\t\n",
+			expectedOutput: "RunId: Test Workflow Run Id\nState: COMPLETE\nTasks: \n\tName\t\tJobId\tStartTime\tStopTimeExitCode\n\tTest Task Name\tXXXXX\t<nil>\t\t<nil>\t\n\t\n",
 		},
 		"workflow name single task empty log": {
 			setupOps: func(opts *logsWorkflowOpts, cwlLopPaginator *awsmocks.MockCwlLogPaginator) {

--- a/packages/cli/internal/pkg/cli/workflow/workflow_tasks.go
+++ b/packages/cli/internal/pkg/cli/workflow/workflow_tasks.go
@@ -14,7 +14,7 @@ type Task struct {
 	JobId     string
 	StartTime *time.Time
 	StopTime  *time.Time
-	ExitCode  int
+	ExitCode  string
 }
 
 type RunLog struct {
@@ -90,7 +90,7 @@ func (m *Manager) getTasks() ([]Task, error) {
 			JobId:     nameParts[1],
 			StartTime: parseLogTime(taskLog.StartTime),
 			StopTime:  parseLogTime(taskLog.EndTime),
-			ExitCode:  int(taskLog.ExitCode),
+			ExitCode:  taskLog.ExitCode,
 		}
 	}
 

--- a/packages/cli/internal/pkg/cli/workflow/workflow_tasks_test.go
+++ b/packages/cli/internal/pkg/cli/workflow/workflow_tasks_test.go
@@ -23,7 +23,7 @@ const (
 	testRunId     = "test-run-id"
 	testTaskName  = "test-task-name"
 	testTaskJobId = "test-task-job-id"
-	testExitCode  = 0
+	testExitCode  = "0"
 )
 
 var (

--- a/packages/wes_api/client/model_log.go
+++ b/packages/wes_api/client/model_log.go
@@ -31,5 +31,5 @@ type Log struct {
 	Stderr string `json:"stderr,omitempty"`
 
 	// Exit code of the program
-	ExitCode int32 `json:"exit_code,omitempty"`
+	ExitCode string `json:"exit_code,omitempty"`
 }


### PR DESCRIPTION
<!-- Title format: type(scope): Short description (72 chars max for line) -->
<!-- `(scope)` is optional and `type` is one of: build, ci, chore, docs, feat, fix, perf, refactor, revert, style, test -->
<!-- Available types:
- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit -->

Issue #, if available:

**Description of Changes**

* In its current state, if the job is successfully, the returnCode for all tasks will show 0. In the metadata received from Cromwell engine, we see the returnCode for the task being 0.
* Similarly, if the job has failed, the returnCode for all tasks will still show 0. However, in the metadata received from Cromwell engine we don’t see any returnCode key.

In its current state, when the job has failed, the returnCode is not accurate and therefore not useful. As we are unable to retrieve a returnCode from Cromwell on a failed job at times, with this new change, we will instead display an empty string (instead of 0) when returnCode is not available in order to not provide misleading information to customers.

[//]: #  (A description of the change that you made and the new user experience that it creates)

**Description of how you validated changes**

[//]: #  (A description of you validated your changes and any relevant logs that show your change works)
Ran multiple workflows and below are examples of a successful and failed workflow and both exit codes have the expected return values. 

<img width="1410" alt="Screen Shot 2022-01-23 at 7 55 22 PM" src="https://user-images.githubusercontent.com/7497012/150734585-3b23815c-6430-4542-bc64-3ee7c5a2c0bd.png">
<img width="1676" alt="Screen Shot 2022-01-23 at 8 00 23 PM" src="https://user-images.githubusercontent.com/7497012/150734606-c2b1f937-d05f-4af1-bee5-06b830ff9268.png">


**Checklist**

- [X] If this change would make any existing documentation invalid, I have included those updates within this PR
- [X] I have added unit tests that prove my fix is effective or that my feature works
- [X] I have linted my code before raising the PR
- [X] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
