### PR TITLE
feat: Download and report WES run log files

### DIFF
--- a/packages/cli/internal/pkg/cli/logs_workflow.go
+++ b/packages/cli/internal/pkg/cli/logs_workflow.go
@@ -106,21 +106,29 @@ func (o *logsWorkflowOpts) Execute() error {
 		printRunLog(runLog)
 		// Go and fetch the run-level log text if available
 		if len(runLog.Stdout) > 0 {
-			logData, err := o.workflowManager.GetRunLogData(o.runId, runLog.Stdout)
+			logDataStream, err := o.workflowManager.GetRunLogData(o.runId, runLog.Stdout)
 			if err != nil {
 				log.Error().Msgf("Could not retrieve standard output from %s: %v", runLog.Stdout, err)
 			} else {
 				printLn("Run Standard Output:")
-				printLn(logData)
+                _, err = io.Copy(os.Stdout, logDataStream)
+                if err != nil {
+                    return err
+                }
+                printLn("")
 			}
 		}
 		if len(runLog.Stderr) > 0 {
-			logData, err := o.workflowManager.GetRunLogData(o.runId, runLog.Stderr)
+			logDataStream, err := o.workflowManager.GetRunLogData(o.runId, runLog.Stderr)
 			if err != nil {
 				log.Error().Msgf("Could not retrieve standard error from %s: %v", runLog.Stderr, err)
 			} else {
 				printLn("Run Standard Error:")
-				printLn(logData)
+				_, err = io.Copy(os.Stdout, logDataStream)
+                if err != nil {
+                    return err
+                }
+                printLn("")
 			}
 		}
 		return nil

--- a/packages/cli/internal/pkg/cli/logs_workflow.go
+++ b/packages/cli/internal/pkg/cli/logs_workflow.go
@@ -104,11 +104,30 @@ func (o *logsWorkflowOpts) Execute() error {
 		}
 	} else {
 		printRunLog(runLog)
+		// Go and fetch the run-level log text if available
+		if len(runLog.Stdout) > 0 {
+			logData, err := o.workflowManager.GetRunLogData(o.runId, runLog.Stdout)
+			if err != nil {
+				log.Error().Msgf("Could not retrieve standard output from %s: %v", runLog.Stdout, err)
+			} else {
+				printLn("Run Standard Output:")
+				printLn(logData)
+			}
+		}
+		if len(runLog.Stderr) > 0 {
+			logData, err := o.workflowManager.GetRunLogData(o.runId, runLog.Stderr)
+			if err != nil {
+				log.Error().Msgf("Could not retrieve standard error from %s: %v", runLog.Stderr, err)
+			} else {
+				printLn("Run Standard Error:")
+				printLn(logData)
+			}
+		}
 		return nil
 	}
 
 	if len(jobIds) == 0 {
-		log.Info().Msgf("No logs available for run '%s'. Please try again later.", o.runId)
+		log.Info().Msgf("No job logs available for run '%s'. Please try again later.", o.runId)
 		return nil
 	}
 	notCachedJobIds := filterCachedJobIds(jobIds)

--- a/packages/cli/internal/pkg/cli/logs_workflow_test.go
+++ b/packages/cli/internal/pkg/cli/logs_workflow_test.go
@@ -147,6 +147,38 @@ func TestLogsWorkflowOpts_Execute(t *testing.T) {
 			},
 			expectedOutput: "RunId: Test Workflow Run Id\nState: COMPLETE\nTasks: \n\tName\t\tJobId\t\tStartTime\tStopTimeExitCode\n\tTest Task Name\tTest Job Id\t<nil>\t\t<nil>\t\n\t\n",
 		},
+		"runId stdout URL": {
+			setupOps: func(opts *logsWorkflowOpts, cwlLopPaginator *awsmocks.MockCwlLogPaginator) {
+				opts.workflowName = testWorkflowName
+				opts.runId = testRunId
+				opts.workflowManager.(*managermocks.MockWorkflowManager).EXPECT().
+					GetRunLog(testRunId).Return(workflow.RunLog{
+					RunId:  testRunId,
+					State:  "COMPLETE",
+					Tasks:  []workflow.Task(nil),
+					Stdout: "log/out",
+				}, nil)
+				opts.workflowManager.(*managermocks.MockWorkflowManager).EXPECT().
+					GetRunLogData(testRunId, "log/out").Return("This is output", nil)
+			},
+			expectedOutput: "RunId: Test Workflow Run Id\nState: COMPLETE\nTasks: No task logs available\nRun Standard Output:\nThis is output\n",
+		},
+		"runId stderr URL": {
+			setupOps: func(opts *logsWorkflowOpts, cwlLopPaginator *awsmocks.MockCwlLogPaginator) {
+				opts.workflowName = testWorkflowName
+				opts.runId = testRunId
+				opts.workflowManager.(*managermocks.MockWorkflowManager).EXPECT().
+					GetRunLog(testRunId).Return(workflow.RunLog{
+					RunId:  testRunId,
+					State:  "COMPLETE",
+					Tasks:  []workflow.Task(nil),
+					Stderr: "log/err",
+				}, nil)
+				opts.workflowManager.(*managermocks.MockWorkflowManager).EXPECT().
+					GetRunLogData(testRunId, "log/err").Return("This is error", nil)
+			},
+			expectedOutput: "RunId: Test Workflow Run Id\nState: COMPLETE\nTasks: No task logs available\nRun Standard Error:\nThis is error\n",
+		},
 		"runId no jobs": {
 			setupOps: func(opts *logsWorkflowOpts, cwlLopPaginator *awsmocks.MockCwlLogPaginator) {
 				opts.workflowName = testWorkflowName

--- a/packages/cli/internal/pkg/cli/logs_workflow_test.go
+++ b/packages/cli/internal/pkg/cli/logs_workflow_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 	"testing"
 	"time"
@@ -158,8 +159,9 @@ func TestLogsWorkflowOpts_Execute(t *testing.T) {
 					Tasks:  []workflow.Task(nil),
 					Stdout: "log/out",
 				}, nil)
+				stream := io.NopCloser(strings.NewReader("This is output"))
 				opts.workflowManager.(*managermocks.MockWorkflowManager).EXPECT().
-					GetRunLogData(testRunId, "log/out").Return("This is output", nil)
+					GetRunLogData(testRunId, "log/out").Return(&stream, nil)
 			},
 			expectedOutput: "RunId: Test Workflow Run Id\nState: COMPLETE\nTasks: No task logs available\nRun Standard Output:\nThis is output\n",
 		},
@@ -174,8 +176,9 @@ func TestLogsWorkflowOpts_Execute(t *testing.T) {
 					Tasks:  []workflow.Task(nil),
 					Stderr: "log/err",
 				}, nil)
+				stream := io.NopCloser(strings.NewReader("This is error"))
 				opts.workflowManager.(*managermocks.MockWorkflowManager).EXPECT().
-					GetRunLogData(testRunId, "log/err").Return("This is error", nil)
+					GetRunLogData(testRunId, "log/err").Return(&stream, nil)
 			},
 			expectedOutput: "RunId: Test Workflow Run Id\nState: COMPLETE\nTasks: No task logs available\nRun Standard Error:\nThis is error\n",
 		},

--- a/packages/cli/internal/pkg/cli/workflow/workflow_status.go
+++ b/packages/cli/internal/pkg/cli/workflow/workflow_status.go
@@ -9,6 +9,7 @@ type StatusManager interface {
 
 type TasksManager interface {
 	GetRunLog(runId string) (RunLog, error)
+	GetRunLogData(runId string, dataUrl string) (string, error)
 	GetWorkflowTasks(runId string) ([]Task, error)
 	StatusWorkflowByName(workflowName string, numInstances int) ([]InstanceSummary, error)
 }

--- a/packages/cli/internal/pkg/cli/workflow/workflow_status.go
+++ b/packages/cli/internal/pkg/cli/workflow/workflow_status.go
@@ -1,7 +1,7 @@
 package workflow
 
 import (
-    "io"
+	"io"
 )
 
 type StatusManager interface {

--- a/packages/cli/internal/pkg/cli/workflow/workflow_status.go
+++ b/packages/cli/internal/pkg/cli/workflow/workflow_status.go
@@ -1,5 +1,9 @@
 package workflow
 
+import (
+    "io"
+)
+
 type StatusManager interface {
 	StatusWorkflowAll(numInstances int) ([]InstanceSummary, error)
 	StatusWorkflowByInstanceId(instanceId string) ([]InstanceSummary, error)
@@ -9,7 +13,7 @@ type StatusManager interface {
 
 type TasksManager interface {
 	GetRunLog(runId string) (RunLog, error)
-	GetRunLogData(runId string, dataUrl string) (string, error)
+	GetRunLogData(runId string, dataUrl string) (*io.ReadCloser, error)
 	GetWorkflowTasks(runId string) ([]Task, error)
 	StatusWorkflowByName(workflowName string, numInstances int) ([]InstanceSummary, error)
 }

--- a/packages/cli/internal/pkg/cli/workflow/workflow_tasks.go
+++ b/packages/cli/internal/pkg/cli/workflow/workflow_tasks.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"fmt"
+	"io"
 	"strings"
 	"time"
 
@@ -59,16 +60,16 @@ func (m *Manager) GetRunLog(runId string) (RunLog, error) {
 	}, nil
 }
 
-func (m *Manager) GetRunLogData(runId string, dataUrl string) (string, error) {
+func (m *Manager) GetRunLogData(runId string, dataUrl string) (*io.ReadCloser, error) {
 	if m.err != nil {
-		return "", m.err
+		return nil, m.err
 	}
-	var data string
-	data, m.err = m.wes.GetRunLogData(context.Background(), runId, dataUrl)
+	var stream *io.ReadCloser
+	stream, m.err = m.wes.GetRunLogData(context.Background(), runId, dataUrl)
 	if m.err != nil {
-		return "", m.err
+		return nil, m.err
 	}
-	return data, nil
+	return stream, nil
 }
 
 func (m *Manager) setContextForRun(runId string) {

--- a/packages/cli/internal/pkg/cli/workflow/workflow_tasks.go
+++ b/packages/cli/internal/pkg/cli/workflow/workflow_tasks.go
@@ -18,9 +18,11 @@ type Task struct {
 }
 
 type RunLog struct {
-	RunId string
-	State string
-	Tasks []Task
+	RunId  string
+	State  string
+	Stdout string
+	Stderr string
+	Tasks  []Task
 }
 
 func (m *Manager) GetWorkflowTasks(runId string) ([]Task, error) {
@@ -49,10 +51,24 @@ func (m *Manager) GetRunLog(runId string) (RunLog, error) {
 	}
 
 	return RunLog{
-		RunId: m.taskProps.runLog.RunId,
-		State: string(m.taskProps.runLog.State),
-		Tasks: tasks,
+		RunId:  m.taskProps.runLog.RunId,
+		State:  string(m.taskProps.runLog.State),
+		Stdout: m.taskProps.runLog.RunLog.Stdout,
+		Stderr: m.taskProps.runLog.RunLog.Stderr,
+		Tasks:  tasks,
 	}, nil
+}
+
+func (m *Manager) GetRunLogData(runId string, dataUrl string) (string, error) {
+	if m.err != nil {
+		return "", m.err
+	}
+	var data string
+	data, m.err = m.wes.GetRunLogData(context.Background(), runId, dataUrl)
+	if m.err != nil {
+		return "", m.err
+	}
+	return data, nil
 }
 
 func (m *Manager) setContextForRun(runId string) {
@@ -72,6 +88,7 @@ func (m *Manager) getRunLog(runId string) {
 		return
 	}
 	m.runLog, m.err = m.wes.GetRunLog(context.Background(), runId)
+	log.Debug().Msgf("Obtained log: %v", m.runLog)
 }
 
 func (m *Manager) getTasks() ([]Task, error) {

--- a/packages/cli/internal/pkg/mocks/manager/mock_interfaces.go
+++ b/packages/cli/internal/pkg/mocks/manager/mock_interfaces.go
@@ -50,7 +50,7 @@ func (mr *MockWorkflowManagerMockRecorder) GetRunLog(runId interface{}) *gomock.
 }
 
 // GetRunLogData mocks base method.
-func (m *MockWorkflowManager) GetRunLogData(runId string, dataUrl string) (str, error) {
+func (m *MockWorkflowManager) GetRunLogData(runId string, dataUrl string) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRunLogData", runId, dataUrl)
 	ret0, _ := ret[0].(string)

--- a/packages/cli/internal/pkg/mocks/manager/mock_interfaces.go
+++ b/packages/cli/internal/pkg/mocks/manager/mock_interfaces.go
@@ -49,6 +49,21 @@ func (mr *MockWorkflowManagerMockRecorder) GetRunLog(runId interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRunLog", reflect.TypeOf((*MockWorkflowManager)(nil).GetRunLog), runId)
 }
 
+// GetRunLogData mocks base method.
+func (m *MockWorkflowManager) GetRunLogData(runId string, dataUrl string) (str, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRunLogData", runId, dataUrl)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRunLogData indicates an expected call of GetRunLogData.
+func (mr *MockWorkflowManagerMockRecorder) GetRunLogData(runId interface{}, dataUrl interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRunLogData", reflect.TypeOf((*MockWorkflowManager)(nil).GetRunLogData), runId, dataUrl)
+}
+
 // GetWorkflowTasks mocks base method.
 func (m *MockWorkflowManager) GetWorkflowTasks(runId string) ([]workflow.Task, error) {
 	m.ctrl.T.Helper()

--- a/packages/cli/internal/pkg/mocks/manager/mock_interfaces.go
+++ b/packages/cli/internal/pkg/mocks/manager/mock_interfaces.go
@@ -5,6 +5,7 @@
 package managermocks
 
 import (
+	io "io"
 	reflect "reflect"
 
 	workflow "github.com/aws/amazon-genomics-cli/internal/pkg/cli/workflow"
@@ -50,16 +51,16 @@ func (mr *MockWorkflowManagerMockRecorder) GetRunLog(runId interface{}) *gomock.
 }
 
 // GetRunLogData mocks base method.
-func (m *MockWorkflowManager) GetRunLogData(runId string, dataUrl string) (string, error) {
+func (m *MockWorkflowManager) GetRunLogData(runId, dataUrl string) (*io.ReadCloser, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRunLogData", runId, dataUrl)
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(*io.ReadCloser)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetRunLogData indicates an expected call of GetRunLogData.
-func (mr *MockWorkflowManagerMockRecorder) GetRunLogData(runId interface{}, dataUrl interface{}) *gomock.Call {
+func (mr *MockWorkflowManagerMockRecorder) GetRunLogData(runId, dataUrl interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRunLogData", reflect.TypeOf((*MockWorkflowManager)(nil).GetRunLogData), runId, dataUrl)
 }

--- a/packages/cli/internal/pkg/mocks/wes/mock_interfaces.go
+++ b/packages/cli/internal/pkg/mocks/wes/mock_interfaces.go
@@ -51,6 +51,21 @@ func (mr *MockWesClientMockRecorder) GetRunLog(ctx, runId interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRunLog", reflect.TypeOf((*MockWesClient)(nil).GetRunLog), ctx, runId)
 }
 
+// GetRunLogData mocks base method.
+func (m *MockWesClient) GetRunLogData(ctx context.Context, runId string, dataUrl string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRunLogData", ctx, runId, dataUrl)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRunLogData indicates an expected call of GetRunLogData.
+func (mr *MockWesClientMockRecorder) GetRunLogData(ctx, runId interface{}, dataUrl interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRunLogData", reflect.TypeOf((*MockWesClient)(nil).GetRunLogData), ctx, runId, dataUrl)
+}
+
 // GetRunStatus mocks base method.
 func (m *MockWesClient) GetRunStatus(ctx context.Context, runId string) (string, error) {
 	m.ctrl.T.Helper()

--- a/packages/cli/internal/pkg/mocks/wes/mock_interfaces.go
+++ b/packages/cli/internal/pkg/mocks/wes/mock_interfaces.go
@@ -6,7 +6,7 @@ package wesmocks
 
 import (
 	context "context"
-    io "io"
+	io "io"
 	reflect "reflect"
 
 	option "github.com/aws/amazon-genomics-cli/internal/pkg/wes/option"

--- a/packages/cli/internal/pkg/mocks/wes/mock_interfaces.go
+++ b/packages/cli/internal/pkg/mocks/wes/mock_interfaces.go
@@ -6,6 +6,7 @@ package wesmocks
 
 import (
 	context "context"
+    io "io"
 	reflect "reflect"
 
 	option "github.com/aws/amazon-genomics-cli/internal/pkg/wes/option"
@@ -52,10 +53,10 @@ func (mr *MockWesClientMockRecorder) GetRunLog(ctx, runId interface{}) *gomock.C
 }
 
 // GetRunLogData mocks base method.
-func (m *MockWesClient) GetRunLogData(ctx context.Context, runId string, dataUrl string) (string, error) {
+func (m *MockWesClient) GetRunLogData(ctx context.Context, runId string, dataUrl string) (*io.ReadCloser, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRunLogData", ctx, runId, dataUrl)
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(*io.ReadCloser)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/packages/cli/internal/pkg/wes/Client.go
+++ b/packages/cli/internal/pkg/wes/Client.go
@@ -51,3 +51,8 @@ func (c *Client) GetRunLog(ctx context.Context, runId string) (wes.RunLog, error
 	runLog, _, err := c.wes.WorkflowExecutionServiceApi.GetRunLog(ctx, runId)
 	return runLog, err
 }
+
+func (c *Client) GetRunLogData(ctx context.Context, runId string, dataUrl string) (string, error) {
+	runLogData, _, err := c.wes.WorkflowExecutionServiceApi.GetRunLogData(ctx, runId, dataUrl)
+	return runLogData, err
+}

--- a/packages/cli/internal/pkg/wes/Client.go
+++ b/packages/cli/internal/pkg/wes/Client.go
@@ -2,6 +2,7 @@ package wes
 
 import (
 	"context"
+	"io"
 
 	"github.com/aws/amazon-genomics-cli/internal/pkg/wes/option"
 	"github.com/rs/zerolog/log"
@@ -52,7 +53,7 @@ func (c *Client) GetRunLog(ctx context.Context, runId string) (wes.RunLog, error
 	return runLog, err
 }
 
-func (c *Client) GetRunLogData(ctx context.Context, runId string, dataUrl string) (string, error) {
-	runLogData, _, err := c.wes.WorkflowExecutionServiceApi.GetRunLogData(ctx, runId, dataUrl)
-	return runLogData, err
+func (c *Client) GetRunLogData(ctx context.Context, runId string, dataUrl string) (*io.ReadCloser, error) {
+	runLogDataStream, _, err := c.wes.WorkflowExecutionServiceApi.GetRunLogData(ctx, runId, dataUrl)
+	return runLogDataStream, err
 }

--- a/packages/cli/internal/pkg/wes/interface.go
+++ b/packages/cli/internal/pkg/wes/interface.go
@@ -2,7 +2,7 @@ package wes
 
 import (
 	"context"
-    "io"
+	"io"
 
 	"github.com/aws/amazon-genomics-cli/internal/pkg/wes/option"
 	wes "github.com/rsc/wes_client"

--- a/packages/cli/internal/pkg/wes/interface.go
+++ b/packages/cli/internal/pkg/wes/interface.go
@@ -2,6 +2,7 @@ package wes
 
 import (
 	"context"
+    "io"
 
 	"github.com/aws/amazon-genomics-cli/internal/pkg/wes/option"
 	wes "github.com/rsc/wes_client"
@@ -12,5 +13,5 @@ type Interface interface {
 	GetRunStatus(ctx context.Context, runId string) (string, error)
 	StopWorkflow(ctx context.Context, runId string) error
 	GetRunLog(ctx context.Context, runId string) (wes.RunLog, error)
-	GetRunLogData(ctx context.Context, runId string, dataUrl string) (string, error)
+	GetRunLogData(ctx context.Context, runId string, dataUrl string) (*io.ReadCloser, error)
 }

--- a/packages/cli/internal/pkg/wes/interface.go
+++ b/packages/cli/internal/pkg/wes/interface.go
@@ -12,4 +12,5 @@ type Interface interface {
 	GetRunStatus(ctx context.Context, runId string) (string, error)
 	StopWorkflow(ctx context.Context, runId string) error
 	GetRunLog(ctx context.Context, runId string) (wes.RunLog, error)
+	GetRunLogData(ctx context.Context, runId string, dataUrl string) (string, error)
 }

--- a/packages/wes_api/client/api_workflow_execution_service_log_extension.go
+++ b/packages/wes_api/client/api_workflow_execution_service_log_extension.go
@@ -1,0 +1,146 @@
+/*
+ * Additional methods for actually retrieving data pointed to by URLs in WES responses. 
+ */
+
+package wes_client
+
+import (
+	_context "context"
+	_ioutil "io/ioutil"
+	_nethttp "net/http"
+	_neturl "net/url"
+	"fmt"
+	"strings"
+)
+
+// Linger please
+var (
+	_ _context.Context
+)
+
+/*
+GetRunLogData Get data linked to by GetRunLog.
+Returns the content of a URL reverenced in a GetRunLog response, if that URL is also on the WES server.
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param runId The run ID used for the GetRunLog call
+ * @param dataUrl The URL string from the GetRunLog call
+@return string
+*/
+func (a *WorkflowExecutionServiceApiService) GetRunLogData(ctx _context.Context, runId string, dataUrl string) (string, *_nethttp.Response, error) {
+	var (
+		localVarHTTPMethod   = _nethttp.MethodGet
+		localVarPostBody     interface{}
+		localVarFormFileName string
+		localVarReturnValue  string
+	)
+
+	// create path and map variables
+	localVarPath := a.client.cfg.BasePath + "/runs/{run_id}"
+	localVarPath = strings.Replace(localVarPath, "{"+"run_id"+"}", _neturl.PathEscape(parameterToString(runId, "")), -1)
+
+	// Evaluate dataUrl relative to localVarPath and replace localVarPath
+	base, err := _neturl.Parse(localVarPath)
+    if err != nil {
+        return localVarReturnValue, nil, err
+    }
+	evaluated, err := base.Parse(dataUrl)
+	if err != nil {
+        return localVarReturnValue, nil, err
+    }
+	if (evaluated.Scheme != base.Scheme && !strings.HasPrefix(evaluated.Scheme, "http")) {
+		// This doesn't look like something we can fetch
+		return localVarReturnValue, nil, fmt.Errorf("WES cannot be used to retrieve %s", dataUrl)
+	}
+	localVarPath = evaluated.String()
+
+	localVarHeaderParams := make(map[string]string)
+	files := make(map[string][]byte)
+	localVarQueryParams := _neturl.Values{}
+	localVarFormParams := _neturl.Values{}
+
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{"text/plain"}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, files)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(r)
+	if err != nil || localVarHTTPResponse == nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	if err != nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	if localVarHTTPResponse.StatusCode >= 300 {
+		newErr := GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHTTPResponse.Status,
+		}
+		if localVarHTTPResponse.StatusCode == 401 {
+			var v ErrorResponse
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 403 {
+			var v ErrorResponse
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 404 {
+			var v ErrorResponse
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 500 {
+			var v ErrorResponse
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	// TODO: Handle odd encodings, unacceptable UTF-8, etc. somehow.
+	localVarReturnValue = string(localVarBody)
+
+	return localVarReturnValue, localVarHTTPResponse, nil
+}
+

--- a/packages/wes_api/client/api_workflow_execution_service_log_extension.go
+++ b/packages/wes_api/client/api_workflow_execution_service_log_extension.go
@@ -10,6 +10,7 @@ import (
 	_nethttp "net/http"
 	_neturl "net/url"
 	"fmt"
+	"io"
 	"strings"
 )
 
@@ -20,18 +21,18 @@ var (
 
 /*
 GetRunLogData Get data linked to by GetRunLog.
-Returns the content of a URL reverenced in a GetRunLog response, if that URL is also on the WES server.
+Returns a stream for the content of a URL referenced in a GetRunLog response.
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param runId The run ID used for the GetRunLog call
  * @param dataUrl The URL string from the GetRunLog call
-@return string
+@return *io.ReadCloser
 */
-func (a *WorkflowExecutionServiceApiService) GetRunLogData(ctx _context.Context, runId string, dataUrl string) (string, *_nethttp.Response, error) {
+func (a *WorkflowExecutionServiceApiService) GetRunLogData(ctx _context.Context, runId string, dataUrl string) (*io.ReadCloser, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
-		localVarReturnValue  string
+		localVarReturnValue  *io.ReadCloser = nil
 	)
 
 	// create path and map variables
@@ -53,93 +54,58 @@ func (a *WorkflowExecutionServiceApiService) GetRunLogData(ctx _context.Context,
 	}
 	localVarPath = evaluated.String()
 
+	// Request headers will go in here.
 	localVarHeaderParams := make(map[string]string)
+	// We don't use any of these, but we need them to invoke prepareRequest.
 	files := make(map[string][]byte)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 
-	// to determine the Content-Type header
-	localVarHTTPContentTypes := []string{}
+	// We don't need any accept type choosing logic; we can only accept plain text.
+	localVarHeaderParams["Accept"] = "text/plain"
 
-	// set Content-Type header
-	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
-	if localVarHTTPContentType != "" {
-		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
-	}
-
-	// to determine the Accept header
-	localVarHTTPHeaderAccepts := []string{"text/plain"}
-
-	// set Accept header
-	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
-	if localVarHTTPHeaderAccept != "" {
-		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
-	}
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, files)
 	if err != nil {
 		return localVarReturnValue, nil, err
 	}
 
+	// Make the request
 	localVarHTTPResponse, err := a.client.callAPI(r)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
-
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
-	if err != nil {
-		return localVarReturnValue, localVarHTTPResponse, err
-	}
+	// Be ready to return the body stream
+	localVarReturnValue = localVarHTTPResponse.Body
 
 	if localVarHTTPResponse.StatusCode >= 300 {
+		// Something has gone wrong sever-side (and this isn't a redirect)
+		// Fetch the entire body
+		localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+		localVarHTTPResponse.Body.Close()
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
 			error: localVarHTTPResponse.Status,
 		}
-		if localVarHTTPResponse.StatusCode == 401 {
-			var v ErrorResponse
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, localVarHTTPResponse, newErr
-			}
-			newErr.model = v
+		if (err) {
+			// Something went wrong during error download.
+			// Add that error to our error.
+			newErr.error = fmt.Errorf("Failed to download body of HTTP error %d %s response: %v", localVarHTTPResponse.StatusCode, localVarHTTPResponse.Status, err)
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
-		if localVarHTTPResponse.StatusCode == 403 {
-			var v ErrorResponse
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, localVarHTTPResponse, newErr
-			}
-			newErr.model = v
+		// Otherwise, we downloaded something. Maybe we can parse it as a WES-style JSON error.
+		var v ErrorResponse
+		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+		if err != nil {
+			// Nope, it's not a WES-style error.
+			// Don't explain why it's not parseable, just pass along what the server said.
+			newErr.error = fmt.Errorf("Instead of log data, server sent a %d %s error with content: %s", localVarHTTPResponse.StatusCode, localVarHTTPResponse.Status, localVarBody)
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
-		if localVarHTTPResponse.StatusCode == 404 {
-			var v ErrorResponse
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, localVarHTTPResponse, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, localVarHTTPResponse, newErr
-		}
-		if localVarHTTPResponse.StatusCode == 500 {
-			var v ErrorResponse
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, localVarHTTPResponse, newErr
-			}
-			newErr.model = v
-		}
+		// Otherwise, it is a WES-style error we can understand (even if not a normally acceptable WES error code)
+		newErr.model = v
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
-
-	// TODO: Handle odd encodings, unacceptable UTF-8, etc. somehow.
-	localVarReturnValue = string(localVarBody)
+	// TODO: handle redirects?
 
 	return localVarReturnValue, localVarHTTPResponse, nil
 }

--- a/packages/wes_api/client/api_workflow_execution_service_log_extension.go
+++ b/packages/wes_api/client/api_workflow_execution_service_log_extension.go
@@ -75,7 +75,7 @@ func (a *WorkflowExecutionServiceApiService) GetRunLogData(ctx _context.Context,
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
 	// Be ready to return the body stream
-	localVarReturnValue = localVarHTTPResponse.Body
+	localVarReturnValue = &localVarHTTPResponse.Body
 
 	if localVarHTTPResponse.StatusCode >= 300 {
 		// Something has gone wrong sever-side (and this isn't a redirect)
@@ -84,12 +84,12 @@ func (a *WorkflowExecutionServiceApiService) GetRunLogData(ctx _context.Context,
 		localVarHTTPResponse.Body.Close()
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
-			error: localVarHTTPResponse.Status,
+			error: localVarHTTPResponse.Status, // Despite the name, this must be a string
 		}
-		if (err) {
+		if err != nil {
 			// Something went wrong during error download.
-			// Add that error to our error.
-			newErr.error = fmt.Errorf("Failed to download body of HTTP error %d %s response: %v", localVarHTTPResponse.StatusCode, localVarHTTPResponse.Status, err)
+			// Add that error to our error as a string.
+			newErr.error = fmt.Sprintf("Failed to download body of HTTP error %d %s response: %v", localVarHTTPResponse.StatusCode, localVarHTTPResponse.Status, err)
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		// Otherwise, we downloaded something. Maybe we can parse it as a WES-style JSON error.
@@ -98,7 +98,7 @@ func (a *WorkflowExecutionServiceApiService) GetRunLogData(ctx _context.Context,
 		if err != nil {
 			// Nope, it's not a WES-style error.
 			// Don't explain why it's not parseable, just pass along what the server said.
-			newErr.error = fmt.Errorf("Instead of log data, server sent a %d %s error with content: %s", localVarHTTPResponse.StatusCode, localVarHTTPResponse.Status, localVarBody)
+			newErr.error = fmt.Sprintf("Instead of log data, server sent a %d %s error with content: %s", localVarHTTPResponse.StatusCode, localVarHTTPResponse.Status, localVarBody)
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		// Otherwise, it is a WES-style error we can understand (even if not a normally acceptable WES error code)


### PR DESCRIPTION
<!-- Title format: type(scope): Short description (72 chars max for line) -->
<!-- `(scope)` is optional and `type` is one of: build, ci, chore, docs, feat, fix, perf, refactor, revert, style, test -->
<!-- Available types:
- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit -->

Issue #, if available: N/A

**Description of Changes**

[//]: #  (A description of the change that you made and the new user experience that it creates)

Currently, AGC does not retrieve the `stdout` and `stderr` URLs referenced by the WES server for a workflow run. The URLs themselves are available in the code, but their content is not fetched and displayed to the user. This can make it hard for the user to debug a workflow run with an engine like Toil (because error logs for individual workflows are not available).

This PR extends the WES API bindings with a method that can fetch the URLs returned with workflow logs, by evaluating them relative to the URL of the document containing them and by properly signing the requests. It also reports these logs on the command line when available. 

**Description of how you validated changes**

[//]: #  (A description of you validated your changes and any relevant logs that show your change works)

As part of 822e51af7a7316282d73dc9f99d878dbd27fe85b I used these changes to test and debug the Toil engine for #317.

**Checklist**

- [X] If this change would make any existing documentation invalid, I have included those updates within this PR
- [X] I have added unit tests that prove my fix is effective or that my feature works
    I don't see any tests at the moment for `GetRunLog` on the Manager (and there's no suite to put one in), or any tests for the WES client, but I added some tests for the CLI output based on what the Manager returns that exercise the new fields at that level.  
- [X] I have linted my code before raising the PR
- [X] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
