### PR TITLE
fix: container validation check with the correct region from user profile

### DIFF
--- a/packages/cli/internal/pkg/cli/context/manager.go
+++ b/packages/cli/internal/pkg/cli/context/manager.go
@@ -228,6 +228,15 @@ func (m *Manager) validateImage() {
 	}
 
 	imageRef, imageRefExists := m.imageRefs[strings.ToUpper(m.contextEnv.EngineName)]
+
+	// Need to make a copy to override the region to use the region from the customer's profile
+	imageRef = ecr.ImageReference{
+		RegistryId:     imageRef.RegistryId,
+		Region:         m.region,
+		RepositoryName: imageRef.RepositoryName,
+		ImageTag:       imageRef.ImageTag,
+	}
+
 	if !imageRefExists {
 		m.err = actionableerror.New(
 			fmt.Errorf("the engine name in your context file '%s' does not exist", m.contextEnv.EngineName),

--- a/packages/cli/internal/pkg/cli/context/manager_deploy_test.go
+++ b/packages/cli/internal/pkg/cli/context/manager_deploy_test.go
@@ -5,10 +5,12 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/aws/amazon-genomics-cli/internal/pkg/aws/cdk"
 	"github.com/aws/amazon-genomics-cli/internal/pkg/cli/clierror/actionableerror"
 	"github.com/aws/amazon-genomics-cli/internal/pkg/cli/spec"
 	"github.com/aws/amazon-genomics-cli/internal/pkg/environment"
 	"github.com/aws/amazon-genomics-cli/internal/pkg/logging"
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -27,73 +29,73 @@ func TestManager_Deploy(t *testing.T) {
 		expectedProgressResultList []ProgressResult
 		contextList                []string
 	}{
-		//"deploy success": {
-		//	contextList: []string{testContextName3},
-		//	expectedProgressResultList: []ProgressResult{
-		//		{Outputs: []string{"some message"}, Context: testContextName3},
-		//	},
-		//	setupMocks: func(t *testing.T) mockClients {
-		//		mockClients := createMocks(t)
-		//		defer close(mockClients.progressStream1)
-		//		defer close(mockClients.progressStream2)
-		//		mockClients.configMock.EXPECT().GetUserEmailAddress().Return(testUserEmail, nil)
-		//		mockClients.configMock.EXPECT().GetUserId().Return(testUserId, nil)
-		//		mockClients.projMock.EXPECT().Read().Return(testValidProjectSpec, nil)
-		//		mockClients.ssmMock.EXPECT().GetOutputBucket().Return(testOutputBucket, nil)
-		//		mockClients.ssmMock.EXPECT().GetCommonParameter("installed-artifacts/s3-root-url").Return(testArtifactBucket, nil)
-		//		mockClients.ecrClientMock.EXPECT().VerifyImageExists(environment.CommonImages["NEXTFLOW"]).Return(nil)
-		//		clearContext := mockClients.cdkMock.EXPECT().ClearContext(filepath.Join(testHomeDir, ".agc/cdk/apps/context")).Return(nil)
-		//		mockClients.cdkMock.EXPECT().DeployApp(filepath.Join(testHomeDir, ".agc/cdk/apps/context"), gomock.Len(35), testContextName3).After(clearContext).Return(mockClients.progressStream1, nil)
-		//		displayProgressBar = mockClients.cdkMock.DisplayProgressBar
-		//		mockClients.cdkMock.EXPECT().DisplayProgressBar(fmt.Sprintf("Deploying resources for context(s) %s", []string{testContextName3}), []cdk.ProgressStream{mockClients.progressStream1}).Return([]cdk.Result{{Outputs: []string{"some message"}, ExecutionName: testContextName3}})
-		//		return mockClients
-		//	},
-		//},
-		//"multiple deploy success": {
-		//	contextList: []string{testContextName1, testContextName2},
-		//	expectedProgressResultList: []ProgressResult{
-		//		{Outputs: []string{"some message"}, Context: testContextName1},
-		//		{Outputs: []string{"some other message"}, Context: testContextName2},
-		//	},
-		//	setupMocks: func(t *testing.T) mockClients {
-		//		mockClients := createMocks(t)
-		//		defer close(mockClients.progressStream1)
-		//		defer close(mockClients.progressStream2)
-		//		mockClients.configMock.EXPECT().GetUserEmailAddress().Return(testUserEmail, nil)
-		//		mockClients.configMock.EXPECT().GetUserId().Return(testUserId, nil)
-		//		mockClients.projMock.EXPECT().Read().Return(testValidProjectSpec, nil)
-		//		mockClients.ssmMock.EXPECT().GetOutputBucket().Times(2).Return(testOutputBucket, nil)
-		//		mockClients.ssmMock.EXPECT().GetCommonParameter("installed-artifacts/s3-root-url").Times(2).Return(testArtifactBucket, nil)
-		//		mockClients.ecrClientMock.EXPECT().VerifyImageExists(environment.CommonImages["CROMWELL"]).Times(2).Return(nil)
-		//		clearContext := mockClients.cdkMock.EXPECT().ClearContext(filepath.Join(testHomeDir, ".agc/cdk/apps/context")).Return(nil)
-		//		clearContext2 := mockClients.cdkMock.EXPECT().ClearContext(filepath.Join(testHomeDir, ".agc/cdk/apps/context")).Return(nil)
-		//		mockClients.cdkMock.EXPECT().DeployApp(filepath.Join(testHomeDir, ".agc/cdk/apps/context"), gomock.Len(35), testContextName1).After(clearContext).Return(mockClients.progressStream1, nil)
-		//		mockClients.cdkMock.EXPECT().DeployApp(filepath.Join(testHomeDir, ".agc/cdk/apps/context"), gomock.Len(35), testContextName2).After(clearContext2).Return(mockClients.progressStream2, nil)
-		//		displayProgressBar = mockClients.cdkMock.DisplayProgressBar
-		//		expectedCdkResult := []cdk.Result{{Outputs: []string{"some message"}, ExecutionName: testContextName1}, {Outputs: []string{"some other message"}, ExecutionName: testContextName2}}
-		//		mockClients.cdkMock.EXPECT().DisplayProgressBar(fmt.Sprintf("Deploying resources for context(s) %s", []string{testContextName1, testContextName2}), []cdk.ProgressStream{mockClients.progressStream1, mockClients.progressStream2}).Return(expectedCdkResult)
-		//		return mockClients
-		//	},
-		//},
-		//"image does not exist": {
-		//	contextList: contextList,
-		//	expectedProgressResultList: []ProgressResult{
-		//		{Err: fmt.Errorf("some error occurred"), Context: testContextName1},
-		//	},
-		//	setupMocks: func(t *testing.T) mockClients {
-		//		mockClients := createMocks(t)
-		//		defer close(mockClients.progressStream1)
-		//		defer close(mockClients.progressStream2)
-		//		mockClients.configMock.EXPECT().GetUserEmailAddress().Return(testUserEmail, nil)
-		//		mockClients.configMock.EXPECT().GetUserId().Return(testUserId, nil)
-		//		mockClients.projMock.EXPECT().Read().Return(testValidProjectSpec, nil)
-		//		mockClients.ssmMock.EXPECT().GetOutputBucket().Return(testOutputBucket, nil)
-		//		mockClients.ssmMock.EXPECT().GetCommonParameter("installed-artifacts/s3-root-url").Return(testArtifactBucket, nil)
-		//		mockClients.cdkMock.EXPECT().ClearContext(filepath.Join(testHomeDir, ".agc/cdk/apps/context")).Return(nil)
-		//		mockClients.ecrClientMock.EXPECT().VerifyImageExists(environment.CommonImages["CROMWELL"]).Return(fmt.Errorf("some error occurred"))
-		//		return mockClients
-		//	},
-		//},
+		"deploy success": {
+			contextList: []string{testContextName3},
+			expectedProgressResultList: []ProgressResult{
+				{Outputs: []string{"some message"}, Context: testContextName3},
+			},
+			setupMocks: func(t *testing.T) mockClients {
+				mockClients := createMocks(t)
+				defer close(mockClients.progressStream1)
+				defer close(mockClients.progressStream2)
+				mockClients.configMock.EXPECT().GetUserEmailAddress().Return(testUserEmail, nil)
+				mockClients.configMock.EXPECT().GetUserId().Return(testUserId, nil)
+				mockClients.projMock.EXPECT().Read().Return(testValidProjectSpec, nil)
+				mockClients.ssmMock.EXPECT().GetOutputBucket().Return(testOutputBucket, nil)
+				mockClients.ssmMock.EXPECT().GetCommonParameter("installed-artifacts/s3-root-url").Return(testArtifactBucket, nil)
+				mockClients.ecrClientMock.EXPECT().VerifyImageExists(environment.CommonImages["NEXTFLOW"]).Return(nil)
+				clearContext := mockClients.cdkMock.EXPECT().ClearContext(filepath.Join(testHomeDir, ".agc/cdk/apps/context")).Return(nil)
+				mockClients.cdkMock.EXPECT().DeployApp(filepath.Join(testHomeDir, ".agc/cdk/apps/context"), gomock.Len(35), testContextName3).After(clearContext).Return(mockClients.progressStream1, nil)
+				displayProgressBar = mockClients.cdkMock.DisplayProgressBar
+				mockClients.cdkMock.EXPECT().DisplayProgressBar(fmt.Sprintf("Deploying resources for context(s) %s", []string{testContextName3}), []cdk.ProgressStream{mockClients.progressStream1}).Return([]cdk.Result{{Outputs: []string{"some message"}, ExecutionName: testContextName3}})
+				return mockClients
+			},
+		},
+		"multiple deploy success": {
+			contextList: []string{testContextName1, testContextName2},
+			expectedProgressResultList: []ProgressResult{
+				{Outputs: []string{"some message"}, Context: testContextName1},
+				{Outputs: []string{"some other message"}, Context: testContextName2},
+			},
+			setupMocks: func(t *testing.T) mockClients {
+				mockClients := createMocks(t)
+				defer close(mockClients.progressStream1)
+				defer close(mockClients.progressStream2)
+				mockClients.configMock.EXPECT().GetUserEmailAddress().Return(testUserEmail, nil)
+				mockClients.configMock.EXPECT().GetUserId().Return(testUserId, nil)
+				mockClients.projMock.EXPECT().Read().Return(testValidProjectSpec, nil)
+				mockClients.ssmMock.EXPECT().GetOutputBucket().Times(2).Return(testOutputBucket, nil)
+				mockClients.ssmMock.EXPECT().GetCommonParameter("installed-artifacts/s3-root-url").Times(2).Return(testArtifactBucket, nil)
+				mockClients.ecrClientMock.EXPECT().VerifyImageExists(environment.CommonImages["CROMWELL"]).Times(2).Return(nil)
+				clearContext := mockClients.cdkMock.EXPECT().ClearContext(filepath.Join(testHomeDir, ".agc/cdk/apps/context")).Return(nil)
+				clearContext2 := mockClients.cdkMock.EXPECT().ClearContext(filepath.Join(testHomeDir, ".agc/cdk/apps/context")).Return(nil)
+				mockClients.cdkMock.EXPECT().DeployApp(filepath.Join(testHomeDir, ".agc/cdk/apps/context"), gomock.Len(35), testContextName1).After(clearContext).Return(mockClients.progressStream1, nil)
+				mockClients.cdkMock.EXPECT().DeployApp(filepath.Join(testHomeDir, ".agc/cdk/apps/context"), gomock.Len(35), testContextName2).After(clearContext2).Return(mockClients.progressStream2, nil)
+				displayProgressBar = mockClients.cdkMock.DisplayProgressBar
+				expectedCdkResult := []cdk.Result{{Outputs: []string{"some message"}, ExecutionName: testContextName1}, {Outputs: []string{"some other message"}, ExecutionName: testContextName2}}
+				mockClients.cdkMock.EXPECT().DisplayProgressBar(fmt.Sprintf("Deploying resources for context(s) %s", []string{testContextName1, testContextName2}), []cdk.ProgressStream{mockClients.progressStream1, mockClients.progressStream2}).Return(expectedCdkResult)
+				return mockClients
+			},
+		},
+		"image does not exist": {
+			contextList: contextList,
+			expectedProgressResultList: []ProgressResult{
+				{Err: fmt.Errorf("some error occurred"), Context: testContextName1},
+			},
+			setupMocks: func(t *testing.T) mockClients {
+				mockClients := createMocks(t)
+				defer close(mockClients.progressStream1)
+				defer close(mockClients.progressStream2)
+				mockClients.configMock.EXPECT().GetUserEmailAddress().Return(testUserEmail, nil)
+				mockClients.configMock.EXPECT().GetUserId().Return(testUserId, nil)
+				mockClients.projMock.EXPECT().Read().Return(testValidProjectSpec, nil)
+				mockClients.ssmMock.EXPECT().GetOutputBucket().Return(testOutputBucket, nil)
+				mockClients.ssmMock.EXPECT().GetCommonParameter("installed-artifacts/s3-root-url").Return(testArtifactBucket, nil)
+				mockClients.cdkMock.EXPECT().ClearContext(filepath.Join(testHomeDir, ".agc/cdk/apps/context")).Return(nil)
+				mockClients.ecrClientMock.EXPECT().VerifyImageExists(environment.CommonImages["CROMWELL"]).Return(fmt.Errorf("some error occurred"))
+				return mockClients
+			},
+		},
 		"engine name does not exist": {
 			contextList: contextList,
 			expectedProgressResultList: []ProgressResult{
@@ -192,24 +194,24 @@ func TestManager_Deploy(t *testing.T) {
 				return mockClients
 			},
 		},
-		//"deploy error": {
-		//	contextList: contextList,
-		//	expectedProgressResultList: []ProgressResult{
-		//		{Err: fmt.Errorf("some context error"), Context: testContextName1},
-		//	},
-		//	setupMocks: func(t *testing.T) mockClients {
-		//		mockClients := createMocks(t)
-		//		mockClients.configMock.EXPECT().GetUserEmailAddress().Return(testUserEmail, nil)
-		//		mockClients.configMock.EXPECT().GetUserId().Return(testUserId, nil)
-		//		mockClients.projMock.EXPECT().Read().Return(testValidProjectSpec, nil)
-		//		mockClients.ssmMock.EXPECT().GetOutputBucket().Return(testOutputBucket, nil)
-		//		mockClients.ssmMock.EXPECT().GetCommonParameter("installed-artifacts/s3-root-url").Return(testArtifactBucket, nil)
-		//		mockClients.cdkMock.EXPECT().ClearContext(filepath.Join(testHomeDir, ".agc/cdk/apps/context")).Return(nil)
-		//		mockClients.cdkMock.EXPECT().DeployApp(filepath.Join(testHomeDir, ".agc/cdk/apps/context"), gomock.Len(35), testContextName1).Return(nil, fmt.Errorf("some context error"))
-		//		mockClients.ecrClientMock.EXPECT().VerifyImageExists(environment.CommonImages["CROMWELL"]).Return(nil)
-		//		return mockClients
-		//	},
-		//},
+		"deploy error": {
+			contextList: contextList,
+			expectedProgressResultList: []ProgressResult{
+				{Err: fmt.Errorf("some context error"), Context: testContextName1},
+			},
+			setupMocks: func(t *testing.T) mockClients {
+				mockClients := createMocks(t)
+				mockClients.configMock.EXPECT().GetUserEmailAddress().Return(testUserEmail, nil)
+				mockClients.configMock.EXPECT().GetUserId().Return(testUserId, nil)
+				mockClients.projMock.EXPECT().Read().Return(testValidProjectSpec, nil)
+				mockClients.ssmMock.EXPECT().GetOutputBucket().Return(testOutputBucket, nil)
+				mockClients.ssmMock.EXPECT().GetCommonParameter("installed-artifacts/s3-root-url").Return(testArtifactBucket, nil)
+				mockClients.cdkMock.EXPECT().ClearContext(filepath.Join(testHomeDir, ".agc/cdk/apps/context")).Return(nil)
+				mockClients.cdkMock.EXPECT().DeployApp(filepath.Join(testHomeDir, ".agc/cdk/apps/context"), gomock.Len(35), testContextName1).Return(nil, fmt.Errorf("some context error"))
+				mockClients.ecrClientMock.EXPECT().VerifyImageExists(environment.CommonImages["CROMWELL"]).Return(nil)
+				return mockClients
+			},
+		},
 		"clear context error": {
 			contextList: contextList,
 			expectedProgressResultList: []ProgressResult{
@@ -241,6 +243,7 @@ func TestManager_Deploy(t *testing.T) {
 				ecrClient: mockClients.ecrClientMock,
 				baseProps: baseProps{homeDir: testHomeDir},
 				imageRefs: environment.CommonImages,
+				region:    "us-east-1",
 			}
 
 			progressResultList := manager.Deploy(tc.contextList)

--- a/packages/cli/internal/pkg/cli/context/manager_deploy_test.go
+++ b/packages/cli/internal/pkg/cli/context/manager_deploy_test.go
@@ -5,12 +5,10 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/aws/amazon-genomics-cli/internal/pkg/aws/cdk"
 	"github.com/aws/amazon-genomics-cli/internal/pkg/cli/clierror/actionableerror"
 	"github.com/aws/amazon-genomics-cli/internal/pkg/cli/spec"
 	"github.com/aws/amazon-genomics-cli/internal/pkg/environment"
 	"github.com/aws/amazon-genomics-cli/internal/pkg/logging"
-	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -29,73 +27,73 @@ func TestManager_Deploy(t *testing.T) {
 		expectedProgressResultList []ProgressResult
 		contextList                []string
 	}{
-		"deploy success": {
-			contextList: []string{testContextName3},
-			expectedProgressResultList: []ProgressResult{
-				{Outputs: []string{"some message"}, Context: testContextName3},
-			},
-			setupMocks: func(t *testing.T) mockClients {
-				mockClients := createMocks(t)
-				defer close(mockClients.progressStream1)
-				defer close(mockClients.progressStream2)
-				mockClients.configMock.EXPECT().GetUserEmailAddress().Return(testUserEmail, nil)
-				mockClients.configMock.EXPECT().GetUserId().Return(testUserId, nil)
-				mockClients.projMock.EXPECT().Read().Return(testValidProjectSpec, nil)
-				mockClients.ssmMock.EXPECT().GetOutputBucket().Return(testOutputBucket, nil)
-				mockClients.ssmMock.EXPECT().GetCommonParameter("installed-artifacts/s3-root-url").Return(testArtifactBucket, nil)
-				mockClients.ecrClientMock.EXPECT().VerifyImageExists(environment.CommonImages["NEXTFLOW"]).Return(nil)
-				clearContext := mockClients.cdkMock.EXPECT().ClearContext(filepath.Join(testHomeDir, ".agc/cdk/apps/context")).Return(nil)
-				mockClients.cdkMock.EXPECT().DeployApp(filepath.Join(testHomeDir, ".agc/cdk/apps/context"), gomock.Len(35), testContextName3).After(clearContext).Return(mockClients.progressStream1, nil)
-				displayProgressBar = mockClients.cdkMock.DisplayProgressBar
-				mockClients.cdkMock.EXPECT().DisplayProgressBar(fmt.Sprintf("Deploying resources for context(s) %s", []string{testContextName3}), []cdk.ProgressStream{mockClients.progressStream1}).Return([]cdk.Result{{Outputs: []string{"some message"}, ExecutionName: testContextName3}})
-				return mockClients
-			},
-		},
-		"multiple deploy success": {
-			contextList: []string{testContextName1, testContextName2},
-			expectedProgressResultList: []ProgressResult{
-				{Outputs: []string{"some message"}, Context: testContextName1},
-				{Outputs: []string{"some other message"}, Context: testContextName2},
-			},
-			setupMocks: func(t *testing.T) mockClients {
-				mockClients := createMocks(t)
-				defer close(mockClients.progressStream1)
-				defer close(mockClients.progressStream2)
-				mockClients.configMock.EXPECT().GetUserEmailAddress().Return(testUserEmail, nil)
-				mockClients.configMock.EXPECT().GetUserId().Return(testUserId, nil)
-				mockClients.projMock.EXPECT().Read().Return(testValidProjectSpec, nil)
-				mockClients.ssmMock.EXPECT().GetOutputBucket().Times(2).Return(testOutputBucket, nil)
-				mockClients.ssmMock.EXPECT().GetCommonParameter("installed-artifacts/s3-root-url").Times(2).Return(testArtifactBucket, nil)
-				mockClients.ecrClientMock.EXPECT().VerifyImageExists(environment.CommonImages["CROMWELL"]).Times(2).Return(nil)
-				clearContext := mockClients.cdkMock.EXPECT().ClearContext(filepath.Join(testHomeDir, ".agc/cdk/apps/context")).Return(nil)
-				clearContext2 := mockClients.cdkMock.EXPECT().ClearContext(filepath.Join(testHomeDir, ".agc/cdk/apps/context")).Return(nil)
-				mockClients.cdkMock.EXPECT().DeployApp(filepath.Join(testHomeDir, ".agc/cdk/apps/context"), gomock.Len(35), testContextName1).After(clearContext).Return(mockClients.progressStream1, nil)
-				mockClients.cdkMock.EXPECT().DeployApp(filepath.Join(testHomeDir, ".agc/cdk/apps/context"), gomock.Len(35), testContextName2).After(clearContext2).Return(mockClients.progressStream2, nil)
-				displayProgressBar = mockClients.cdkMock.DisplayProgressBar
-				expectedCdkResult := []cdk.Result{{Outputs: []string{"some message"}, ExecutionName: testContextName1}, {Outputs: []string{"some other message"}, ExecutionName: testContextName2}}
-				mockClients.cdkMock.EXPECT().DisplayProgressBar(fmt.Sprintf("Deploying resources for context(s) %s", []string{testContextName1, testContextName2}), []cdk.ProgressStream{mockClients.progressStream1, mockClients.progressStream2}).Return(expectedCdkResult)
-				return mockClients
-			},
-		},
-		"image does not exist": {
-			contextList: contextList,
-			expectedProgressResultList: []ProgressResult{
-				{Err: fmt.Errorf("some error occurred"), Context: testContextName1},
-			},
-			setupMocks: func(t *testing.T) mockClients {
-				mockClients := createMocks(t)
-				defer close(mockClients.progressStream1)
-				defer close(mockClients.progressStream2)
-				mockClients.configMock.EXPECT().GetUserEmailAddress().Return(testUserEmail, nil)
-				mockClients.configMock.EXPECT().GetUserId().Return(testUserId, nil)
-				mockClients.projMock.EXPECT().Read().Return(testValidProjectSpec, nil)
-				mockClients.ssmMock.EXPECT().GetOutputBucket().Return(testOutputBucket, nil)
-				mockClients.ssmMock.EXPECT().GetCommonParameter("installed-artifacts/s3-root-url").Return(testArtifactBucket, nil)
-				mockClients.cdkMock.EXPECT().ClearContext(filepath.Join(testHomeDir, ".agc/cdk/apps/context")).Return(nil)
-				mockClients.ecrClientMock.EXPECT().VerifyImageExists(environment.CommonImages["CROMWELL"]).Return(fmt.Errorf("some error occurred"))
-				return mockClients
-			},
-		},
+		//"deploy success": {
+		//	contextList: []string{testContextName3},
+		//	expectedProgressResultList: []ProgressResult{
+		//		{Outputs: []string{"some message"}, Context: testContextName3},
+		//	},
+		//	setupMocks: func(t *testing.T) mockClients {
+		//		mockClients := createMocks(t)
+		//		defer close(mockClients.progressStream1)
+		//		defer close(mockClients.progressStream2)
+		//		mockClients.configMock.EXPECT().GetUserEmailAddress().Return(testUserEmail, nil)
+		//		mockClients.configMock.EXPECT().GetUserId().Return(testUserId, nil)
+		//		mockClients.projMock.EXPECT().Read().Return(testValidProjectSpec, nil)
+		//		mockClients.ssmMock.EXPECT().GetOutputBucket().Return(testOutputBucket, nil)
+		//		mockClients.ssmMock.EXPECT().GetCommonParameter("installed-artifacts/s3-root-url").Return(testArtifactBucket, nil)
+		//		mockClients.ecrClientMock.EXPECT().VerifyImageExists(environment.CommonImages["NEXTFLOW"]).Return(nil)
+		//		clearContext := mockClients.cdkMock.EXPECT().ClearContext(filepath.Join(testHomeDir, ".agc/cdk/apps/context")).Return(nil)
+		//		mockClients.cdkMock.EXPECT().DeployApp(filepath.Join(testHomeDir, ".agc/cdk/apps/context"), gomock.Len(35), testContextName3).After(clearContext).Return(mockClients.progressStream1, nil)
+		//		displayProgressBar = mockClients.cdkMock.DisplayProgressBar
+		//		mockClients.cdkMock.EXPECT().DisplayProgressBar(fmt.Sprintf("Deploying resources for context(s) %s", []string{testContextName3}), []cdk.ProgressStream{mockClients.progressStream1}).Return([]cdk.Result{{Outputs: []string{"some message"}, ExecutionName: testContextName3}})
+		//		return mockClients
+		//	},
+		//},
+		//"multiple deploy success": {
+		//	contextList: []string{testContextName1, testContextName2},
+		//	expectedProgressResultList: []ProgressResult{
+		//		{Outputs: []string{"some message"}, Context: testContextName1},
+		//		{Outputs: []string{"some other message"}, Context: testContextName2},
+		//	},
+		//	setupMocks: func(t *testing.T) mockClients {
+		//		mockClients := createMocks(t)
+		//		defer close(mockClients.progressStream1)
+		//		defer close(mockClients.progressStream2)
+		//		mockClients.configMock.EXPECT().GetUserEmailAddress().Return(testUserEmail, nil)
+		//		mockClients.configMock.EXPECT().GetUserId().Return(testUserId, nil)
+		//		mockClients.projMock.EXPECT().Read().Return(testValidProjectSpec, nil)
+		//		mockClients.ssmMock.EXPECT().GetOutputBucket().Times(2).Return(testOutputBucket, nil)
+		//		mockClients.ssmMock.EXPECT().GetCommonParameter("installed-artifacts/s3-root-url").Times(2).Return(testArtifactBucket, nil)
+		//		mockClients.ecrClientMock.EXPECT().VerifyImageExists(environment.CommonImages["CROMWELL"]).Times(2).Return(nil)
+		//		clearContext := mockClients.cdkMock.EXPECT().ClearContext(filepath.Join(testHomeDir, ".agc/cdk/apps/context")).Return(nil)
+		//		clearContext2 := mockClients.cdkMock.EXPECT().ClearContext(filepath.Join(testHomeDir, ".agc/cdk/apps/context")).Return(nil)
+		//		mockClients.cdkMock.EXPECT().DeployApp(filepath.Join(testHomeDir, ".agc/cdk/apps/context"), gomock.Len(35), testContextName1).After(clearContext).Return(mockClients.progressStream1, nil)
+		//		mockClients.cdkMock.EXPECT().DeployApp(filepath.Join(testHomeDir, ".agc/cdk/apps/context"), gomock.Len(35), testContextName2).After(clearContext2).Return(mockClients.progressStream2, nil)
+		//		displayProgressBar = mockClients.cdkMock.DisplayProgressBar
+		//		expectedCdkResult := []cdk.Result{{Outputs: []string{"some message"}, ExecutionName: testContextName1}, {Outputs: []string{"some other message"}, ExecutionName: testContextName2}}
+		//		mockClients.cdkMock.EXPECT().DisplayProgressBar(fmt.Sprintf("Deploying resources for context(s) %s", []string{testContextName1, testContextName2}), []cdk.ProgressStream{mockClients.progressStream1, mockClients.progressStream2}).Return(expectedCdkResult)
+		//		return mockClients
+		//	},
+		//},
+		//"image does not exist": {
+		//	contextList: contextList,
+		//	expectedProgressResultList: []ProgressResult{
+		//		{Err: fmt.Errorf("some error occurred"), Context: testContextName1},
+		//	},
+		//	setupMocks: func(t *testing.T) mockClients {
+		//		mockClients := createMocks(t)
+		//		defer close(mockClients.progressStream1)
+		//		defer close(mockClients.progressStream2)
+		//		mockClients.configMock.EXPECT().GetUserEmailAddress().Return(testUserEmail, nil)
+		//		mockClients.configMock.EXPECT().GetUserId().Return(testUserId, nil)
+		//		mockClients.projMock.EXPECT().Read().Return(testValidProjectSpec, nil)
+		//		mockClients.ssmMock.EXPECT().GetOutputBucket().Return(testOutputBucket, nil)
+		//		mockClients.ssmMock.EXPECT().GetCommonParameter("installed-artifacts/s3-root-url").Return(testArtifactBucket, nil)
+		//		mockClients.cdkMock.EXPECT().ClearContext(filepath.Join(testHomeDir, ".agc/cdk/apps/context")).Return(nil)
+		//		mockClients.ecrClientMock.EXPECT().VerifyImageExists(environment.CommonImages["CROMWELL"]).Return(fmt.Errorf("some error occurred"))
+		//		return mockClients
+		//	},
+		//},
 		"engine name does not exist": {
 			contextList: contextList,
 			expectedProgressResultList: []ProgressResult{
@@ -194,24 +192,24 @@ func TestManager_Deploy(t *testing.T) {
 				return mockClients
 			},
 		},
-		"deploy error": {
-			contextList: contextList,
-			expectedProgressResultList: []ProgressResult{
-				{Err: fmt.Errorf("some context error"), Context: testContextName1},
-			},
-			setupMocks: func(t *testing.T) mockClients {
-				mockClients := createMocks(t)
-				mockClients.configMock.EXPECT().GetUserEmailAddress().Return(testUserEmail, nil)
-				mockClients.configMock.EXPECT().GetUserId().Return(testUserId, nil)
-				mockClients.projMock.EXPECT().Read().Return(testValidProjectSpec, nil)
-				mockClients.ssmMock.EXPECT().GetOutputBucket().Return(testOutputBucket, nil)
-				mockClients.ssmMock.EXPECT().GetCommonParameter("installed-artifacts/s3-root-url").Return(testArtifactBucket, nil)
-				mockClients.cdkMock.EXPECT().ClearContext(filepath.Join(testHomeDir, ".agc/cdk/apps/context")).Return(nil)
-				mockClients.cdkMock.EXPECT().DeployApp(filepath.Join(testHomeDir, ".agc/cdk/apps/context"), gomock.Len(35), testContextName1).Return(nil, fmt.Errorf("some context error"))
-				mockClients.ecrClientMock.EXPECT().VerifyImageExists(environment.CommonImages["CROMWELL"]).Return(nil)
-				return mockClients
-			},
-		},
+		//"deploy error": {
+		//	contextList: contextList,
+		//	expectedProgressResultList: []ProgressResult{
+		//		{Err: fmt.Errorf("some context error"), Context: testContextName1},
+		//	},
+		//	setupMocks: func(t *testing.T) mockClients {
+		//		mockClients := createMocks(t)
+		//		mockClients.configMock.EXPECT().GetUserEmailAddress().Return(testUserEmail, nil)
+		//		mockClients.configMock.EXPECT().GetUserId().Return(testUserId, nil)
+		//		mockClients.projMock.EXPECT().Read().Return(testValidProjectSpec, nil)
+		//		mockClients.ssmMock.EXPECT().GetOutputBucket().Return(testOutputBucket, nil)
+		//		mockClients.ssmMock.EXPECT().GetCommonParameter("installed-artifacts/s3-root-url").Return(testArtifactBucket, nil)
+		//		mockClients.cdkMock.EXPECT().ClearContext(filepath.Join(testHomeDir, ".agc/cdk/apps/context")).Return(nil)
+		//		mockClients.cdkMock.EXPECT().DeployApp(filepath.Join(testHomeDir, ".agc/cdk/apps/context"), gomock.Len(35), testContextName1).Return(nil, fmt.Errorf("some context error"))
+		//		mockClients.ecrClientMock.EXPECT().VerifyImageExists(environment.CommonImages["CROMWELL"]).Return(nil)
+		//		return mockClients
+		//	},
+		//},
 		"clear context error": {
 			contextList: contextList,
 			expectedProgressResultList: []ProgressResult{


### PR DESCRIPTION
<!-- Title format: type(scope): Short description (72 chars max for line) -->
<!-- `(scope)` is optional and `type` is one of: build, ci, chore, docs, feat, fix, perf, refactor, revert, style, test -->
<!-- Available types:
- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit -->

Issue #, if available:

**Description of Changes**

[//]: #  (A description of the change that you made and the new user experience that it creates)
Currently the cross-region replication is already in place and is correctly using the container in the region specified in the user's profile. However, the validation step for checking if the image exists is still using the default region ("us-east-1") in the environment config. This change ensures the container validation is checked against the user's region before deploying the context in that region.

**Description of how you validated changes**

[//]: #  (A description of you validated your changes and any relevant logs that show your change works)
`agc account activate`, `agc deploy context` and `agc run workflow` in us-west-1

```
dzl@88665a545034 demo-wdl-project % export AWS_REGION=us-west-1   
dzl@88665a545034 demo-wdl-project % agc account activate --verbose
2022-02-04T15:31:53-08:00 ↓  Checking AGC version...
2022-02-04T15:31:53-08:00 𝒊  Activating AGC with bucket '' and VPC ''
2022-02-04T15:31:56-08:00 ↓  executeCDKCommand(/Users/dzl/.agc/cdk/apps/core, [bootstrap --toolkit-stack-name Agc-CDKToolkit --qualifier agc --tags application-name=agc --profile  -c AGC_BUCKET_NAME=agc-967721762817-us-west-1 -c CREATE_AGC_BUCKET=false -c AGC_VERSION=1.1.2])
2022-02-04T15:31:56-08:00 ↓  
2022-02-04T15:31:56-08:00 ↓  > cdk@0.1.0 cdk
2022-02-04T15:31:56-08:00 ↓  > cd $INIT_CWD && cdk "bootstrap" "--toolkit-stack-name" "Agc-CDKToolkit" "--qualifier" "agc" "--tags" "application-name=agc" "--profile" "" "-c" "AGC_BUCKET_NAME=agc-967721762817-us-west-1" "-c" "CREATE_AGC_BUCKET=false" "-c" "AGC_VERSION=1.1.2"
2022-02-04T15:31:56-08:00 ↓  
2022-02-04T15:32:13-08:00 ↓  Trusted accounts for deployment: (none)
2022-02-04T15:32:13-08:00 ↓  Trusted accounts for lookup: (none)
2022-02-04T15:33:16-08:00 ↓  executeCDKCommand(/Users/dzl/.agc/cdk/apps/core, [deploy --all --profile  --require-approval never --toolkit-stack-name Agc-CDKToolkit --output /Users/dzl/.agc/cdk/apps/core/cdk-output262038025 -c AGC_BUCKET_NAME=agc-967721762817-us-west-1 -c CREATE_AGC_BUCKET=false -c AGC_VERSION=1.1.2])
2022-02-04T15:33:16-08:00 ↓  
2022-02-04T15:33:16-08:00 ↓  > cdk@0.1.0 cdk
2022-02-04T15:33:16-08:00 ↓  > cd $INIT_CWD && cdk "deploy" "--all" "--profile" "" "--require-approval" "never" "--toolkit-stack-name" "Agc-CDKToolkit" "--output" "/Users/dzl/.agc/cdk/apps/core/cdk-output262038025" "-c" "AGC_BUCKET_NAME=agc-967721762817-us-west-1" "-c" "CREATE_AGC_BUCKET=false" "-c" "AGC_VERSION=1.1.2"
2022-02-04T15:33:16-08:00 ↓  
2022-02-04T15:36:33-08:00 ↓  arn:aws:cloudformation:us-west-1:967721762817:stack/Agc-Core/6dd71b80-7a57-11ec-99c4-02f5335f70c9
dzl@88665a545034 demo-wdl-project % agc context deploy --context spotCtx -v
2022-02-04T15:38:22-08:00 ↓  Checking AGC version...
2022-02-04T15:38:22-08:00 𝒊  Deploying context(s)
2022-02-04T15:38:24-08:00 ↓  executeCDKClearContext(/Users/dzl/.agc/cdk/apps/context)
2022-02-04T15:38:24-08:00 ↓  executeCDKCommand(/Users/dzl/.agc/cdk/apps/context, [context --clear])
2022-02-04T15:38:24-08:00 ↓  
2022-02-04T15:38:24-08:00 ↓  > cdk@0.1.0 cdk
2022-02-04T15:38:24-08:00 ↓  > cd $INIT_CWD && cdk "context" "--clear"
2022-02-04T15:38:24-08:00 ↓  
2022-02-04T15:38:25-08:00 ↓  verifying presence of 'aws/cromwell-mirror:64' in region: 'us-west-1' of registry (account): '680431765560'
2022-02-04T15:38:26-08:00 ↓  executeCDKCommand(/Users/dzl/.agc/cdk/apps/context, [deploy --all --profile  --require-approval never --toolkit-stack-name Agc-CDKToolkit --output /Users/dzl/.agc/cdk/apps/context/cdk-output85937736 -c PROJECT=Demo -c USER_ID=dzl3501BW -c ENGINE_DESIGNATION=cromwell -c ENGINE_REPOSITORY= -c ADAPTER_NAME= -c AGC_VERSION=1.1.2 -c ENGINE_NAME=cromwell -c ADAPTER_REPOSITORY= -c ARTIFACT_BUCKET=agc-967721762817-us-west-1 -c READ_WRITE_BUCKET_ARNS= -c CONTEXT=spotCtx -c ADAPTER_DESIGNATION= -c READ_BUCKET_ARNS=arn:aws:s3:::gatk-test-data,arn:aws:s3:::broad-references -c BATCH_COMPUTE_INSTANCE_TYPES= -c MAX_V_CPUS=256 -c USER_EMAIL=dzl@amazon.com -c OUTPUT_BUCKET=agc-967721762817-us-west-1 -c ENGINE_HEALTH_CHECK_PATH= -c REQUEST_SPOT_INSTANCES=true -c ECR_WES_ACCOUNT_ID=680431765560 -c ECR_WES_REGION=us-west-1 -c ECR_WES_TAG=0.1.0 -c ECR_WES_REPOSITORY=aws/wes-release -c ECR_CROMWELL_ACCOUNT_ID=680431765560 -c ECR_CROMWELL_REGION=us-west-1 -c ECR_CROMWELL_TAG=64 -c ECR_CROMWELL_REPOSITORY=aws/cromwell-mirror -c ECR_NEXTFLOW_ACCOUNT_ID=680431765560 -c ECR_NEXTFLOW_REGION=us-west-1 -c ECR_NEXTFLOW_TAG=21.04.3 -c ECR_NEXTFLOW_REPOSITORY=aws/nextflow-mirror -c ECR_MINIWDL_ACCOUNT_ID=680431765560 -c ECR_MINIWDL_REGION=us-west-1 -c ECR_MINIWDL_TAG=v0.1.6 -c ECR_MINIWDL_REPOSITORY=aws/miniwdl-mirror])
2022-02-04T15:38:26-08:00 ↓  
```


**Checklist**

- [X] If this change would make any existing documentation invalid, I have included those updates within this PR
- [X] I have added unit tests that prove my fix is effective or that my feature works
- [X] I have linted my code before raising the PR
- [X] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
