### PR TITLE
fix: Delete bootstrap bucket on account deactivate

### DIFF
--- a/packages/cli/internal/pkg/aws/s3/delete_bucket.go
+++ b/packages/cli/internal/pkg/aws/s3/delete_bucket.go
@@ -1,0 +1,21 @@
+package s3
+
+import (
+	"context"
+
+	"github.com/aws/amazon-genomics-cli/internal/pkg/cli/clierror/actionableerror"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+func (c *Client) DeleteBucket(bucketName string) error {
+	_, err := c.s3.DeleteBucket(context.Background(), &s3.DeleteBucketInput{
+		Bucket: aws.String(bucketName),
+	})
+
+	if err != nil {
+		return actionableerror.FindSuggestionForError(err, actionableerror.AwsErrorMessageToSuggestedActionMap)
+	}
+
+	return nil
+}

--- a/packages/cli/internal/pkg/aws/s3/delete_bucket_test.go
+++ b/packages/cli/internal/pkg/aws/s3/delete_bucket_test.go
@@ -1,0 +1,40 @@
+package s3
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/stretchr/testify/assert"
+)
+
+func (m *S3Mock) DeleteBucket(ctx context.Context, input *s3.DeleteBucketInput, opts ...func(*s3.Options)) (*s3.DeleteBucketOutput, error) {
+	args := m.Called(ctx, input)
+	output := args.Get(0)
+	err := args.Error(1)
+
+	if output != nil {
+		return output.(*s3.DeleteBucketOutput), err
+	}
+	return nil, err
+}
+
+func TestClient_DeleteBucket_Success(t *testing.T) {
+	client := NewMockClient()
+	client.s3.(*S3Mock).On("DeleteBucket", context.Background(), &s3.DeleteBucketInput{
+		Bucket: aws.String(testBucketName),
+	}).Return(nil, nil)
+	err := client.DeleteBucket(testBucketName)
+	assert.NoError(t, err)
+}
+
+func TestClient_DeleteBucket_Failure(t *testing.T) {
+	client := NewMockClient()
+	client.s3.(*S3Mock).On("DeleteBucket", context.Background(), &s3.DeleteBucketInput{
+		Bucket: aws.String(testBucketName),
+	}).Return(nil, fmt.Errorf(testErrorMessage))
+	err := client.DeleteBucket(testBucketName)
+	assert.Error(t, err)
+}

--- a/packages/cli/internal/pkg/aws/s3/delete_object.go
+++ b/packages/cli/internal/pkg/aws/s3/delete_object.go
@@ -1,0 +1,36 @@
+package s3
+
+import (
+	"context"
+
+	"github.com/aws/amazon-genomics-cli/internal/pkg/cli/clierror/actionableerror"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+func (c *Client) DeleteObject(bucketName, key string) error {
+	_, err := c.s3.DeleteObject(context.Background(), &s3.DeleteObjectInput{
+		Bucket: aws.String(bucketName),
+		Key:    aws.String(key),
+	})
+
+	if err != nil {
+		return actionableerror.FindSuggestionForError(err, actionableerror.AwsErrorMessageToSuggestedActionMap)
+	}
+
+	return nil
+}
+
+func (c *Client) DeleteObjectVersion(bucketName, key, versionId string) error {
+	_, err := c.s3.DeleteObject(context.Background(), &s3.DeleteObjectInput{
+		Bucket:    aws.String(bucketName),
+		Key:       aws.String(key),
+		VersionId: aws.String(versionId),
+	})
+
+	if err != nil {
+		return actionableerror.FindSuggestionForError(err, actionableerror.AwsErrorMessageToSuggestedActionMap)
+	}
+
+	return nil
+}

--- a/packages/cli/internal/pkg/aws/s3/delete_object_test.go
+++ b/packages/cli/internal/pkg/aws/s3/delete_object_test.go
@@ -1,0 +1,68 @@
+package s3
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	testBucketVersionId = "test-bucket-version-id"
+)
+
+func (m *S3Mock) DeleteObject(ctx context.Context, input *s3.DeleteObjectInput, opts ...func(*s3.Options)) (*s3.DeleteObjectOutput, error) {
+	args := m.Called(ctx, input)
+	output := args.Get(0)
+	err := args.Error(1)
+
+	if output != nil {
+		return output.(*s3.DeleteObjectOutput), err
+	}
+	return nil, err
+}
+
+func TestClient_DeleteObject_Success(t *testing.T) {
+	client := NewMockClient()
+	client.s3.(*S3Mock).On("DeleteObject", context.Background(), &s3.DeleteObjectInput{
+		Bucket: aws.String(testBucketName),
+		Key:    aws.String(testBucketKey),
+	}).Return(nil, nil)
+	err := client.DeleteObject(testBucketName, testBucketKey)
+	assert.NoError(t, err)
+}
+
+func TestClient_DeleteObject_Failure(t *testing.T) {
+	client := NewMockClient()
+	client.s3.(*S3Mock).On("DeleteObject", context.Background(), &s3.DeleteObjectInput{
+		Bucket: aws.String(testBucketName),
+		Key:    aws.String(testBucketKey),
+	}).Return(nil, fmt.Errorf(testErrorMessage))
+	err := client.DeleteObject(testBucketName, testBucketKey)
+	assert.Error(t, err)
+}
+
+func TestClient_DeleteObjectVersion_Success(t *testing.T) {
+	client := NewMockClient()
+	client.s3.(*S3Mock).On("DeleteObject", context.Background(), &s3.DeleteObjectInput{
+		Bucket:    aws.String(testBucketName),
+		Key:       aws.String(testBucketKey),
+		VersionId: aws.String(testBucketVersionId),
+	}).Return(nil, nil)
+	err := client.DeleteObjectVersion(testBucketName, testBucketKey, testBucketVersionId)
+	assert.NoError(t, err)
+}
+
+func TestClient_DeleteObjectVersion_Failure(t *testing.T) {
+	client := NewMockClient()
+	client.s3.(*S3Mock).On("DeleteObject", context.Background(), &s3.DeleteObjectInput{
+		Bucket:    aws.String(testBucketName),
+		Key:       aws.String(testBucketKey),
+		VersionId: aws.String(testBucketVersionId),
+	}).Return(nil, fmt.Errorf(testErrorMessage))
+	err := client.DeleteObjectVersion(testBucketName, testBucketKey, testBucketVersionId)
+	assert.Error(t, err)
+}

--- a/packages/cli/internal/pkg/aws/s3/empty_bucket.go
+++ b/packages/cli/internal/pkg/aws/s3/empty_bucket.go
@@ -1,0 +1,73 @@
+package s3
+
+import (
+	"context"
+
+	"github.com/aws/amazon-genomics-cli/internal/pkg/cli/clierror/actionableerror"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/rs/zerolog/log"
+)
+
+func (c *Client) EmptyBucket(bucketName string) error {
+	if err := c.deleteAllBucketObjects(bucketName); err != nil {
+		return actionableerror.FindSuggestionForError(err, actionableerror.AwsErrorMessageToSuggestedActionMap)
+	}
+
+	if err := c.deleteAllBucketObjectVersions(bucketName); err != nil {
+		return actionableerror.FindSuggestionForError(err, actionableerror.AwsErrorMessageToSuggestedActionMap)
+	}
+
+	return nil
+}
+
+func (c *Client) deleteAllBucketObjects(bucketName string) error {
+	ctx := context.Background()
+	input := &s3.ListObjectsV2Input{Bucket: aws.String(bucketName)}
+	paginator := s3.NewListObjectsV2Paginator(c.s3, input)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return actionableerror.FindSuggestionForError(err, actionableerror.AwsErrorMessageToSuggestedActionMap)
+		}
+		for _, object := range page.Contents {
+			key := aws.ToString(object.Key)
+			log.Debug().Msgf("Deleting object '%s' in bucket '%s'\n", key, bucketName)
+			if err := c.DeleteObject(bucketName, key); err != nil {
+				return actionableerror.FindSuggestionForError(err, actionableerror.AwsErrorMessageToSuggestedActionMap)
+			}
+		}
+	}
+	return nil
+}
+
+func (c *Client) deleteAllBucketObjectVersions(bucketName string) error {
+	ctx := context.Background()
+	input := &s3.ListObjectVersionsInput{Bucket: aws.String(bucketName)}
+	for {
+		output, err := c.s3.ListObjectVersions(ctx, input)
+		if err != nil {
+			return actionableerror.FindSuggestionForError(err, actionableerror.AwsErrorMessageToSuggestedActionMap)
+		}
+		for _, marker := range output.DeleteMarkers {
+			log.Debug().Msgf("Deleting object delete marker '%s.%s' in bucket '%s'\n", *marker.Key, *marker.VersionId, bucketName)
+			if err := c.DeleteObjectVersion(bucketName, aws.ToString(marker.Key), aws.ToString(marker.VersionId)); err != nil {
+				return actionableerror.FindSuggestionForError(err, actionableerror.AwsErrorMessageToSuggestedActionMap)
+			}
+		}
+		for _, marker := range output.Versions {
+			log.Debug().Msgf("Deleting object version marker '%s.%s' in bucket '%s'\n", *marker.Key, *marker.VersionId, bucketName)
+			if err := c.DeleteObjectVersion(bucketName, aws.ToString(marker.Key), aws.ToString(marker.VersionId)); err != nil {
+				return actionableerror.FindSuggestionForError(err, actionableerror.AwsErrorMessageToSuggestedActionMap)
+			}
+		}
+
+		if output.IsTruncated {
+			input.KeyMarker = output.NextKeyMarker
+			input.VersionIdMarker = output.NextVersionIdMarker
+		} else {
+			break
+		}
+	}
+	return nil
+}

--- a/packages/cli/internal/pkg/aws/s3/empty_bucket_test.go
+++ b/packages/cli/internal/pkg/aws/s3/empty_bucket_test.go
@@ -1,0 +1,172 @@
+package s3
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func (m *S3Mock) ListObjectsV2(ctx context.Context, input *s3.ListObjectsV2Input, opts ...func(*s3.Options)) (*s3.ListObjectsV2Output, error) {
+	args := m.Called(ctx, input)
+	output := args.Get(0)
+	err := args.Error(1)
+
+	if output != nil {
+		return output.(*s3.ListObjectsV2Output), err
+	}
+	return nil, err
+}
+
+func (m *S3Mock) ListObjectVersions(ctx context.Context, input *s3.ListObjectVersionsInput, opts ...func(*s3.Options)) (*s3.ListObjectVersionsOutput, error) {
+	args := m.Called(ctx, input)
+	output := args.Get(0)
+	err := args.Error(1)
+
+	if output != nil {
+		return output.(*s3.ListObjectVersionsOutput), err
+	}
+	return nil, err
+}
+
+func TestClient_EmptyBucket_Success(t *testing.T) {
+	client := NewMockClient()
+	client.s3.(*S3Mock).On("ListObjectsV2", context.Background(), &s3.ListObjectsV2Input{
+		Bucket: aws.String(testBucketName),
+	}).Return(&s3.ListObjectsV2Output{
+		Contents: []types.Object{
+			{
+				Key: aws.String(testBucketKey),
+			},
+		},
+	}, nil)
+	client.s3.(*S3Mock).On("DeleteObject", context.Background(), &s3.DeleteObjectInput{
+		Bucket: aws.String(testBucketName),
+		Key:    aws.String(testBucketKey),
+	}).Return(nil, nil)
+
+	client.s3.(*S3Mock).On("ListObjectVersions", context.Background(), &s3.ListObjectVersionsInput{
+		Bucket: aws.String(testBucketName),
+	}).Return(&s3.ListObjectVersionsOutput{
+		DeleteMarkers: []types.DeleteMarkerEntry{
+			{
+				Key:       aws.String(testBucketKey),
+				VersionId: aws.String(testBucketVersionId),
+			},
+		},
+		Versions: []types.ObjectVersion{
+			{
+				Key:       aws.String(testBucketKey),
+				VersionId: aws.String(testBucketVersionId),
+			},
+		},
+	}, nil)
+	client.s3.(*S3Mock).On("DeleteObject", context.Background(), &s3.DeleteObjectInput{
+		Bucket:    aws.String(testBucketName),
+		Key:       aws.String(testBucketKey),
+		VersionId: aws.String(testBucketVersionId),
+	}).Return(nil, nil)
+
+	err := client.EmptyBucket(testBucketName)
+	assert.NoError(t, err)
+}
+
+func TestClient_EmptyBucket_Failure_1(t *testing.T) {
+	client := NewMockClient()
+	client.s3.(*S3Mock).On("ListObjectsV2", context.Background(), &s3.ListObjectsV2Input{
+		Bucket: aws.String(testBucketName),
+	}).Return(nil, fmt.Errorf(testErrorMessage))
+
+	err := client.EmptyBucket(testBucketName)
+	assert.Error(t, err)
+}
+
+func TestClient_EmptyBucket_Failure_2(t *testing.T) {
+	client := NewMockClient()
+	client.s3.(*S3Mock).On("ListObjectsV2", context.Background(), &s3.ListObjectsV2Input{
+		Bucket: aws.String(testBucketName),
+	}).Return(&s3.ListObjectsV2Output{
+		Contents: []types.Object{
+			{
+				Key: aws.String(testBucketKey),
+			},
+		},
+	}, nil)
+	client.s3.(*S3Mock).On("DeleteObject", context.Background(), &s3.DeleteObjectInput{
+		Bucket: aws.String(testBucketName),
+		Key:    aws.String(testBucketKey),
+	}).Return(nil, fmt.Errorf(testErrorMessage))
+
+	err := client.EmptyBucket(testBucketName)
+	assert.Error(t, err)
+}
+
+func TestClient_EmptyBucket_Failure_3(t *testing.T) {
+	client := NewMockClient()
+	client.s3.(*S3Mock).On("ListObjectsV2", context.Background(), &s3.ListObjectsV2Input{
+		Bucket: aws.String(testBucketName),
+	}).Return(&s3.ListObjectsV2Output{
+		Contents: []types.Object{
+			{
+				Key: aws.String(testBucketKey),
+			},
+		},
+	}, nil)
+	client.s3.(*S3Mock).On("DeleteObject", context.Background(), &s3.DeleteObjectInput{
+		Bucket: aws.String(testBucketName),
+		Key:    aws.String(testBucketKey),
+	}).Return(nil, nil)
+
+	client.s3.(*S3Mock).On("ListObjectVersions", context.Background(), &s3.ListObjectVersionsInput{
+		Bucket: aws.String(testBucketName),
+	}).Return(nil, fmt.Errorf(testErrorMessage))
+
+	err := client.EmptyBucket(testBucketName)
+	assert.Error(t, err)
+}
+
+func TestClient_EmptyBucket_Failure_4(t *testing.T) {
+	client := NewMockClient()
+	client.s3.(*S3Mock).On("ListObjectsV2", context.Background(), &s3.ListObjectsV2Input{
+		Bucket: aws.String(testBucketName),
+	}).Return(&s3.ListObjectsV2Output{
+		Contents: []types.Object{
+			{
+				Key: aws.String(testBucketKey),
+			},
+		},
+	}, nil)
+	client.s3.(*S3Mock).On("DeleteObject", context.Background(), &s3.DeleteObjectInput{
+		Bucket: aws.String(testBucketName),
+		Key:    aws.String(testBucketKey),
+	}).Return(nil, nil)
+
+	client.s3.(*S3Mock).On("ListObjectVersions", context.Background(), &s3.ListObjectVersionsInput{
+		Bucket: aws.String(testBucketName),
+	}).Return(&s3.ListObjectVersionsOutput{
+		DeleteMarkers: []types.DeleteMarkerEntry{
+			{
+				Key:       aws.String(testBucketKey),
+				VersionId: aws.String(testBucketVersionId),
+			},
+		},
+		Versions: []types.ObjectVersion{
+			{
+				Key:       aws.String(testBucketKey),
+				VersionId: aws.String(testBucketVersionId),
+			},
+		},
+	}, nil)
+	client.s3.(*S3Mock).On("DeleteObject", context.Background(), &s3.DeleteObjectInput{
+		Bucket:    aws.String(testBucketName),
+		Key:       aws.String(testBucketKey),
+		VersionId: aws.String(testBucketVersionId),
+	}).Return(nil, fmt.Errorf(testErrorMessage))
+
+	err := client.EmptyBucket(testBucketName)
+	assert.Error(t, err)
+}

--- a/packages/cli/internal/pkg/aws/s3/interface.go
+++ b/packages/cli/internal/pkg/aws/s3/interface.go
@@ -1,6 +1,8 @@
 package s3
 
 import (
+	"context"
+
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 )
@@ -9,10 +11,18 @@ type Interface interface {
 	BucketExists(string) (bool, error)
 	SyncFile(bucketName, key, filePath string) error
 	UploadFile(bucketName, key, filePath string) error
+	DeleteBucket(bucketName string) error
+	EmptyBucket(bucketName string) error
+	DeleteObject(bucketName, key string) error
+	DeleteObjectVersion(bucketName, key, versionId string) error
 }
 
 type s3Interface interface {
 	s3.HeadBucketAPIClient
 	s3.HeadObjectAPIClient
+	s3.ListObjectsV2APIClient
 	manager.UploadAPIClient
+	DeleteBucket(ctx context.Context, params *s3.DeleteBucketInput, optFns ...func(*s3.Options)) (*s3.DeleteBucketOutput, error)
+	DeleteObject(ctx context.Context, params *s3.DeleteObjectInput, optFns ...func(*s3.Options)) (*s3.DeleteObjectOutput, error)
+	ListObjectVersions(ctx context.Context, params *s3.ListObjectVersionsInput, optFns ...func(*s3.Options)) (*s3.ListObjectVersionsOutput, error)
 }

--- a/packages/cli/internal/pkg/cli/awsresources/awsresources.go
+++ b/packages/cli/internal/pkg/cli/awsresources/awsresources.go
@@ -28,3 +28,7 @@ func RenderBucketDataKey(projectName, userId string, suffix ...string) string {
 func RenderBootstrapStackName() string {
 	return fmt.Sprintf("%s-%s", constants.ProductName, "CDKToolkit")
 }
+
+func RenderBootstrapAssetBucketName(accountId, region string) string {
+	return fmt.Sprintf("cdk-agc-assets-%s-%s", accountId, region)
+}

--- a/packages/cli/internal/pkg/mocks/aws/mock_interfaces.go
+++ b/packages/cli/internal/pkg/mocks/aws/mock_interfaces.go
@@ -42,20 +42,6 @@ func (m *MockCdkClient) EXPECT() *MockCdkClientMockRecorder {
 	return m.recorder
 }
 
-// ClearContext mocks base method.
-func (m *MockCdkClient) ClearContext(appDir string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ClearContext", appDir)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ClearContext indicates an expected call of ClearContext.
-func (mr *MockCdkClientMockRecorder) ClearContext(appDir interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearContext", reflect.TypeOf((*MockCdkClient)(nil).ClearContext), appDir)
-}
-
 // Bootstrap mocks base method.
 func (m *MockCdkClient) Bootstrap(appDir string, context []string, executionName string) (cdk.ProgressStream, error) {
 	m.ctrl.T.Helper()
@@ -69,6 +55,20 @@ func (m *MockCdkClient) Bootstrap(appDir string, context []string, executionName
 func (mr *MockCdkClientMockRecorder) Bootstrap(appDir, context, executionName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bootstrap", reflect.TypeOf((*MockCdkClient)(nil).Bootstrap), appDir, context, executionName)
+}
+
+// ClearContext mocks base method.
+func (m *MockCdkClient) ClearContext(appDir string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ClearContext", appDir)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ClearContext indicates an expected call of ClearContext.
+func (mr *MockCdkClientMockRecorder) ClearContext(appDir interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearContext", reflect.TypeOf((*MockCdkClient)(nil).ClearContext), appDir)
 }
 
 // DeployApp mocks base method.
@@ -165,6 +165,62 @@ func (m *MockS3Client) BucketExists(arg0 string) (bool, error) {
 func (mr *MockS3ClientMockRecorder) BucketExists(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BucketExists", reflect.TypeOf((*MockS3Client)(nil).BucketExists), arg0)
+}
+
+// DeleteBucket mocks base method.
+func (m *MockS3Client) DeleteBucket(bucketName string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteBucket", bucketName)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteBucket indicates an expected call of DeleteBucket.
+func (mr *MockS3ClientMockRecorder) DeleteBucket(bucketName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBucket", reflect.TypeOf((*MockS3Client)(nil).DeleteBucket), bucketName)
+}
+
+// DeleteObject mocks base method.
+func (m *MockS3Client) DeleteObject(bucketName, key string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteObject", bucketName, key)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteObject indicates an expected call of DeleteObject.
+func (mr *MockS3ClientMockRecorder) DeleteObject(bucketName, key interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteObject", reflect.TypeOf((*MockS3Client)(nil).DeleteObject), bucketName, key)
+}
+
+// DeleteObjectVersion mocks base method.
+func (m *MockS3Client) DeleteObjectVersion(bucketName, key, versionId string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteObjectVersion", bucketName, key, versionId)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteObjectVersion indicates an expected call of DeleteObjectVersion.
+func (mr *MockS3ClientMockRecorder) DeleteObjectVersion(bucketName, key, versionId interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteObjectVersion", reflect.TypeOf((*MockS3Client)(nil).DeleteObjectVersion), bucketName, key, versionId)
+}
+
+// EmptyBucket mocks base method.
+func (m *MockS3Client) EmptyBucket(bucketName string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EmptyBucket", bucketName)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// EmptyBucket indicates an expected call of EmptyBucket.
+func (mr *MockS3ClientMockRecorder) EmptyBucket(bucketName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EmptyBucket", reflect.TypeOf((*MockS3Client)(nil).EmptyBucket), bucketName)
 }
 
 // SyncFile mocks base method.


### PR DESCRIPTION
<!-- Title format: type(scope): Short description (72 chars max for line) -->
<!-- `(scope)` is optional and `type` is one of: build, ci, chore, docs, feat, fix, perf, refactor, revert, style, test -->
<!-- Available types:
- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit -->

**Description of Changes**

When deactivating an AGC-CDK bootstrapped account, we do not delete the assets bucket associated with the bootstrap stack, causing subsequent activations to fail.

**Description of how you validated changes**

Activated and deactivated and reactivated account to confirm bucket is deleted and does not block reactivation.


**Checklist**

- [x] If this change would make any existing documentation invalid, I have included those updates within this PR
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have linted my code before raising the PR
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
