### PR TITLE
fix: hot fix for bug with if statement in provision script

### DIFF
--- a/packages/cdk/lib/artifacts/batch-artifacts/ecs-additions/provision.sh
+++ b/packages/cdk/lib/artifacts/batch-artifacts/ecs-additions/provision.sh
@@ -98,7 +98,7 @@ echo "ARTIFACT_S3_ROOT_URL = $ARTIFACT_S3_ROOT_URL"
 
 
 # retrieve and install amazon-ebs-autoscale
-if [ "$WORKFLOW_ORCHESTRATOR" != "miniwdl" && "$WORKFLOW_ORCHESTRATOR" != "snakemake" ]; then
+if [ "$WORKFLOW_ORCHESTRATOR" != "miniwdl" ] && [ "$WORKFLOW_ORCHESTRATOR" != "snakemake" ]; then
   echo "obtaining amazon-ebs-autoscale artifacts"
   cd /opt
   sh "$BASEDIR"/get-amazon-ebs-autoscale.sh \


### PR DESCRIPTION
**Description of Changes**

Corrected if statement that was preventing use of EBS auto expansion in all engines

**Description of how you validated changes**

Validated syntax in a Bash terminal:
```
export WORKFLOW_ORCHESTRATOR=cromwell
$ if [ "$WORKFLOW_ORCHESTRATOR" != "miniwdl" ] && [ "$WORKFLOW_ORCHESTRATOR" != "snakemake" ]; then
> echo "not miniwdl or snakemake"
> fi
not miniwdl or snakemake
```

**Checklist**

- [ ] If this change would make any existing documentation invalid, I have included those updates within this PR
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have linted my code before raising the PR
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
