### PR TITLE
fix: Nextflow workflow logs unable to deserialize

### DIFF
--- a/packages/cdk/lib/wes_adapter/amazon_genomics/wes/adapters/BatchAdapter.py
+++ b/packages/cdk/lib/wes_adapter/amazon_genomics/wes/adapters/BatchAdapter.py
@@ -230,6 +230,7 @@ class BatchAdapter(AbstractWESAdapter):
 
         start_time = to_iso(job_details.get("startedAt"))
         end_time = to_iso(job_details.get("stoppedAt"))
+        exitCode = job_details["container"].get("exitCode")
 
         return Log(
             name=task_name,
@@ -237,7 +238,7 @@ class BatchAdapter(AbstractWESAdapter):
             start_time=start_time,
             end_time=end_time,
             stdout=job_details["container"].get("logStreamName"),
-            exit_code=job_details["container"].get("exitCode"),
+            exit_code= ("" if exitCode == None else str(exitCode)),
         )
 
 


### PR DESCRIPTION
<!-- Title format: type(scope): Short description (72 chars max for line) -->
<!-- `(scope)` is optional and `type` is one of: build, ci, chore, docs, feat, fix, perf, refactor, revert, style, test -->
<!-- Available types:
- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit -->

Issue #, if available:

**Description of Changes**

[//]: #  (A description of the change that you made and the new user experience that it creates)
Nextflow workflow logs unable to unmarshal number. This is causing nextflow workflows to not show any workflow logs. 

**Description of how you validated changes**

[//]: #  (A description of you validated your changes and any relevant logs that show your change works)
I deployed a workflow for miniwdl, Cromwell, Nextflow engines. 

This is running hello workflow for nextflow for onDemandContext

```
$ agc workflow run hello -c onDemandContext -v
2022-01-28T17:29:53-08:00 ↓  Checking AGC version...
2022-01-28T17:29:53-08:00 𝒊  Running workflow. Workflow name: 'hello', Arguments: '', Context: 'onDemandContext'
2022-01-28T17:29:55-08:00 ↓  No Manifest file was found in folder /var/folders/z_/x3wsksxs26q4z5k3qn0ps56w0000gs/T/workflow_3153495673
2022-01-28T17:29:56-08:00 ↓  EstablishWesConnection(https://vpvja44zi2.execute-api.us-west-2.amazonaws.com/prod/ga4gh/wes/v1)
2022-01-28T17:29:56-08:00 ↓  Ping WES endpoint until we get an answer:
2022-01-28T17:29:56-08:00 ↓  Attempt 1 of 3
2022-01-28T17:29:59-08:00 ↓  Connected to WES endpoint
b598020a-bc12-419e-845e-0612cc88c051
$ agc logs workflow hello -r b598020a-bc12-419e-845e-0612cc88c051
2022-01-28T17:30:15-08:00 𝒊  Showing the logs for 'hello'
RunId: b598020a-bc12-419e-845e-0612cc88c051
State: QUEUED
Tasks: No task logs available
$ agc logs workflow hello -r b598020a-bc12-419e-845e-0612cc88c051
2022-01-28T17:37:07-08:00 𝒊  Showing the logs for 'hello'
RunId: b598020a-bc12-419e-845e-0612cc88c051
State: COMPLETE
Tasks: 
	Name		JobId					StartTime				StopTime				ExitCode
	sayHello_3	30399990-b99e-4cbc-87f0-dd5436e05d48	2022-01-29 01:34:50.705 +0000 +0000	2022-01-29 01:34:57.177 +0000 +0000	0
	sayHello_1	4f75d21e-0ffe-4813-83af-b5ac44ef184c	2022-01-29 01:34:19.825 +0000 +0000	2022-01-29 01:34:26.275 +0000 +0000	0
	sayHello_4	7d474e9f-c339-49be-8455-f6d60fda7228	2022-01-29 01:33:23.811 +0000 +0000	2022-01-29 01:33:30.304 +0000 +0000	0
	sayHello_2	32b213bc-7fe3-4b8e-b896-f99c6a29c200	2022-01-29 01:33:49.342 +0000 +0000	2022-01-29 01:33:55.686 +0000 +0000	0
```

**Checklist**

- [X] If this change would make any existing documentation invalid, I have included those updates within this PR
- [X] I have added unit tests that prove my fix is effective or that my feature works
- [X] I have linted my code before raising the PR
- [X] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
