### PR TITLE
feat: Implement EFS IOPs specification in Project YAML

### DIFF
--- a/packages/cdk/lib/env/context-app-parameters.ts
+++ b/packages/cdk/lib/env/context-app-parameters.ts
@@ -46,6 +46,10 @@ export class ContextAppParameters {
    */
   public readonly engineName: string;
   /**
+   * Name of the filesystem to use.
+   */
+  public readonly filesystemType?: string;
+  /**
    * Name of the engine ECR image.
    */
   public readonly engineDesignation: string;
@@ -98,6 +102,7 @@ export class ContextAppParameters {
     this.readWriteBucketArns = getEnvStringListOrDefault(node, "READ_WRITE_BUCKET_ARNS");
 
     this.engineName = getEnvString(node, "ENGINE_NAME");
+    this.filesystemType = getEnvStringOrDefault(node, "FILESYSTEM_TYPE", this.getDefaultFilesystem());
     this.engineDesignation = getEnvString(node, "ENGINE_DESIGNATION");
     this.engineHealthCheckPath = getEnvStringOrDefault(node, "ENGINE_HEALTH_CHECK_PATH", "/engine/v1/status")!;
     this.callCachingEnabled = getEnvBoolOrDefault(node, "CALL_CACHING_ENABLED", true)!;
@@ -150,5 +155,23 @@ export class ContextAppParameters {
         ...additionalEnvVars,
       },
     };
+  }
+
+  public getDefaultFilesystem(): string {
+    let defFilesystem: string;
+    switch (this.engineName) {
+      case "cromwell":
+        defFilesystem = "S3";
+        break;
+      case "nextflow":
+        defFilesystem = "S3";
+        break;
+      case "miniwdl":
+        defFilesystem = "EFS";
+        break;
+      default:
+        throw Error(`Engine '${this.engineName}' is not supported`);
+    }
+    return defFilesystem;
   }
 }

--- a/packages/cli/internal/pkg/cli/spec/context.go
+++ b/packages/cli/internal/pkg/cli/spec/context.go
@@ -1,17 +1,48 @@
 package spec
 
+import "fmt"
+
 const DefaultMaxVCpus = 256
+const DefaultFSProvisionedThroughput = 0
 
-type Engine struct {
-	Type   string `yaml:"type"`
-	Engine string `yaml:"engine"`
+type FSConfig struct {
+	FSProvisionedThroughput int `yaml:"provisionedThroughput"`
 }
-
+type Filesystem struct {
+	FSType        string   `yaml:"fsType"`
+	Configuration FSConfig `yaml:"configuration"`
+}
+type Engine struct {
+	Type       string     `yaml:"type"`
+	Engine     string     `yaml:"engine"`
+	Filesystem Filesystem `yaml:"filesystem,omitempty"`
+}
 type Context struct {
 	InstanceTypes        []string `yaml:"instanceTypes,omitempty"`
 	RequestSpotInstances bool     `yaml:"requestSpotInstances,omitempty"`
 	MaxVCpus             int      `yaml:"maxVCpus,omitempty"`
 	Engines              []Engine `yaml:"engines"`
+}
+
+func (filesystem *Filesystem) UnmarshalYAML(unmarshal func(interface{}) error) error {
+
+	type defValFilesystem Filesystem
+	defaults := defValFilesystem{Configuration: FSConfig{
+		FSProvisionedThroughput: DefaultFSProvisionedThroughput,
+	},
+	}
+	if err := unmarshal(&defaults); err != nil {
+		return err
+	}
+
+	*filesystem = Filesystem(defaults)
+	switch filesystem.FSType {
+	case "S3", "EFS", "":
+		return nil
+	default:
+		return fmt.Errorf("Invalid filesystem type found. Options are `S3` and `EFS`")
+	}
+	return nil
 }
 
 func (context *Context) UnmarshalYAML(unmarshal func(interface{}) error) error {

--- a/packages/cli/internal/pkg/cli/spec/project_schema.json
+++ b/packages/cli/internal/pkg/cli/spec/project_schema.json
@@ -102,6 +102,28 @@
                   "engine": {
                     "type": "string",
                     "minLength": 1
+                  },
+                  "filesystem": {
+                    "type": "object",
+                    "items": {
+                      "properties": {
+                        "fsType": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "configuration": {
+                          "type": "object",
+                          "items": {
+                            "properties": {
+                              "provisionedThroughput": {
+                                "type": "string",
+                                "minLength": 1
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
                   }
                 },
                 "required": ["type", "engine"]

--- a/packages/cli/internal/pkg/cli/spec/project_test.go
+++ b/packages/cli/internal/pkg/cli/spec/project_test.go
@@ -29,7 +29,14 @@ func TestProjectYaml(t *testing.T) {
 					"testContext": {
 						MaxVCpus: 256,
 						Engines: []Engine{
-							{Type: "wdl", Engine: "cromwell"},
+							{
+								Type:   "wdl",
+								Engine: "cromwell",
+								Filesystem: Filesystem{
+									FSType:        "S3",
+									Configuration: FSConfig{FSProvisionedThroughput: 0},
+								},
+							},
 						},
 					},
 				},
@@ -61,6 +68,10 @@ contexts:
         engines:
             - type: wdl
               engine: cromwell
+              filesystem:
+                fsType: S3
+                configuration:
+                    provisionedThroughput: 0
 `,
 		},
 		"empty": {
@@ -86,13 +97,27 @@ schemaVersion: 0
 					"ctx1": {
 						MaxVCpus: 256,
 						Engines: []Engine{
-							{Type: "wdl", Engine: "miniwdl"},
+							{
+								Type:   "wdl",
+								Engine: "miniwdl",
+								Filesystem: Filesystem{
+									FSType:        "S3",
+									Configuration: FSConfig{FSProvisionedThroughput: 0},
+								},
+							},
 						},
 					},
 					"ctx2": {
 						MaxVCpus: 256,
 						Engines: []Engine{
-							{Type: "nextflow", Engine: "nextflow"},
+							{
+								Type:   "nextflow",
+								Engine: "nextflow",
+								Filesystem: Filesystem{
+									FSType:        "S3",
+									Configuration: FSConfig{FSProvisionedThroughput: 0},
+								},
+							},
 						},
 					},
 				},
@@ -122,11 +147,19 @@ contexts:
         engines:
             - type: wdl
               engine: miniwdl
+              filesystem:
+                fsType: S3
+                configuration:
+                    provisionedThroughput: 0
     ctx2:
         maxVCpus: 256
         engines:
             - type: nextflow
               engine: nextflow
+              filesystem:
+                fsType: S3
+                configuration:
+                    provisionedThroughput: 0
 `,
 		},
 	}
@@ -168,6 +201,25 @@ contexts:
 	})
 }
 
+func TestEngineDefaults(t *testing.T) {
+	const yamlStr = `
+name: DefaultTest
+schemaVersion: 1
+contexts:
+    context:
+        engines:
+            - type: wdl
+              engine: cromwell
+`
+
+	t.Run("EngineDefaults", func(t *testing.T) {
+		result := Engine{}
+		err := yaml.Unmarshal([]byte(yamlStr), &result)
+		require.NoError(t, err)
+		assert.Equal(t, result.Filesystem.Configuration.FSProvisionedThroughput, DefaultFSProvisionedThroughput)
+	})
+}
+
 func TestGetContext(t *testing.T) {
 	type args struct {
 		projectSpec Project
@@ -187,12 +239,26 @@ func TestGetContext(t *testing.T) {
 					Contexts: map[string]Context{
 						"ctx1": {
 							Engines: []Engine{
-								{Type: "wdl", Engine: "miniwdl"},
+								{
+									Type:   "wdl",
+									Engine: "miniwdl",
+									Filesystem: Filesystem{
+										FSType:        "S3",
+										Configuration: FSConfig{FSProvisionedThroughput: 0},
+									},
+								},
 							},
 						},
 						"ctx2": {
 							Engines: []Engine{
-								{Type: "nextflow", Engine: "nextflow"},
+								{
+									Type:   "nextflow",
+									Engine: "nextflow",
+									Filesystem: Filesystem{
+										FSType:        "S3",
+										Configuration: FSConfig{FSProvisionedThroughput: 0},
+									},
+								},
 							},
 						},
 					},
@@ -209,12 +275,26 @@ func TestGetContext(t *testing.T) {
 					Contexts: map[string]Context{
 						"ctx1": {
 							Engines: []Engine{
-								{Type: "wdl", Engine: "miniwdl"},
+								{
+									Type:   "wdl",
+									Engine: "miniwdl",
+									Filesystem: Filesystem{
+										FSType:        "S3",
+										Configuration: FSConfig{FSProvisionedThroughput: 0},
+									},
+								},
 							},
 						},
 						"ctx2": {
 							Engines: []Engine{
-								{Type: "nextflow", Engine: "nextflow"},
+								{
+									Type:   "nextflow",
+									Engine: "nextflow",
+									Filesystem: Filesystem{
+										FSType:        "S3",
+										Configuration: FSConfig{FSProvisionedThroughput: 0},
+									},
+								},
 							},
 						},
 					},
@@ -223,7 +303,14 @@ func TestGetContext(t *testing.T) {
 			},
 			expectedContext: Context{
 				Engines: []Engine{
-					{Type: "wdl", Engine: "miniwdl"},
+					{
+						Type:   "wdl",
+						Engine: "miniwdl",
+						Filesystem: Filesystem{
+							FSType:        "S3",
+							Configuration: FSConfig{FSProvisionedThroughput: 0},
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
**Description of Changes**

We want to be able to specify the filesystem used and the throughput. This allows customers with large numbers of large files to accelerate workflows. Filesystem options are S3 and EFS, with a default of S3 for Cromwell and Nextflow and a default of EFS for MiniWDL. Valid throughput values are 1 to 1024.

**Description of how you validated changes**

I have added a test that checks that the default throughput is set. I have run `./scripts/run-dev.sh` with a valid `agc-project.yaml` and invalid versions containing invalid filesystems and invalid throughput values.

**Checklist**

- [ ] If this change would make any existing documentation invalid, I have included those updates within this PR
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have linted my code before raising the PR
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
