### PR TITLE
fix: fix retry logic for ecs-additions

### DIFF
--- a/packages/cdk/lib/constants.ts
+++ b/packages/cdk/lib/constants.ts
@@ -83,8 +83,8 @@ runcmd:
 # install aws-cli v2 and copy the static binary in an easy to find location for bind-mounts into containers
 - mkdir -p /opt/aws-cli/bin
 - curl -s "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip" && unzip -q /tmp/awscliv2.zip -d /tmp && /tmp/aws/install -b /usr/bin && cp -a -f $(dirname $(find /usr/local/aws-cli -name 'aws' -type f))/. /opt/aws-cli/bin/
-- command -v aws || sleep 5 | curl -s "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip" && unzip -q /tmp/awscliv2.zip -d /tmp && /tmp/aws/install -b /usr/bin && cp -a -f $(dirname $(find /usr/local/aws-cli -name 'aws' -type f))/. /opt/aws-cli/bin/
-- command -v aws || sleep 10 | curl -s "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip" && unzip -q /tmp/awscliv2.zip -d /tmp && /tmp/aws/install -b /usr/bin && cp -a -f $(dirname $(find /usr/local/aws-cli -name 'aws' -type f))/. /opt/aws-cli/bin/
+- command -v aws || sleep 5 && curl -s "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip" && unzip -q /tmp/awscliv2.zip -d /tmp && /tmp/aws/install -b /usr/bin && cp -a -f $(dirname $(find /usr/local/aws-cli -name 'aws' -type f))/. /opt/aws-cli/bin/
+- command -v aws || sleep 10 && curl -s "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip" && unzip -q /tmp/awscliv2.zip -d /tmp && /tmp/aws/install -b /usr/bin && cp -a -f $(dirname $(find /usr/local/aws-cli -name 'aws' -type f))/. /opt/aws-cli/bin/
 - command -v aws || shutdown -P now
 
 # set environment variables for provisioning

--- a/packages/cdk/lib/constants.ts
+++ b/packages/cdk/lib/constants.ts
@@ -100,8 +100,8 @@ runcmd:
 # Setup ecs additions
 - cd /opt
 - aws s3 sync \${INSTALLED_ARTIFACTS_S3_ROOT_URL}/ecs-additions/ ./ecs-additions && chmod a+x /opt/ecs-additions/provision.sh  
-- test -f ./ecs-additions/fetch_and_run.sh || sleep 5 || aws s3 sync \${INSTALLED_ARTIFACTS_S3_ROOT_URL}/ecs-additions/ ./ecs-additions && chmod a+x /opt/ecs-additions/provision.sh    
-- test -f ./ecs-additions/fetch_and_run.sh || sleep 10 || aws s3 sync \${INSTALLED_ARTIFACTS_S3_ROOT_URL}/ecs-additions/ ./ecs-additions && chmod a+x /opt/ecs-additions/provision.sh    
+- test -f ./ecs-additions/fetch_and_run.sh || sleep 5 && aws s3 sync \${INSTALLED_ARTIFACTS_S3_ROOT_URL}/ecs-additions/ ./ecs-additions && chmod a+x /opt/ecs-additions/provision.sh    
+- test -f ./ecs-additions/fetch_and_run.sh || sleep 10 && aws s3 sync \${INSTALLED_ARTIFACTS_S3_ROOT_URL}/ecs-additions/ ./ecs-additions && chmod a+x /opt/ecs-additions/provision.sh    
 - test -f ./ecs-additions/fetch_and_run.sh || shutdown -P now
 - /opt/ecs-additions/provision.sh
 


### PR DESCRIPTION
<!-- Title format: type(scope): Short description (72 chars max for line) -->
<!-- `(scope)` is optional and `type` is one of: build, ci, chore, docs, feat, fix, perf, refactor, revert, style, test -->
<!-- Available types:
- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit -->

Issue #, if available:

**Description of Changes**

Fix ecs-addition retry logics. Currently the retry never happens because after `sleep` execute successful, it never goes into the retry block due to the `||` logic. Changed it to `&&` so it gets correctly executed. 

[//]: #  (A description of the change that you made and the new user experience that it creates)

**Description of how you validated changes**

[//]: #  (A description of you validated your changes and any relevant logs that show your change works)
`make`, `agc account activate` and `agc deploy context`

**Checklist**

- [X] If this change would make any existing documentation invalid, I have included those updates within this PR
- [X] I have added unit tests that prove my fix is effective or that my feature works
- [X] I have linted my code before raising the PR
- [X] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
