### PR TITLE
feat: Implement EFS IOPs specification in Project YAML

### DIFF
--- a/packages/cdk/lib/constructs/engines/engine.ts
+++ b/packages/cdk/lib/constructs/engines/engine.ts
@@ -1,8 +1,8 @@
 import { ILogGroup, LogGroup } from "aws-cdk-lib/aws-logs";
 import { Construct } from "constructs";
 import { IVpc } from "aws-cdk-lib/aws-ec2";
-import { AccessPoint, FileSystem, PerformanceMode } from "aws-cdk-lib/aws-efs";
-import { RemovalPolicy } from "aws-cdk-lib";
+import { AccessPoint, FileSystem, PerformanceMode, ThroughputMode } from "aws-cdk-lib/aws-efs";
+import { RemovalPolicy, Size } from "aws-cdk-lib";
 import { MountPoint, Volume } from "aws-cdk-lib/aws-ecs";
 
 export interface EngineProps {
@@ -59,9 +59,11 @@ export class Engine extends Construct {
     });
   }
 
-  protected createFileSystem(vpc: IVpc): FileSystem {
+  protected createFileSystem(vpc: IVpc, iops: Size): FileSystem {
     return new FileSystem(this, "FileSystem", {
       vpc: vpc,
+      provisionedThroughputPerSecond: iops,
+      throughputMode: ThroughputMode.PROVISIONED,
       encrypted: true,
       performanceMode: PerformanceMode.MAX_IO,
       removalPolicy: RemovalPolicy.DESTROY,

--- a/packages/cdk/lib/constructs/engines/engine.ts
+++ b/packages/cdk/lib/constructs/engines/engine.ts
@@ -59,11 +59,21 @@ export class Engine extends Construct {
     });
   }
 
-  protected createFileSystem(vpc: IVpc, iops: Size): FileSystem {
+  protected createFileSystemIOPS(vpc: IVpc, iops: Size): FileSystem {
     return new FileSystem(this, "FileSystem", {
       vpc: vpc,
       provisionedThroughputPerSecond: iops,
       throughputMode: ThroughputMode.PROVISIONED,
+      encrypted: true,
+      performanceMode: PerformanceMode.MAX_IO,
+      removalPolicy: RemovalPolicy.DESTROY,
+    });
+  }
+
+  protected createFileSystemDefaultThroughput(vpc: IVpc): FileSystem {
+    return new FileSystem(this, "FileSystem", {
+      vpc: vpc,
+      throughputMode: ThroughputMode.BURSTING,
       encrypted: true,
       performanceMode: PerformanceMode.MAX_IO,
       removalPolicy: RemovalPolicy.DESTROY,

--- a/packages/cdk/lib/constructs/engines/miniwdl/miniwdl-engine.ts
+++ b/packages/cdk/lib/constructs/engines/miniwdl/miniwdl-engine.ts
@@ -6,11 +6,12 @@ import { Batch } from "../../batch";
 import { Engine, EngineProps } from "../engine";
 import { EngineJobDefinition } from "../engine-job-definition";
 import { Size } from "aws-cdk-lib";
+import { FileSystem } from "aws-cdk-lib/aws-efs";
 
 export interface MiniWdlEngineProps extends EngineProps {
   readonly engineBatch: Batch;
   readonly workerBatch: Batch;
-  readonly iops: Size;
+  readonly iops?: Size;
 }
 
 const MINIWDL_IMAGE_DESIGNATION = "miniwdl";
@@ -19,17 +20,22 @@ export class MiniWdlEngine extends Engine {
   readonly headJobDefinition: JobDefinition;
   private readonly engineMemoryMiB = 4096;
   private readonly volumeName = "efs";
+  readonly fileSystem: FileSystem;
 
   constructor(scope: Construct, id: string, props: MiniWdlEngineProps) {
     super(scope, id);
 
     const { vpc, iops, rootDirS3Uri, engineBatch, workerBatch } = props;
-    const fileSystem = this.createFileSystem(vpc, iops);
-    const accessPoint = this.createAccessPoint(fileSystem);
+    if (iops?.toMebibytes() == 0 || iops == undefined) {
+      this.fileSystem = this.createFileSystemDefaultThroughput(vpc);
+    } else {
+      this.fileSystem = this.createFileSystemIOPS(vpc, iops);
+    }
+    const accessPoint = this.createAccessPoint(this.fileSystem);
 
-    fileSystem.connections.allowDefaultPortFromAnyIpv4();
-    fileSystem.grant(engineBatch.role, "elasticfilesystem:DescribeMountTargets", "elasticfilesystem:DescribeFileSystems");
-    fileSystem.grant(workerBatch.role, "elasticfilesystem:DescribeMountTargets", "elasticfilesystem:DescribeFileSystems");
+    this.fileSystem.connections.allowDefaultPortFromAnyIpv4();
+    this.fileSystem.grant(engineBatch.role, "elasticfilesystem:DescribeMountTargets", "elasticfilesystem:DescribeFileSystems");
+    this.fileSystem.grant(workerBatch.role, "elasticfilesystem:DescribeMountTargets", "elasticfilesystem:DescribeFileSystems");
 
     this.headJobDefinition = new EngineJobDefinition(this, "MiniwdlHeadJobDef", {
       logGroup: this.logGroup,
@@ -41,12 +47,12 @@ export class MiniWdlEngine extends Engine {
         image: createEcrImage(this, MINIWDL_IMAGE_DESIGNATION),
         platformVersion: FargatePlatformVersion.VERSION1_4,
         environment: {
-          MINIWDL__AWS__FS: fileSystem.fileSystemId,
+          MINIWDL__AWS__FS: this.fileSystem.fileSystemId,
           MINIWDL__AWS__FSAP: accessPoint.accessPointId,
           MINIWDL__AWS__TASK_QUEUE: workerBatch.jobQueue.jobQueueArn,
           MINIWDL_S3_OUTPUT_URI: rootDirS3Uri,
         },
-        volumes: [this.toVolume(fileSystem, accessPoint, this.volumeName)],
+        volumes: [this.toVolume(this.fileSystem, accessPoint, this.volumeName)],
         mountPoints: [this.toMountPoint("/mnt/efs", this.volumeName)],
       },
     });

--- a/packages/cdk/lib/constructs/engines/miniwdl/miniwdl-engine.ts
+++ b/packages/cdk/lib/constructs/engines/miniwdl/miniwdl-engine.ts
@@ -5,10 +5,12 @@ import { createEcrImage } from "../../../util";
 import { Batch } from "../../batch";
 import { Engine, EngineProps } from "../engine";
 import { EngineJobDefinition } from "../engine-job-definition";
+import { Size } from "aws-cdk-lib";
 
 export interface MiniWdlEngineProps extends EngineProps {
   readonly engineBatch: Batch;
   readonly workerBatch: Batch;
+  readonly iops: Size;
 }
 
 const MINIWDL_IMAGE_DESIGNATION = "miniwdl";
@@ -21,8 +23,8 @@ export class MiniWdlEngine extends Engine {
   constructor(scope: Construct, id: string, props: MiniWdlEngineProps) {
     super(scope, id);
 
-    const { vpc, rootDirS3Uri, engineBatch, workerBatch } = props;
-    const fileSystem = this.createFileSystem(vpc);
+    const { vpc, iops, rootDirS3Uri, engineBatch, workerBatch } = props;
+    const fileSystem = this.createFileSystem(vpc, iops);
     const accessPoint = this.createAccessPoint(fileSystem);
 
     fileSystem.connections.allowDefaultPortFromAnyIpv4();

--- a/packages/cdk/lib/constructs/engines/snakemake/snakemake-engine.ts
+++ b/packages/cdk/lib/constructs/engines/snakemake/snakemake-engine.ts
@@ -6,10 +6,12 @@ import { Engine, EngineProps } from "../engine";
 import { Batch } from "../../batch";
 import { FargatePlatformVersion } from "aws-cdk-lib/aws-ecs";
 import { AccessPoint, FileSystem } from "aws-cdk-lib/aws-efs";
+import { Size } from "aws-cdk-lib";
 
 export interface SnakemakeEngineProps extends EngineProps {
   readonly engineBatch: Batch;
   readonly workerBatch: Batch;
+  readonly iops: Size;
 }
 
 const SNAKEMAKE_IMAGE_DESIGNATION = "snakemake";
@@ -24,8 +26,8 @@ export class SnakemakeEngine extends Engine {
   constructor(scope: Construct, id: string, props: SnakemakeEngineProps) {
     super(scope, id);
 
-    const { vpc, engineBatch, workerBatch } = props;
-    this.fileSystem = this.createFileSystem(vpc);
+    const { vpc, iops, engineBatch, workerBatch } = props;
+    this.fileSystem = this.createFileSystem(vpc, iops);
     this.fsap = this.createAccessPoint(this.fileSystem);
 
     this.fileSystem.connections.allowDefaultPortFromAnyIpv4();

--- a/packages/cdk/lib/constructs/engines/snakemake/snakemake-engine.ts
+++ b/packages/cdk/lib/constructs/engines/snakemake/snakemake-engine.ts
@@ -11,7 +11,7 @@ import { Size } from "aws-cdk-lib";
 export interface SnakemakeEngineProps extends EngineProps {
   readonly engineBatch: Batch;
   readonly workerBatch: Batch;
-  readonly iops: Size;
+  readonly iops?: Size;
 }
 
 const SNAKEMAKE_IMAGE_DESIGNATION = "snakemake";
@@ -27,7 +27,11 @@ export class SnakemakeEngine extends Engine {
     super(scope, id);
 
     const { vpc, iops, engineBatch, workerBatch } = props;
-    this.fileSystem = this.createFileSystem(vpc, iops);
+    if (iops?.toMebibytes() == 0 || iops == undefined) {
+      this.fileSystem = this.createFileSystemDefaultThroughput(vpc);
+    } else {
+      this.fileSystem = this.createFileSystemIOPS(vpc, iops);
+    }
     this.fsap = this.createAccessPoint(this.fileSystem);
 
     this.fileSystem.connections.allowDefaultPortFromAnyIpv4();

--- a/packages/cdk/lib/env/context-app-parameters.ts
+++ b/packages/cdk/lib/env/context-app-parameters.ts
@@ -46,6 +46,10 @@ export class ContextAppParameters {
    */
   public readonly engineName: string;
   /**
+   * Name of the filesystem to use.
+   */
+  public readonly filesystemType?: string;
+  /**
    * Name of the engine ECR image.
    */
   public readonly engineDesignation: string;
@@ -98,6 +102,7 @@ export class ContextAppParameters {
     this.readWriteBucketArns = getEnvStringListOrDefault(node, "READ_WRITE_BUCKET_ARNS");
 
     this.engineName = getEnvString(node, "ENGINE_NAME");
+    this.filesystemType = getEnvStringOrDefault(node, "FILESYSTEM_TYPE", this.getDefaultFilesystem());
     this.engineDesignation = getEnvString(node, "ENGINE_DESIGNATION");
     this.engineHealthCheckPath = getEnvStringOrDefault(node, "ENGINE_HEALTH_CHECK_PATH", "/engine/v1/status")!;
     this.callCachingEnabled = getEnvBoolOrDefault(node, "CALL_CACHING_ENABLED", true)!;
@@ -150,5 +155,23 @@ export class ContextAppParameters {
         ...additionalEnvVars,
       },
     };
+  }
+
+  public getDefaultFilesystem(): string {
+    let defFilesystem: string;
+    switch (this.engineName) {
+      case "cromwell":
+        defFilesystem = "S3";
+        break;
+      case "nextflow":
+        defFilesystem = "S3";
+        break;
+      case "miniwdl":
+        defFilesystem = "EFS";
+        break;
+      default:
+        throw Error(`Engine '${this.engineName}' is not supported`);
+    }
+    return defFilesystem;
   }
 }

--- a/packages/cdk/lib/env/context-app-parameters.ts
+++ b/packages/cdk/lib/env/context-app-parameters.ts
@@ -46,9 +46,13 @@ export class ContextAppParameters {
    */
   public readonly engineName: string;
   /**
-   * Name of the filesystem to use.
+   * Name of the filesystem type to use (e.g. EFS, S3).
    */
   public readonly filesystemType?: string;
+  /**
+   * Name of the filesystem type to use (e.g. EFS, S3).
+   */
+  public readonly fsProvisionedThroughput?: number;
   /**
    * Name of the engine ECR image.
    */
@@ -103,6 +107,7 @@ export class ContextAppParameters {
 
     this.engineName = getEnvString(node, "ENGINE_NAME");
     this.filesystemType = getEnvStringOrDefault(node, "FILESYSTEM_TYPE", this.getDefaultFilesystem());
+    this.fsProvisionedThroughput = getEnvNumber(node, "FS_PROVISIONED_THROUGHPUT");
     this.engineDesignation = getEnvString(node, "ENGINE_DESIGNATION");
     this.engineHealthCheckPath = getEnvStringOrDefault(node, "ENGINE_HEALTH_CHECK_PATH", "/engine/v1/status")!;
     this.callCachingEnabled = getEnvBoolOrDefault(node, "CALL_CACHING_ENABLED", true)!;
@@ -167,6 +172,9 @@ export class ContextAppParameters {
         defFilesystem = "S3";
         break;
       case "miniwdl":
+        defFilesystem = "EFS";
+        break;
+      case "snakemake":
         defFilesystem = "EFS";
         break;
       default:

--- a/packages/cdk/lib/env/context-app-parameters.ts
+++ b/packages/cdk/lib/env/context-app-parameters.ts
@@ -50,7 +50,7 @@ export class ContextAppParameters {
    */
   public readonly filesystemType?: string;
   /**
-   * Name of the filesystem type to use (e.g. EFS, S3).
+   * Amount of provisioned IOPS to use.
    */
   public readonly fsProvisionedThroughput?: number;
   /**

--- a/packages/cdk/lib/stacks/engines/miniwdl-engine-construct.ts
+++ b/packages/cdk/lib/stacks/engines/miniwdl-engine-construct.ts
@@ -45,6 +45,7 @@ export class MiniwdlEngineConstruct extends EngineConstruct {
 
     this.miniwdlEngine = new MiniWdlEngine(this, "MiniWdlEngine", {
       vpc: props.vpc,
+      iops: props.iops,
       rootDirS3Uri: rootDirS3Uri,
       engineBatch: this.batchHead,
       workerBatch: this.batchWorkers,

--- a/packages/cdk/lib/stacks/engines/snakemake-engine-construct.ts
+++ b/packages/cdk/lib/stacks/engines/snakemake-engine-construct.ts
@@ -88,6 +88,7 @@ export class SnakemakeEngineConstruct extends EngineConstruct {
   private createSnakemakeEngine(props: EngineOptions, batchHead: Batch, batchWorkers: Batch): SnakemakeEngine {
     return new SnakemakeEngine(this, "SnakemakeEngine", {
       vpc: props.vpc,
+      iops: props.iops,
       engineBatch: batchHead,
       workerBatch: batchWorkers,
       rootDirS3Uri: props.contextParameters.getEngineBucketPath(),

--- a/packages/cdk/lib/types/engine-options.ts
+++ b/packages/cdk/lib/types/engine-options.ts
@@ -1,6 +1,7 @@
 import { RoleProps } from "aws-cdk-lib/aws-iam";
 import { IVpc } from "aws-cdk-lib/aws-ec2";
 import { ContextAppParameters } from "../env";
+import { Size } from "aws-cdk-lib";
 
 export type PolicyOptions = Pick<RoleProps, "inlinePolicies" | "managedPolicies">;
 
@@ -15,6 +16,10 @@ export interface EngineOptions {
    * VPC to run resources in.
    */
   readonly vpc: IVpc;
+  /**
+   * Filesystem provisioned throughput to use for EFS.
+   */
+  readonly iops: Size;
   /**
    * Parameters determined by the context.
    */

--- a/packages/cdk/lib/types/engine-options.ts
+++ b/packages/cdk/lib/types/engine-options.ts
@@ -19,7 +19,7 @@ export interface EngineOptions {
   /**
    * Filesystem provisioned throughput to use for EFS.
    */
-  readonly iops: Size;
+  readonly iops?: Size;
   /**
    * Parameters determined by the context.
    */

--- a/packages/cli/internal/pkg/cli/context/context_environment.go
+++ b/packages/cli/internal/pkg/cli/context/context_environment.go
@@ -17,10 +17,12 @@ type contextEnvironment struct {
 	UserEmail        string
 	OutputBucketName string
 
-	EngineName            string
-	EngineDesignation     string
-	EngineRepository      string
-	EngineHealthCheckPath string
+	EngineName              string
+	FilesystemType          string
+	FSProvisionedThroughput int
+	EngineDesignation       string
+	EngineRepository        string
+	EngineHealthCheckPath   string
 
 	AdapterName        string
 	AdapterDesignation string
@@ -44,10 +46,12 @@ func (input contextEnvironment) ToEnvironmentList() []string {
 		"OUTPUT_BUCKET": input.OutputBucketName,
 		"AGC_VERSION":   version.Version,
 
-		"ENGINE_NAME":              input.EngineName,
-		"ENGINE_DESIGNATION":       input.EngineDesignation,
-		"ENGINE_REPOSITORY":        input.EngineRepository,
-		"ENGINE_HEALTH_CHECK_PATH": input.EngineHealthCheckPath,
+		"ENGINE_NAME":               input.EngineName,
+		"FILESYSTEM_TYPE":           input.FilesystemType,
+		"FS_PROVISIONED_THROUGHPUT": strconv.Itoa(input.FSProvisionedThroughput),
+		"ENGINE_DESIGNATION":        input.EngineDesignation,
+		"ENGINE_REPOSITORY":         input.EngineRepository,
+		"ENGINE_HEALTH_CHECK_PATH":  input.EngineHealthCheckPath,
 
 		"ADAPTER_NAME":        input.AdapterName,
 		"ADAPTER_DESIGNATION": input.AdapterDesignation,

--- a/packages/cli/internal/pkg/cli/context/manager.go
+++ b/packages/cli/internal/pkg/cli/context/manager.go
@@ -218,8 +218,10 @@ func (m *Manager) setContextEnv(contextName string) {
 		RequestSpotInstances: m.contextSpec.RequestSpotInstances,
 		// TODO: we default to a single engine in a context for now
 		// need to allow for multiple engines in the same context
-		EngineName:        context.Engines[0].Engine,
-		EngineDesignation: context.Engines[0].Engine,
+		EngineName:              context.Engines[0].Engine,
+		EngineDesignation:       context.Engines[0].Engine,
+		FilesystemType:          context.Engines[0].Filesystem.FSType,
+		FSProvisionedThroughput: context.Engines[0].Filesystem.Configuration.FSProvisionedThroughput,
 	}
 }
 func (m *Manager) validateImage() {

--- a/packages/cli/internal/pkg/cli/context/manager_deploy_test.go
+++ b/packages/cli/internal/pkg/cli/context/manager_deploy_test.go
@@ -45,7 +45,7 @@ func TestManager_Deploy(t *testing.T) {
 				mockClients.ssmMock.EXPECT().GetCommonParameter("installed-artifacts/s3-root-url").Return(testArtifactBucket, nil)
 				mockClients.ecrClientMock.EXPECT().VerifyImageExists(environment.CommonImages["NEXTFLOW"]).Return(nil)
 				clearContext := mockClients.cdkMock.EXPECT().ClearContext(filepath.Join(testHomeDir, ".agc/cdk/apps/context")).Return(nil)
-				mockClients.cdkMock.EXPECT().DeployApp(filepath.Join(testHomeDir, ".agc/cdk/apps/context"), gomock.Len(39), testContextName3).After(clearContext).Return(mockClients.progressStream1, nil)
+				mockClients.cdkMock.EXPECT().DeployApp(filepath.Join(testHomeDir, ".agc/cdk/apps/context"), gomock.Len(41), testContextName3).After(clearContext).Return(mockClients.progressStream1, nil)
 				displayProgressBar = mockClients.cdkMock.DisplayProgressBar
 				mockClients.cdkMock.EXPECT().DisplayProgressBar(fmt.Sprintf("Deploying resources for context(s) %s", []string{testContextName3}), []cdk.ProgressStream{mockClients.progressStream1}).Return([]cdk.Result{{Outputs: []string{"some message"}, ExecutionName: testContextName3}})
 				return mockClients
@@ -69,8 +69,8 @@ func TestManager_Deploy(t *testing.T) {
 				mockClients.ecrClientMock.EXPECT().VerifyImageExists(environment.CommonImages["CROMWELL"]).Times(2).Return(nil)
 				clearContext := mockClients.cdkMock.EXPECT().ClearContext(filepath.Join(testHomeDir, ".agc/cdk/apps/context")).Return(nil)
 				clearContext2 := mockClients.cdkMock.EXPECT().ClearContext(filepath.Join(testHomeDir, ".agc/cdk/apps/context")).Return(nil)
-				mockClients.cdkMock.EXPECT().DeployApp(filepath.Join(testHomeDir, ".agc/cdk/apps/context"), gomock.Len(39), testContextName1).After(clearContext).Return(mockClients.progressStream1, nil)
-				mockClients.cdkMock.EXPECT().DeployApp(filepath.Join(testHomeDir, ".agc/cdk/apps/context"), gomock.Len(39), testContextName2).After(clearContext2).Return(mockClients.progressStream2, nil)
+				mockClients.cdkMock.EXPECT().DeployApp(filepath.Join(testHomeDir, ".agc/cdk/apps/context"), gomock.Len(41), testContextName1).After(clearContext).Return(mockClients.progressStream1, nil)
+				mockClients.cdkMock.EXPECT().DeployApp(filepath.Join(testHomeDir, ".agc/cdk/apps/context"), gomock.Len(41), testContextName2).After(clearContext2).Return(mockClients.progressStream2, nil)
 				displayProgressBar = mockClients.cdkMock.DisplayProgressBar
 				expectedCdkResult := []cdk.Result{{Outputs: []string{"some message"}, ExecutionName: testContextName1}, {Outputs: []string{"some other message"}, ExecutionName: testContextName2}}
 				mockClients.cdkMock.EXPECT().DisplayProgressBar(fmt.Sprintf("Deploying resources for context(s) %s", []string{testContextName1, testContextName2}), []cdk.ProgressStream{mockClients.progressStream1, mockClients.progressStream2}).Return(expectedCdkResult)
@@ -207,7 +207,7 @@ func TestManager_Deploy(t *testing.T) {
 				mockClients.ssmMock.EXPECT().GetOutputBucket().Return(testOutputBucket, nil)
 				mockClients.ssmMock.EXPECT().GetCommonParameter("installed-artifacts/s3-root-url").Return(testArtifactBucket, nil)
 				mockClients.cdkMock.EXPECT().ClearContext(filepath.Join(testHomeDir, ".agc/cdk/apps/context")).Return(nil)
-				mockClients.cdkMock.EXPECT().DeployApp(filepath.Join(testHomeDir, ".agc/cdk/apps/context"), gomock.Len(39), testContextName1).Return(nil, fmt.Errorf("some context error"))
+				mockClients.cdkMock.EXPECT().DeployApp(filepath.Join(testHomeDir, ".agc/cdk/apps/context"), gomock.Len(41), testContextName1).Return(nil, fmt.Errorf("some context error"))
 				mockClients.ecrClientMock.EXPECT().VerifyImageExists(environment.CommonImages["CROMWELL"]).Return(nil)
 				return mockClients
 			},

--- a/packages/cli/internal/pkg/cli/spec/context.go
+++ b/packages/cli/internal/pkg/cli/spec/context.go
@@ -1,17 +1,44 @@
 package spec
 
+import "fmt"
+
 const DefaultMaxVCpus = 256
+const DefaultFSProvisionedThroughput = 0
 
-type Engine struct {
-	Type   string `yaml:"type"`
-	Engine string `yaml:"engine"`
+type FSConfig struct {
+	FSProvisionedThroughput int `yaml:"provisionedThroughput"`
 }
-
+type Filesystem struct {
+	FSType        string   `yaml:"fsType"`
+	Configuration FSConfig `yaml:"configuration,omitempty"`
+}
+type Engine struct {
+	Type       string     `yaml:"type"`
+	Engine     string     `yaml:"engine"`
+	Filesystem Filesystem `yaml:"filesystem,omitempty"`
+}
 type Context struct {
 	InstanceTypes        []string `yaml:"instanceTypes,omitempty"`
 	RequestSpotInstances bool     `yaml:"requestSpotInstances,omitempty"`
 	MaxVCpus             int      `yaml:"maxVCpus,omitempty"`
 	Engines              []Engine `yaml:"engines"`
+}
+
+func (filesystem *Filesystem) UnmarshalYAML(unmarshal func(interface{}) error) error {
+
+	type defValFilesystem Filesystem
+	defaults := defValFilesystem{Configuration: FSConfig{FSProvisionedThroughput: DefaultFSProvisionedThroughput}}
+	if err := unmarshal(&defaults); err != nil {
+		return err
+	}
+
+	*filesystem = Filesystem(defaults)
+	switch filesystem.FSType {
+	case "S3", "EFS", "":
+		return nil
+	default:
+		return fmt.Errorf("filesystem %s is invalid. Options are `S3` and `EFS`", filesystem.FSType)
+	}
 }
 
 func (context *Context) UnmarshalYAML(unmarshal func(interface{}) error) error {

--- a/packages/cli/internal/pkg/cli/spec/context.go
+++ b/packages/cli/internal/pkg/cli/spec/context.go
@@ -3,7 +3,7 @@ package spec
 import "fmt"
 
 const DefaultMaxVCpus = 256
-const DefaultFSProvisionedThroughput = 0
+const DefaultFSProvisionedThroughput = 1
 
 type FSConfig struct {
 	FSProvisionedThroughput int `yaml:"provisionedThroughput"`
@@ -34,10 +34,13 @@ func (filesystem *Filesystem) UnmarshalYAML(unmarshal func(interface{}) error) e
 
 	*filesystem = Filesystem(defaults)
 	switch filesystem.FSType {
-	case "S3", "EFS", "":
+	case "EFS", "":
+		return nil
+	case "S3":
+		filesystem.Configuration.FSProvisionedThroughput = 0
 		return nil
 	default:
-		return fmt.Errorf("filesystem %s is invalid. Options are `S3` and `EFS`", filesystem.FSType)
+		return fmt.Errorf("filesystem '%s' is invalid. Options are `S3` and `EFS`", filesystem.FSType)
 	}
 }
 

--- a/packages/cli/internal/pkg/cli/spec/context.go
+++ b/packages/cli/internal/pkg/cli/spec/context.go
@@ -1,9 +1,6 @@
 package spec
 
-import "fmt"
-
 const DefaultMaxVCpus = 256
-const DefaultFSProvisionedThroughput = 1
 
 type FSConfig struct {
 	FSProvisionedThroughput int `yaml:"provisionedThroughput"`
@@ -22,26 +19,6 @@ type Context struct {
 	RequestSpotInstances bool     `yaml:"requestSpotInstances,omitempty"`
 	MaxVCpus             int      `yaml:"maxVCpus,omitempty"`
 	Engines              []Engine `yaml:"engines"`
-}
-
-func (filesystem *Filesystem) UnmarshalYAML(unmarshal func(interface{}) error) error {
-
-	type defValFilesystem Filesystem
-	defaults := defValFilesystem{Configuration: FSConfig{FSProvisionedThroughput: DefaultFSProvisionedThroughput}}
-	if err := unmarshal(&defaults); err != nil {
-		return err
-	}
-
-	*filesystem = Filesystem(defaults)
-	switch filesystem.FSType {
-	case "EFS", "":
-		return nil
-	case "S3":
-		filesystem.Configuration.FSProvisionedThroughput = 0
-		return nil
-	default:
-		return fmt.Errorf("filesystem '%s' is invalid. Options are `S3` and `EFS`", filesystem.FSType)
-	}
 }
 
 func (context *Context) UnmarshalYAML(unmarshal func(interface{}) error) error {

--- a/packages/cli/internal/pkg/cli/spec/project_schema.json
+++ b/packages/cli/internal/pkg/cli/spec/project_schema.json
@@ -102,6 +102,29 @@
                   "engine": {
                     "type": "string",
                     "minLength": 1
+                  },
+                  "filesystem": {
+                    "type": "object",
+                    "items": {
+                      "properties": {
+                        "fsType": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "configuration": {
+                          "type": "object",
+                          "items": {
+                            "properties": {
+                              "provisionedThroughput": {
+                                "type": "integer",
+                                "minimum": 1,
+                                "maximum": 1024
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
                   }
                 },
                 "required": ["type", "engine"]

--- a/packages/cli/internal/pkg/cli/spec/project_schema.json
+++ b/packages/cli/internal/pkg/cli/spec/project_schema.json
@@ -109,7 +109,8 @@
                       "properties": {
                         "fsType": {
                           "type": "string",
-                          "minLength": 1
+                          "minLength": 1,
+                          "enum": ["S3","EFS"]
                         },
                         "configuration": {
                           "type": "object",
@@ -120,11 +121,29 @@
                                 "minimum": 1,
                                 "maximum": 1024
                               }
-                            }
+                            },
+                            "required": ["provisionedThroughput"]
                           }
                         }
                       }
-                    }
+                    },
+                    "oneOf": [
+                      {
+                        "properties": {
+                          "fsType": {
+                            "enum": ["S3"]
+                          }
+                        },
+                        "not": {"required": ["configuration"]}
+                      },
+                      {
+                        "properties": {
+                          "fsType": {
+                            "enum": ["EFS"]
+                          }
+                        }
+                      }
+                    ]
                   }
                 },
                 "required": ["type", "engine"]

--- a/packages/cli/internal/pkg/cli/spec/project_test.go
+++ b/packages/cli/internal/pkg/cli/spec/project_test.go
@@ -29,7 +29,13 @@ func TestProjectYaml(t *testing.T) {
 					"testContext": {
 						MaxVCpus: 256,
 						Engines: []Engine{
-							{Type: "wdl", Engine: "cromwell"},
+							{
+								Type:   "wdl",
+								Engine: "cromwell",
+								Filesystem: Filesystem{
+									FSType: "S3",
+								},
+							},
 						},
 					},
 				},
@@ -61,6 +67,8 @@ contexts:
         engines:
             - type: wdl
               engine: cromwell
+              filesystem:
+                fsType: S3
 `,
 		},
 		"empty": {
@@ -86,13 +94,27 @@ schemaVersion: 0
 					"ctx1": {
 						MaxVCpus: 256,
 						Engines: []Engine{
-							{Type: "wdl", Engine: "miniwdl"},
+							{
+								Type:   "wdl",
+								Engine: "miniwdl",
+								Filesystem: Filesystem{
+									FSType:        "S3",
+									Configuration: FSConfig{FSProvisionedThroughput: 0},
+								},
+							},
 						},
 					},
 					"ctx2": {
 						MaxVCpus: 256,
 						Engines: []Engine{
-							{Type: "nextflow", Engine: "nextflow"},
+							{
+								Type:   "nextflow",
+								Engine: "nextflow",
+								Filesystem: Filesystem{
+									FSType:        "S3",
+									Configuration: FSConfig{FSProvisionedThroughput: 0},
+								},
+							},
 						},
 					},
 				},
@@ -122,11 +144,15 @@ contexts:
         engines:
             - type: wdl
               engine: miniwdl
+              filesystem:
+                fsType: S3
     ctx2:
         maxVCpus: 256
         engines:
             - type: nextflow
               engine: nextflow
+              filesystem:
+                fsType: S3
 `,
 		},
 	}
@@ -168,6 +194,27 @@ contexts:
 	})
 }
 
+func TestEngineDefaults(t *testing.T) {
+	const yamlStr = `
+name: DefaultTest
+schemaVersion: 1
+contexts:
+    context:
+        engines:
+            - type: wdl
+              engine: cromwell
+              filesystem:
+                fsType: EFS
+`
+
+	t.Run("EngineDefaults", func(t *testing.T) {
+		result := Engine{}
+		err := yaml.Unmarshal([]byte(yamlStr), &result)
+		require.NoError(t, err)
+		assert.Equal(t, result.Filesystem.Configuration.FSProvisionedThroughput, DefaultFSProvisionedThroughput)
+	})
+}
+
 func TestGetContext(t *testing.T) {
 	type args struct {
 		projectSpec Project
@@ -187,12 +234,26 @@ func TestGetContext(t *testing.T) {
 					Contexts: map[string]Context{
 						"ctx1": {
 							Engines: []Engine{
-								{Type: "wdl", Engine: "miniwdl"},
+								{
+									Type:   "wdl",
+									Engine: "miniwdl",
+									Filesystem: Filesystem{
+										FSType:        "S3",
+										Configuration: FSConfig{FSProvisionedThroughput: 0},
+									},
+								},
 							},
 						},
 						"ctx2": {
 							Engines: []Engine{
-								{Type: "nextflow", Engine: "nextflow"},
+								{
+									Type:   "nextflow",
+									Engine: "nextflow",
+									Filesystem: Filesystem{
+										FSType:        "S3",
+										Configuration: FSConfig{FSProvisionedThroughput: 0},
+									},
+								},
 							},
 						},
 					},
@@ -209,12 +270,26 @@ func TestGetContext(t *testing.T) {
 					Contexts: map[string]Context{
 						"ctx1": {
 							Engines: []Engine{
-								{Type: "wdl", Engine: "miniwdl"},
+								{
+									Type:   "wdl",
+									Engine: "miniwdl",
+									Filesystem: Filesystem{
+										FSType:        "S3",
+										Configuration: FSConfig{FSProvisionedThroughput: 0},
+									},
+								},
 							},
 						},
 						"ctx2": {
 							Engines: []Engine{
-								{Type: "nextflow", Engine: "nextflow"},
+								{
+									Type:   "nextflow",
+									Engine: "nextflow",
+									Filesystem: Filesystem{
+										FSType:        "S3",
+										Configuration: FSConfig{FSProvisionedThroughput: 0},
+									},
+								},
 							},
 						},
 					},
@@ -223,7 +298,14 @@ func TestGetContext(t *testing.T) {
 			},
 			expectedContext: Context{
 				Engines: []Engine{
-					{Type: "wdl", Engine: "miniwdl"},
+					{
+						Type:   "wdl",
+						Engine: "miniwdl",
+						Filesystem: Filesystem{
+							FSType:        "S3",
+							Configuration: FSConfig{FSProvisionedThroughput: 0},
+						},
+					},
 				},
 			},
 		},

--- a/packages/cli/internal/pkg/cli/spec/project_test.go
+++ b/packages/cli/internal/pkg/cli/spec/project_test.go
@@ -209,27 +209,6 @@ contexts:
 	})
 }
 
-func TestEngineDefaults(t *testing.T) {
-	const yamlStr = `
-name: DefaultTest
-schemaVersion: 1
-contexts:
-    context:
-        engines:
-            - type: wdl
-              engine: cromwell
-              filesystem:
-                fsType: S3
-`
-
-	t.Run("EngineDefaults", func(t *testing.T) {
-		result := Filesystem{}
-		err := yaml.Unmarshal([]byte(yamlStr), &result)
-		require.NoError(t, err)
-		assert.Equal(t, result.Configuration.FSProvisionedThroughput, DefaultFSProvisionedThroughput)
-	})
-}
-
 func TestGetContext(t *testing.T) {
 	type args struct {
 		projectSpec Project

--- a/packages/cli/internal/pkg/cli/spec/project_test.go
+++ b/packages/cli/internal/pkg/cli/spec/project_test.go
@@ -98,8 +98,8 @@ schemaVersion: 0
 								Type:   "wdl",
 								Engine: "miniwdl",
 								Filesystem: Filesystem{
-									FSType:        "S3",
-									Configuration: FSConfig{FSProvisionedThroughput: 0},
+									FSType:        "EFS",
+									Configuration: FSConfig{FSProvisionedThroughput: 50},
 								},
 							},
 						},
@@ -111,9 +111,17 @@ schemaVersion: 0
 								Type:   "nextflow",
 								Engine: "nextflow",
 								Filesystem: Filesystem{
-									FSType:        "S3",
-									Configuration: FSConfig{FSProvisionedThroughput: 0},
+									FSType: "S3",
 								},
+							},
+						},
+					},
+					"ctx3": {
+						MaxVCpus: 256,
+						Engines: []Engine{
+							{
+								Type:   "nextflow",
+								Engine: "nextflow",
 							},
 						},
 					},
@@ -145,7 +153,9 @@ contexts:
             - type: wdl
               engine: miniwdl
               filesystem:
-                fsType: S3
+                fsType: EFS
+                configuration:
+                    provisionedThroughput: 50
     ctx2:
         maxVCpus: 256
         engines:
@@ -153,6 +163,11 @@ contexts:
               engine: nextflow
               filesystem:
                 fsType: S3
+    ctx3:
+        maxVCpus: 256
+        engines:
+            - type: nextflow
+              engine: nextflow
 `,
 		},
 	}
@@ -204,14 +219,14 @@ contexts:
             - type: wdl
               engine: cromwell
               filesystem:
-                fsType: EFS
+                fsType: S3
 `
 
 	t.Run("EngineDefaults", func(t *testing.T) {
-		result := Engine{}
+		result := Filesystem{}
 		err := yaml.Unmarshal([]byte(yamlStr), &result)
 		require.NoError(t, err)
-		assert.Equal(t, result.Filesystem.Configuration.FSProvisionedThroughput, DefaultFSProvisionedThroughput)
+		assert.Equal(t, result.Configuration.FSProvisionedThroughput, DefaultFSProvisionedThroughput)
 	})
 }
 
@@ -238,8 +253,8 @@ func TestGetContext(t *testing.T) {
 									Type:   "wdl",
 									Engine: "miniwdl",
 									Filesystem: Filesystem{
-										FSType:        "S3",
-										Configuration: FSConfig{FSProvisionedThroughput: 0},
+										FSType:        "EFS",
+										Configuration: FSConfig{FSProvisionedThroughput: 1},
 									},
 								},
 							},
@@ -250,8 +265,7 @@ func TestGetContext(t *testing.T) {
 									Type:   "nextflow",
 									Engine: "nextflow",
 									Filesystem: Filesystem{
-										FSType:        "S3",
-										Configuration: FSConfig{FSProvisionedThroughput: 0},
+										FSType: "S3",
 									},
 								},
 							},
@@ -274,8 +288,8 @@ func TestGetContext(t *testing.T) {
 									Type:   "wdl",
 									Engine: "miniwdl",
 									Filesystem: Filesystem{
-										FSType:        "S3",
-										Configuration: FSConfig{FSProvisionedThroughput: 0},
+										FSType:        "EFS",
+										Configuration: FSConfig{FSProvisionedThroughput: 1},
 									},
 								},
 							},
@@ -286,8 +300,7 @@ func TestGetContext(t *testing.T) {
 									Type:   "nextflow",
 									Engine: "nextflow",
 									Filesystem: Filesystem{
-										FSType:        "S3",
-										Configuration: FSConfig{FSProvisionedThroughput: 0},
+										FSType: "S3",
 									},
 								},
 							},
@@ -302,8 +315,8 @@ func TestGetContext(t *testing.T) {
 						Type:   "wdl",
 						Engine: "miniwdl",
 						Filesystem: Filesystem{
-							FSType:        "S3",
-							Configuration: FSConfig{FSProvisionedThroughput: 0},
+							FSType:        "EFS",
+							Configuration: FSConfig{FSProvisionedThroughput: 1},
 						},
 					},
 				},


### PR DESCRIPTION
<!-- Title format: type(scope): Short description (72 chars max for line) -->
<!-- `(scope)` is optional and `type` is one of: build, ci, chore, docs, feat, fix, perf, refactor, revert, style, test -->
<!-- Available types:
- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit -->

**Description of Changes**

We want to be able to specify the filesystem used and the throughput. This allows customers with large numbers of large files to accelerate workflows. Filesystem options are S3 and EFS, with a default of S3 for Cromwell and Nextflow and a default of EFS for MiniWDL. Valid throughput values are 1 to 1024.

**Description of how you validated changes**

I have added a test that checks that the default throughput is set. I have run `./scripts/run-dev.sh` and `agc project validate` with a valid agc-project.yaml and an invalid version containing an invalid filesystem.


**Checklist**

- [ ] If this change would make any existing documentation invalid, I have included those updates within this PR
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have linted my code before raising the PR
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
