### PR TITLE
feat: don't use ebs auto scale for minidl

### DIFF
--- a/packages/cdk/lib/artifacts/batch-artifacts/ecs-additions/get-amazon-ebs-autoscale.sh
+++ b/packages/cdk/lib/artifacts/batch-artifacts/ecs-additions/get-amazon-ebs-autoscale.sh
@@ -4,6 +4,7 @@ set -x
 
 INSTALL_VERSION=dist_release
 FILESYSTEM=btrfs
+INITIAL_SIZE=200
 
 USAGE=$(cat <<EOF
 Retrieve and install Amazon EBS Autoscale
@@ -53,7 +54,11 @@ while (( "$#" )); do
             shift 2
             ;;
         -f|--file-system)
-            FILE_SYSTEM=$2
+            FILESYSTEM=$2
+            shift 2
+            ;;
+        -s|--initial-size)
+            INITIAL_SIZE=$2
             shift 2
             ;;
         -h|--help)
@@ -122,7 +127,7 @@ function s3CopyWithRetry() {
             echo "failed to copy $s3_path after $i attempts. aborting"
             exit 2
         fi
-        sleep $((7 * $i))
+        sleep $((7 * i))
     done
 }
 

--- a/packages/cdk/lib/artifacts/batch-artifacts/ecs-additions/provision.sh
+++ b/packages/cdk/lib/artifacts/batch-artifacts/ecs-additions/provision.sh
@@ -7,8 +7,7 @@ export OS=`uname -r`
 BASEDIR=`dirname $0`
 
 # Expected environment variables
-#   GWFCORE_NAMESPACE
-#   ARTIFACT_S3_ROOT_URL
+#   ARTIFACT_S3_ROOT_URL (obtained from SSM parameter store)
 #   WORKFLOW_ORCHESTRATOR (OPTIONAL)
 
 printenv
@@ -62,11 +61,15 @@ ARTIFACT_S3_ROOT_URL=$(\
 
 
 # retrieve and install amazon-ebs-autoscale
-cd /opt
-sh $BASEDIR/get-amazon-ebs-autoscale.sh \
-    --install-version dist_release \
-    --artifact-root-url $ARTIFACT_S3_ROOT_URL \
-    --file-system btrfs
+if [ "$WORKFLOW_ORCHESTRATOR" != "miniwdl" ]; then
+  initial_ebs_size=200
+  cd /opt
+  sh $BASEDIR/get-amazon-ebs-autoscale.sh \
+      --install-version dist_release \
+      --artifact-root-url "$ARTIFACT_S3_ROOT_URL" \
+      --file-system btrfs \
+      --initial-size "$initial_ebs_size"
+fi
 
 # common provisioning for all workflow orchestrators
 cd /opt

--- a/packages/cdk/lib/artifacts/batch-artifacts/ecs-additions/provision.sh
+++ b/packages/cdk/lib/artifacts/batch-artifacts/ecs-additions/provision.sh
@@ -5,6 +5,7 @@ set -x
 
 export OS=`uname -r`
 BASEDIR=`dirname $0`
+INITIAL_EBS_SIZE="${$1:-200}"
 
 # Expected environment variables
 #   ARTIFACT_S3_ROOT_URL (obtained from SSM parameter store)
@@ -62,13 +63,12 @@ ARTIFACT_S3_ROOT_URL=$(\
 
 # retrieve and install amazon-ebs-autoscale
 if [ "$WORKFLOW_ORCHESTRATOR" != "miniwdl" ]; then
-  initial_ebs_size=200
   cd /opt
   sh $BASEDIR/get-amazon-ebs-autoscale.sh \
       --install-version dist_release \
       --artifact-root-url "$ARTIFACT_S3_ROOT_URL" \
       --file-system btrfs \
-      --initial-size "$initial_ebs_size"
+      --initial-size "$INITIAL_EBS_SIZE"
 fi
 
 # common provisioning for all workflow orchestrators

--- a/packages/cdk/lib/constants.ts
+++ b/packages/cdk/lib/constants.ts
@@ -1,5 +1,3 @@
-import * as path from "path";
-
 export const PRODUCT_NAME = "Agc";
 export const APP_NAME = "agc";
 export const APP_ENV_NAME = "AGC";
@@ -14,5 +12,3 @@ export const VPC_PARAMETER_NAME = "vpc";
 export const ENGINE_CROMWELL = "cromwell";
 export const ENGINE_MINIWDL = "miniwdl";
 export const ENGINE_NEXTFLOW = "nextflow";
-
-export const wesAdapterSourcePath = path.resolve(path.join(__dirname, "./wes_adapter"));

--- a/packages/cdk/lib/constants.ts
+++ b/packages/cdk/lib/constants.ts
@@ -1,3 +1,5 @@
+import * as path from "path";
+
 export const PRODUCT_NAME = "Agc";
 export const APP_NAME = "agc";
 export const APP_ENV_NAME = "AGC";
@@ -9,102 +11,8 @@ export const USER_EMAIL_TAG_KEY = `${APP_NAME}-user-email`;
 export const AGC_VERSION_KEY = `${APP_NAME}-version`;
 export const VPC_PARAMETER_NAME = "vpc";
 
-export const LAUNCH_TEMPLATE = `MIME-Version: 1.0
-Content-Type: multipart/mixed; boundary="==MYBOUNDARY=="
+export const ENGINE_CROMWELL = "cromwell";
+export const ENGINE_MINIWDL = "miniwdl";
+export const ENGINE_NEXTFLOW = "nextflow";
 
---==MYBOUNDARY==
-Content-Type: text/cloud-config; charset="us-ascii"
-
-packages:
-- jq
-- grep
-- btrfs-progs
-- sed
-- git
-- unzip
-- amazon-cloudwatch-agent
-
-write_files:
-- permissions: '0644'
-  path: /opt/aws/amazon-cloudwatch-agent/etc/config.json
-  content: |
-    {
-      "agent": {
-        "logfile": "/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log"
-      },
-      "logs": {
-        "logs_collected": {
-          "files": {
-            "collect_list": [
-              {
-                "file_path": "/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log",
-                "log_group_name": "/aws/ecs/container-instance/${APP_NAME}",
-                "log_stream_name": "/aws/ecs/container-instance/${APP_NAME}/{instance_id}/amazon-cloudwatch-agent.log"
-              },
-              {
-                "file_path": "/var/log/cloud-init.log",
-                "log_group_name": "/aws/ecs/container-instance/${APP_NAME}",
-                "log_stream_name": "/aws/ecs/container-instance/${APP_NAME}/{instance_id}/cloud-init.log"
-              },
-              {
-                "file_path": "/var/log/cloud-init-output.log",
-                "log_group_name": "/aws/ecs/container-instance/${APP_NAME}",
-                "log_stream_name": "/aws/ecs/container-instance/${APP_NAME}/{instance_id}/cloud-init-output.log"
-              },
-              {
-                "file_path": "/var/log/ecs/ecs-init.log",
-                "log_group_name": "/aws/ecs/container-instance/${APP_NAME}",
-                "log_stream_name": "/aws/ecs/container-instance/${APP_NAME}/{instance_id}/ecs-init.log"
-              },
-              {
-                "file_path": "/var/log/ecs/ecs-agent.log",
-                "log_group_name": "/aws/ecs/container-instance/${APP_NAME}",
-                "log_stream_name": "/aws/ecs/container-instance/${APP_NAME}/{instance_id}/ecs-agent.log"
-              },
-              {
-                "file_path": "/var/log/ecs/ecs-volume-plugin.log",
-                "log_group_name": "/aws/ecs/container-instance/${APP_NAME}",
-                "log_stream_name": "/aws/ecs/container-instance/${APP_NAME}/{instance_id}/ecs-volume-plugin.log"
-              }
-            ]
-          }
-        }
-      }
-    }
-
-runcmd:
-
-# start the amazon-cloudwatch-agent
-- /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/opt/aws/amazon-cloudwatch-agent/etc/config.json
-- /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -m ec2 -a status | jq -r '.status' | grep -iw "running" || sleep 5 && /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/opt/aws/amazon-cloudwatch-agent/etc/config.json
-- /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -m ec2 -a status | jq -r '.status' | grep -iw "running" || sleep 10 && /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/opt/aws/amazon-cloudwatch-agent/etc/config.json
-- /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -m ec2 -a status | jq -r '.status' | grep -iw "running" || shutdown -P now
-
-# install aws-cli v2 and copy the static binary in an easy to find location for bind-mounts into containers
-- mkdir -p /opt/aws-cli/bin
-- curl -s "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip" && unzip -q /tmp/awscliv2.zip -d /tmp && /tmp/aws/install -b /usr/bin && cp -a -f $(dirname $(find /usr/local/aws-cli -name 'aws' -type f))/. /opt/aws-cli/bin/
-- command -v aws || sleep 5 | curl -s "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip" && unzip -q /tmp/awscliv2.zip -d /tmp && /tmp/aws/install -b /usr/bin && cp -a -f $(dirname $(find /usr/local/aws-cli -name 'aws' -type f))/. /opt/aws-cli/bin/
-- command -v aws || sleep 10 | curl -s "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip" && unzip -q /tmp/awscliv2.zip -d /tmp && /tmp/aws/install -b /usr/bin && cp -a -f $(dirname $(find /usr/local/aws-cli -name 'aws' -type f))/. /opt/aws-cli/bin/
-- command -v aws || shutdown -P now
-
-# set environment variables for provisioning
-- export ARTIFACTS_NAMESPACE=${APP_NAME}
-- export INSTALLED_ARTIFACTS_S3_ROOT_URL=$(aws ssm get-parameter --name /\${ARTIFACTS_NAMESPACE}/_common/installed-artifacts/s3-root-url --query 'Parameter.Value' --output text)
-
-# enable ecs spot instance draining
-- echo ECS_ENABLE_SPOT_INSTANCE_DRAINING=true >> /etc/ecs/ecs.config
-
-# pull docker images only if missing
-- echo ECS_IMAGE_PULL_BEHAVIOR=prefer-cached >> /etc/ecs/ecs.config
-
-# Setup ecs additions
-- cd /opt
-- aws s3 sync \${INSTALLED_ARTIFACTS_S3_ROOT_URL}/ecs-additions/ ./ecs-additions && chmod a+x /opt/ecs-additions/provision.sh  
-- test -f ./ecs-additions/fetch_and_run.sh || sleep 5 || aws s3 sync \${INSTALLED_ARTIFACTS_S3_ROOT_URL}/ecs-additions/ ./ecs-additions && chmod a+x /opt/ecs-additions/provision.sh    
-- test -f ./ecs-additions/fetch_and_run.sh || sleep 10 || aws s3 sync \${INSTALLED_ARTIFACTS_S3_ROOT_URL}/ecs-additions/ ./ecs-additions && chmod a+x /opt/ecs-additions/provision.sh    
-- test -f ./ecs-additions/fetch_and_run.sh || shutdown -P now
-- /opt/ecs-additions/provision.sh
-
-- echo "successfully initiated"
---==MYBOUNDARY==--
-`;
+export const wesAdapterSourcePath = path.resolve(path.join(__dirname, "./wes_adapter"));

--- a/packages/cdk/lib/constructs/batch.ts
+++ b/packages/cdk/lib/constructs/batch.ts
@@ -71,6 +71,12 @@ export interface BatchProps extends ComputeOptions {
    * @default - No additional policies are added to the role
    */
   awsPolicyNames?: string[];
+
+  /**
+   * Use this if you need to pass the name of the workflow orchestrator to the LaunchTemplate so that `provision.sh` is
+   * aware of the engine orchestrating the workflow tasks.
+   */
+  workflowOrchestrator?: string;
 }
 
 const defaultComputeType = ComputeResourceType.ON_DEMAND;
@@ -163,6 +169,10 @@ export class Batch extends Construct {
       });
     }
 
+    /*
+     * TAKE NOTE! If you change the launch template you will need to destroy any existing contexts and deploy. A CDK update won't
+     * be enough to trigger an update of the Batch compute environment to use the new template.
+     */
     const launchTemplate = options.launchTemplateData
       ? new CfnLaunchTemplate(this, "LaunchTemplate", {
           launchTemplateName: Names.uniqueId(this),

--- a/packages/cdk/lib/constructs/launch-template-data.ts
+++ b/packages/cdk/lib/constructs/launch-template-data.ts
@@ -82,8 +82,8 @@ runcmd:
 # install aws-cli v2 and copy the static binary in an easy to find location for bind-mounts into containers
 - mkdir -p /opt/aws-cli/bin
 - curl -s "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip" && unzip -q /tmp/awscliv2.zip -d /tmp && /tmp/aws/install -b /usr/bin && cp -a -f $(dirname $(find /usr/local/aws-cli -name 'aws' -type f))/. /opt/aws-cli/bin/
-- command -v aws || sleep 5 | curl -s "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip" && unzip -q /tmp/awscliv2.zip -d /tmp && /tmp/aws/install -b /usr/bin && cp -a -f $(dirname $(find /usr/local/aws-cli -name 'aws' -type f))/. /opt/aws-cli/bin/
-- command -v aws || sleep 10 | curl -s "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip" && unzip -q /tmp/awscliv2.zip -d /tmp && /tmp/aws/install -b /usr/bin && cp -a -f $(dirname $(find /usr/local/aws-cli -name 'aws' -type f))/. /opt/aws-cli/bin/
+- command -v aws || sleep 5 && curl -s "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip" && unzip -q /tmp/awscliv2.zip -d /tmp && /tmp/aws/install -b /usr/bin && cp -a -f $(dirname $(find /usr/local/aws-cli -name 'aws' -type f))/. /opt/aws-cli/bin/
+- command -v aws || sleep 10 && curl -s "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip" && unzip -q /tmp/awscliv2.zip -d /tmp && /tmp/aws/install -b /usr/bin && cp -a -f $(dirname $(find /usr/local/aws-cli -name 'aws' -type f))/. /opt/aws-cli/bin/
 - command -v aws || echo "Unable to install AWS CLI v2"
 
 # set environment variables for provisioning

--- a/packages/cdk/lib/constructs/launch-template-data.ts
+++ b/packages/cdk/lib/constructs/launch-template-data.ts
@@ -100,8 +100,8 @@ runcmd:
 # Setup ecs additions
 - cd /opt
 - aws s3 sync \${INSTALLED_ARTIFACTS_S3_ROOT_URL}/ecs-additions/ ./ecs-additions && chmod a+x /opt/ecs-additions/provision.sh  
-- test -f ./ecs-additions/fetch_and_run.sh || sleep 5 || aws s3 sync \${INSTALLED_ARTIFACTS_S3_ROOT_URL}/ecs-additions/ ./ecs-additions && chmod a+x /opt/ecs-additions/provision.sh    
-- test -f ./ecs-additions/fetch_and_run.sh || sleep 10 || aws s3 sync \${INSTALLED_ARTIFACTS_S3_ROOT_URL}/ecs-additions/ ./ecs-additions && chmod a+x /opt/ecs-additions/provision.sh    
+- test -f ./ecs-additions/fetch_and_run.sh || sleep 5 && aws s3 sync \${INSTALLED_ARTIFACTS_S3_ROOT_URL}/ecs-additions/ ./ecs-additions && chmod a+x /opt/ecs-additions/provision.sh    
+- test -f ./ecs-additions/fetch_and_run.sh || sleep 10 && aws s3 sync \${INSTALLED_ARTIFACTS_S3_ROOT_URL}/ecs-additions/ ./ecs-additions && chmod a+x /opt/ecs-additions/provision.sh    
 - test -f ./ecs-additions/fetch_and_run.sh || echo "Unable to install ecs-additions"
 - /opt/ecs-additions/provision.sh
 

--- a/packages/cdk/lib/constructs/launch-template-data.ts
+++ b/packages/cdk/lib/constructs/launch-template-data.ts
@@ -1,0 +1,112 @@
+import { APP_NAME } from "../constants";
+
+export class LaunchTemplateData {
+  /**
+   * WARNING! Changing the content of the launch template user data WILL NOT cause the redeployment of any AWS Batch
+   * compute environments that use the template. Ensure you create a new Compute Environment by, for example, running:
+   * agc context destroy --all
+   * agc context deploy <context-name>
+   */
+  static renderLaunchTemplateData(workflowOrchestrator: string): string {
+    return `MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="==MYBOUNDARY=="
+
+--==MYBOUNDARY==
+Content-Type: text/cloud-config; charset="us-ascii"
+
+packages:
+- jq
+- grep
+- btrfs-progs
+- sed
+- git
+- unzip
+- amazon-cloudwatch-agent
+
+write_files:
+- permissions: '0644'
+  path: /opt/aws/amazon-cloudwatch-agent/etc/config.json
+  content: |
+    {
+      "agent": {
+        "logfile": "/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log"
+      },
+      "logs": {
+        "logs_collected": {
+          "files": {
+            "collect_list": [
+              {
+                "file_path": "/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log",
+                "log_group_name": "/aws/ecs/container-instance/${APP_NAME}",
+                "log_stream_name": "/aws/ecs/container-instance/${APP_NAME}/{instance_id}/amazon-cloudwatch-agent.log"
+              },
+              {
+                "file_path": "/var/log/cloud-init.log",
+                "log_group_name": "/aws/ecs/container-instance/${APP_NAME}",
+                "log_stream_name": "/aws/ecs/container-instance/${APP_NAME}/{instance_id}/cloud-init.log"
+              },
+              {
+                "file_path": "/var/log/cloud-init-output.log",
+                "log_group_name": "/aws/ecs/container-instance/${APP_NAME}",
+                "log_stream_name": "/aws/ecs/container-instance/${APP_NAME}/{instance_id}/cloud-init-output.log"
+              },
+              {
+                "file_path": "/var/log/ecs/ecs-init.log",
+                "log_group_name": "/aws/ecs/container-instance/${APP_NAME}",
+                "log_stream_name": "/aws/ecs/container-instance/${APP_NAME}/{instance_id}/ecs-init.log"
+              },
+              {
+                "file_path": "/var/log/ecs/ecs-agent.log",
+                "log_group_name": "/aws/ecs/container-instance/${APP_NAME}",
+                "log_stream_name": "/aws/ecs/container-instance/${APP_NAME}/{instance_id}/ecs-agent.log"
+              },
+              {
+                "file_path": "/var/log/ecs/ecs-volume-plugin.log",
+                "log_group_name": "/aws/ecs/container-instance/${APP_NAME}",
+                "log_stream_name": "/aws/ecs/container-instance/${APP_NAME}/{instance_id}/ecs-volume-plugin.log"
+              }
+            ]
+          }
+        }
+      }
+    }
+
+runcmd:
+
+# start the amazon-cloudwatch-agent
+- /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/opt/aws/amazon-cloudwatch-agent/etc/config.json
+- /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -m ec2 -a status | jq -r '.status' | grep -iw "running" || sleep 5 && /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/opt/aws/amazon-cloudwatch-agent/etc/config.json
+- /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -m ec2 -a status | jq -r '.status' | grep -iw "running" || sleep 10 && /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/opt/aws/amazon-cloudwatch-agent/etc/config.json
+- /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -m ec2 -a status | jq -r '.status' | grep -iw "running" || shutdown -P now
+
+# install aws-cli v2 and copy the static binary in an easy to find location for bind-mounts into containers
+- mkdir -p /opt/aws-cli/bin
+- curl -s "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip" && unzip -q /tmp/awscliv2.zip -d /tmp && /tmp/aws/install -b /usr/bin && cp -a -f $(dirname $(find /usr/local/aws-cli -name 'aws' -type f))/. /opt/aws-cli/bin/
+- command -v aws || sleep 5 | curl -s "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip" && unzip -q /tmp/awscliv2.zip -d /tmp && /tmp/aws/install -b /usr/bin && cp -a -f $(dirname $(find /usr/local/aws-cli -name 'aws' -type f))/. /opt/aws-cli/bin/
+- command -v aws || sleep 10 | curl -s "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip" && unzip -q /tmp/awscliv2.zip -d /tmp && /tmp/aws/install -b /usr/bin && cp -a -f $(dirname $(find /usr/local/aws-cli -name 'aws' -type f))/. /opt/aws-cli/bin/
+- command -v aws || echo "Unable to install AWS CLI v2"
+
+# set environment variables for provisioning
+- export ARTIFACTS_NAMESPACE=${APP_NAME}
+- export INSTALLED_ARTIFACTS_S3_ROOT_URL=$(aws ssm get-parameter --name /\${ARTIFACTS_NAMESPACE}/_common/installed-artifacts/s3-root-url --query 'Parameter.Value' --output text)
+- export WORKFLOW_ORCHESTRATOR=${workflowOrchestrator}
+
+# enable ecs spot instance draining
+- echo ECS_ENABLE_SPOT_INSTANCE_DRAINING=true >> /etc/ecs/ecs.config
+
+# pull docker images only if missing
+- echo ECS_IMAGE_PULL_BEHAVIOR=prefer-cached >> /etc/ecs/ecs.config
+
+# Setup ecs additions
+- cd /opt
+- aws s3 sync \${INSTALLED_ARTIFACTS_S3_ROOT_URL}/ecs-additions/ ./ecs-additions && chmod a+x /opt/ecs-additions/provision.sh  
+- test -f ./ecs-additions/fetch_and_run.sh || sleep 5 || aws s3 sync \${INSTALLED_ARTIFACTS_S3_ROOT_URL}/ecs-additions/ ./ecs-additions && chmod a+x /opt/ecs-additions/provision.sh    
+- test -f ./ecs-additions/fetch_and_run.sh || sleep 10 || aws s3 sync \${INSTALLED_ARTIFACTS_S3_ROOT_URL}/ecs-additions/ ./ecs-additions && chmod a+x /opt/ecs-additions/provision.sh    
+- test -f ./ecs-additions/fetch_and_run.sh || echo "Unable to install ecs-additions"
+- /opt/ecs-additions/provision.sh
+
+- echo "successfully initiated"
+--==MYBOUNDARY==--
+`;
+  }
+}

--- a/packages/cdk/lib/stacks/context-stack.ts
+++ b/packages/cdk/lib/stacks/context-stack.ts
@@ -2,7 +2,7 @@ import { Stack, StackProps } from "aws-cdk-lib";
 import { IVpc, Vpc } from "aws-cdk-lib/aws-ec2";
 import { Construct } from "constructs";
 import { getCommonParameter } from "../util";
-import { VPC_PARAMETER_NAME } from "../constants";
+import { ENGINE_CROMWELL, ENGINE_MINIWDL, ENGINE_NEXTFLOW, VPC_PARAMETER_NAME } from "../constants";
 import { ContextAppParameters } from "../env";
 import { BatchConstruct, BatchConstructProps } from "./engines/batch-construct";
 import { CromwellEngineConstruct } from "./engines/cromwell-engine-construct";
@@ -26,13 +26,13 @@ export class ContextStack extends Stack {
     const { engineName } = contextParameters;
 
     switch (engineName) {
-      case "cromwell":
+      case ENGINE_CROMWELL:
         this.renderCromwellStack(props);
         break;
-      case "nextflow":
+      case ENGINE_NEXTFLOW:
         this.renderNextflowStack(props);
         break;
-      case "miniwdl":
+      case ENGINE_MINIWDL:
         this.renderMiniwdlStack(props);
         break;
       default:
@@ -52,7 +52,7 @@ export class ContextStack extends Stack {
     }
 
     const commonEngineProps = this.getCommonEngineProps(props);
-    new CromwellEngineConstruct(this, "cromwell", {
+    new CromwellEngineConstruct(this, ENGINE_CROMWELL, {
       jobQueue,
       ...commonEngineProps,
     }).outputToParent();
@@ -71,7 +71,7 @@ export class ContextStack extends Stack {
     }
 
     const commonEngineProps = this.getCommonEngineProps(props);
-    new NextflowEngineConstruct(this, "nextflow", {
+    new NextflowEngineConstruct(this, ENGINE_NEXTFLOW, {
       ...commonEngineProps,
       jobQueue,
       headQueue,
@@ -80,7 +80,7 @@ export class ContextStack extends Stack {
 
   private renderMiniwdlStack(props: ContextStackProps) {
     const commonEngineProps = this.getCommonEngineProps(props);
-    new MiniwdlEngineConstruct(this, "miniwdl", {
+    new MiniwdlEngineConstruct(this, ENGINE_MINIWDL, {
       ...commonEngineProps,
     }).outputToParent();
   }

--- a/packages/cdk/lib/stacks/engines/batch-construct.ts
+++ b/packages/cdk/lib/stacks/engines/batch-construct.ts
@@ -1,12 +1,12 @@
 import { IVpc } from "aws-cdk-lib/aws-ec2";
 import { Stack } from "aws-cdk-lib";
-import { LAUNCH_TEMPLATE } from "../../constants";
 import { Batch } from "../../constructs";
 import { ContextAppParameters } from "../../env";
 import { BucketOperations } from "../../common/BucketOperations";
 import { IRole } from "aws-cdk-lib/aws-iam";
 import { ComputeResourceType } from "@aws-cdk/aws-batch-alpha";
 import { Construct } from "constructs";
+import { LaunchTemplateData } from "../../constructs/launch-template-data";
 
 export interface BatchConstructProps {
   /**
@@ -62,7 +62,7 @@ export class BatchConstruct extends Construct {
       computeType,
       instanceTypes: appParams.instanceTypes,
       maxVCpus: appParams.maxVCpus,
-      launchTemplateData: LAUNCH_TEMPLATE,
+      launchTemplateData: LaunchTemplateData.renderLaunchTemplateData(appParams.engineName),
       awsPolicyNames: ["AmazonSSMManagedInstanceCore", "CloudWatchAgentServerPolicy"],
       resourceTags: Stack.of(this).tags.tagValues(),
     });

--- a/packages/cdk/lib/stacks/engines/miniwdl-engine-construct.ts
+++ b/packages/cdk/lib/stacks/engines/miniwdl-engine-construct.ts
@@ -6,7 +6,7 @@ import { IRole, PolicyDocument, PolicyStatement, Role, ServicePrincipal, Managed
 import { ILogGroup } from "aws-cdk-lib/aws-logs";
 import { MiniWdlEngine } from "../../constructs/engines/miniwdl/miniwdl-engine";
 import { IVpc } from "aws-cdk-lib/aws-ec2";
-import { LAUNCH_TEMPLATE } from "../../constants";
+import { ENGINE_MINIWDL } from "../../constants";
 import { ComputeResourceType } from "@aws-cdk/aws-batch-alpha";
 import { BucketOperations } from "../../common/BucketOperations";
 import { ContextAppParameters } from "../../env";
@@ -14,6 +14,7 @@ import { HeadJobBatchPolicy } from "../../roles/policies/head-job-batch-policy";
 import { BatchPolicies } from "../../roles/policies/batch-policies";
 import { EngineOptions } from "../../types";
 import { Construct } from "constructs";
+import { LaunchTemplateData } from "../../constructs/launch-template-data";
 
 export class MiniwdlEngineConstruct extends EngineConstruct {
   public readonly apiProxy: ApiProxy;
@@ -118,9 +119,10 @@ export class MiniwdlEngineConstruct extends EngineConstruct {
       computeType,
       instanceTypes: appParams.instanceTypes,
       maxVCpus: appParams.maxVCpus,
-      launchTemplateData: LAUNCH_TEMPLATE,
+      launchTemplateData: LaunchTemplateData.renderLaunchTemplateData(ENGINE_MINIWDL),
       awsPolicyNames: ["AmazonSSMManagedInstanceCore", "CloudWatchAgentServerPolicy"],
       resourceTags: Stack.of(this).tags.tagValues(),
+      workflowOrchestrator: ENGINE_MINIWDL,
     });
   }
 
@@ -130,7 +132,7 @@ export class MiniwdlEngineConstruct extends EngineConstruct {
 
   private renderAdapterLambda({ vpc, role, jobQueueArn, jobDefinitionArn, rootDirS3Uri }) {
     return super.renderPythonLambda(this, "MiniWDLWesAdapterLambda", vpc, role, {
-      ENGINE_NAME: "miniwdl",
+      ENGINE_NAME: ENGINE_MINIWDL,
       JOB_QUEUE: jobQueueArn,
       JOB_DEFINITION: jobDefinitionArn,
       OUTPUT_DIR_S3_URI: rootDirS3Uri,


### PR DESCRIPTION
Issue #, if available:

#278
#275

**Description of Changes**

* Make LaunchTemplate user data aware of workflow orchestrator (engine). Don't use ebs-autoscale when running miniwdl.
* Add code comment  about the need to redeploy contexts when changing the LaunchTemplate.
* Change shutdown to echo error because shutdown won't cause batch to restart a new instance.
* Exposed initial ebs volume size to provision.sh to make it easier to change this value.
* fixed additional typo/ bug from issue 275

**Description of how you validated changes**

Because the changes here modify the ecs-additions scripts a full account deactivate, activate is required.

* deploy miniwdl context and run `demo-wdl-project` workflows. Make sure the autoexpand EBS volume is *not* created on batch workers
* deploy cromwell context and run `demo-wdl-project` workflows. Make sure the autoexpand EBS volume is still created on batch workers

**Checklist**

- [ ] If this change would make any existing documentation invalid, I have included those updates within this PR
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have linted my code before raising the PR
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
