### PR TITLE
fix: Fixes issues with workflows that only have a single file

### DIFF
--- a/packages/cli/internal/pkg/cli/workflow/workflow_run.go
+++ b/packages/cli/internal/pkg/cli/workflow/workflow_run.go
@@ -13,7 +13,8 @@ func (m *Manager) RunWorkflow(contextName, workflowName, argumentsUrl string) (s
 	m.parseWorkflowLocation()
 	if m.isUploadRequired() {
 		m.setBaseObjectKey(contextName, workflowName)
-		m.packWorkflowFiles()
+		m.setWorkflowPath()
+		m.packWorkflowPath()
 		m.uploadWorkflowToS3()
 		m.cleanUpWorkflow()
 	}

--- a/packages/cli/internal/pkg/mocks/io/interfaces.go
+++ b/packages/cli/internal/pkg/mocks/io/interfaces.go
@@ -2,6 +2,7 @@ package iomocks
 
 import (
 	"io/fs"
+	"time"
 
 	"github.com/aws/amazon-genomics-cli/internal/pkg/cli/spec"
 	"github.com/rs/zerolog"
@@ -16,6 +17,15 @@ type OS interface {
 	Stat(name string) (fs.FileInfo, error)
 	MkdirAll(path string, perm fs.FileMode) error
 	IsNotExist(err error) bool
+}
+
+type FileInfo interface {
+	Name() string       // base name of the file
+	Size() int64        // length in bytes for regular files; system-dependent for others
+	Mode() fs.FileMode  // file mode bits
+	ModTime() time.Time // modification time
+	IsDir() bool        // abbreviation for Mode().IsDir()
+	Sys() interface{}   // underlying data source (can return nil)
 }
 
 type Zip interface {

--- a/packages/cli/internal/pkg/mocks/io/mock_interfaces.go
+++ b/packages/cli/internal/pkg/mocks/io/mock_interfaces.go
@@ -7,6 +7,7 @@ package iomocks
 import (
 	fs "io/fs"
 	reflect "reflect"
+	time "time"
 
 	spec "github.com/aws/amazon-genomics-cli/internal/pkg/cli/spec"
 	gomock "github.com/golang/mock/gomock"
@@ -149,6 +150,113 @@ func (m *MockOS) UserHomeDir() (string, error) {
 func (mr *MockOSMockRecorder) UserHomeDir() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UserHomeDir", reflect.TypeOf((*MockOS)(nil).UserHomeDir))
+}
+
+// MockFileInfo is a mock of FileInfo interface.
+type MockFileInfo struct {
+	ctrl     *gomock.Controller
+	recorder *MockFileInfoMockRecorder
+}
+
+// MockFileInfoMockRecorder is the mock recorder for MockFileInfo.
+type MockFileInfoMockRecorder struct {
+	mock *MockFileInfo
+}
+
+// NewMockFileInfo creates a new mock instance.
+func NewMockFileInfo(ctrl *gomock.Controller) *MockFileInfo {
+	mock := &MockFileInfo{ctrl: ctrl}
+	mock.recorder = &MockFileInfoMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockFileInfo) EXPECT() *MockFileInfoMockRecorder {
+	return m.recorder
+}
+
+// IsDir mocks base method.
+func (m *MockFileInfo) IsDir() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsDir")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsDir indicates an expected call of IsDir.
+func (mr *MockFileInfoMockRecorder) IsDir() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsDir", reflect.TypeOf((*MockFileInfo)(nil).IsDir))
+}
+
+// ModTime mocks base method.
+func (m *MockFileInfo) ModTime() time.Time {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ModTime")
+	ret0, _ := ret[0].(time.Time)
+	return ret0
+}
+
+// ModTime indicates an expected call of ModTime.
+func (mr *MockFileInfoMockRecorder) ModTime() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModTime", reflect.TypeOf((*MockFileInfo)(nil).ModTime))
+}
+
+// Mode mocks base method.
+func (m *MockFileInfo) Mode() fs.FileMode {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Mode")
+	ret0, _ := ret[0].(fs.FileMode)
+	return ret0
+}
+
+// Mode indicates an expected call of Mode.
+func (mr *MockFileInfoMockRecorder) Mode() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Mode", reflect.TypeOf((*MockFileInfo)(nil).Mode))
+}
+
+// Name mocks base method.
+func (m *MockFileInfo) Name() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Name")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Name indicates an expected call of Name.
+func (mr *MockFileInfoMockRecorder) Name() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockFileInfo)(nil).Name))
+}
+
+// Size mocks base method.
+func (m *MockFileInfo) Size() int64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Size")
+	ret0, _ := ret[0].(int64)
+	return ret0
+}
+
+// Size indicates an expected call of Size.
+func (mr *MockFileInfoMockRecorder) Size() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Size", reflect.TypeOf((*MockFileInfo)(nil).Size))
+}
+
+// Sys mocks base method.
+func (m *MockFileInfo) Sys() interface{} {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Sys")
+	ret0, _ := ret[0].(interface{})
+	return ret0
+}
+
+// Sys indicates an expected call of Sys.
+func (mr *MockFileInfoMockRecorder) Sys() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sys", reflect.TypeOf((*MockFileInfo)(nil).Sys))
 }
 
 // MockZip is a mock of Zip interface.


### PR DESCRIPTION
Issue #, if available:

**Description of Changes**

Currently single definition workflows fail to initialize due to incorrect logic around zipping the contents. This has been changed to take this into consideration when running the workflows

**Description of how you validated changes**

Ran multiple single and multi file definition workflows in AGC.

```
$ agc workflow run read -c miniContext
2022-02-16T08:45:31-08:00 𝒊  Running workflow. Workflow name: 'read', Arguments: '', Context: 'miniContext'
f352bfe2-77bb-41c2-920d-c2121a92d4cc
$ agc workflow run hello -c miniContext
2022-02-16T08:45:55-08:00 𝒊  Running workflow. Workflow name: 'hello', Arguments: '', Context: 'miniContext'
3b1443d1-940e-485d-a3b5-b0cdd8921650
$ agc
```

**Checklist**

- [x] If this change would make any existing documentation invalid, I have included those updates within this PR
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have linted my code before raising the PR
- [ ] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
