### PR TITLE
fix: force use node v14 in cdk package

### DIFF
--- a/packages/cdk/.npmrc
+++ b/packages/cdk/.npmrc
@@ -1,0 +1,2 @@
+engine-strict=true
+package-lock=false

--- a/packages/cdk/.npmrc
+++ b/packages/cdk/.npmrc
@@ -1,2 +1,1 @@
-engine-strict=true
 lockfile-version=1

--- a/packages/cdk/.npmrc
+++ b/packages/cdk/.npmrc
@@ -1,2 +1,2 @@
 engine-strict=true
-package-lock=false
+lockfile-version=1

--- a/packages/cdk/Makefile
+++ b/packages/cdk/Makefile
@@ -12,7 +12,7 @@ format:
 	npm run format
 
 init: 
-	npm ci
+	npm ci --loglevel error
 
 release:
 	npm shrinkwrap && npm pack --silent | xargs -I '{}' mv {} cdk.tgz

--- a/packages/cdk/Makefile
+++ b/packages/cdk/Makefile
@@ -12,7 +12,7 @@ format:
 	npm run format
 
 init: 
-	npm ci --silent
+	npm ci
 
 release:
 	npm shrinkwrap && npm pack --silent | xargs -I '{}' mv {} cdk.tgz

--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -3,10 +3,6 @@
   "version": "0.1.0",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "engines": {
-    "node": ">=14.0.0",
-    "npm": ">=6.0.0"
-  },
   "scripts": {
     "build": "tsc",
     "format": "prettier --write '{**/*,*}.{ts,tsx}'",

--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -4,8 +4,8 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "engines": {
-    "node": "^14",
-    "npm": "^6"
+    "node": ">=14.0.0",
+    "npm": ">=6.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -3,6 +3,10 @@
   "version": "0.1.0",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "engines": {
+    "node": "^14",
+    "npm": "^6"
+  },
   "scripts": {
     "build": "tsc",
     "format": "prettier --write '{**/*,*}.{ts,tsx}'",


### PR DESCRIPTION
<!-- Title format: type(scope): Short description (72 chars max for line) -->
<!-- `(scope)` is optional and `type` is one of: build, ci, chore, docs, feat, fix, perf, refactor, revert, style, test -->
<!-- Available types:
- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit -->

Issue #, if available: [294](https://github.com/aws/amazon-genomics-cli/issues/294), [292](https://github.com/aws/amazon-genomics-cli/issues/292)

**Description of Changes**
Force use version 14 when running npm

[//]: #  (A description of the change that you made and the new user experience that it creates)

**Description of how you validated changes**
Ran `make init` which calls `npm ci` with version 15, 16, 17 and verified failure with message engine node version is not v14. Reran `make init` with version 14 succeeded.

[//]: #  (A description of you validated your changes and any relevant logs that show your change works)
v17 logs
```
npm ERR! code EBADENGINE
npm ERR! engine Unsupported engine
npm ERR! engine Not compatible with your version of node/npm: cdk@0.1.0
npm ERR! notsup Not compatible with your version of node/npm: cdk@0.1.0
npm ERR! notsup Required: {"node":"^14","npm":"^6"}
npm ERR! notsup Actual:   {"npm":"8.3.1","node":"v17.4.0"}

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/chuanyut/.npm/_logs/2022-02-01T23_35_58_661Z-debug-0.log
make: *** [init] Error 1
```

v14 logs
```
npm WARN prepare removing existing node_modules/ before installation
added 830 packages in 10.981s
```

**Checklist**

- [x] If this change would make any existing documentation invalid, I have included those updates within this PR
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have linted my code before raising the PR
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
