### PR TITLE
fix: corrects wes return value from base64 to json

### DIFF
--- a/packages/wes_adapter/index.py
+++ b/packages/wes_adapter/index.py
@@ -3,6 +3,8 @@ from rest_api import create_app
 
 app = create_app()
 
+# stops wsgi from sending Json as a Base64 string
+serverless_wsgi.TEXT_MIME_TYPES.append("application/problem+json")
 
 def handler(event, context):
     return serverless_wsgi.handle_request(app, event, context)


### PR DESCRIPTION
<!-- Title format: type(scope): Short description (72 chars max for line) -->
<!-- `(scope)` is optional and `type` is one of: build, ci, chore, docs, feat, fix, perf, refactor, revert, style, test -->
<!-- Available types:
- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit -->

Issue #, if available:
#322 

**Description of Changes**
This bug is due to the WES adapter, when the header isn't standard (normally application/error+json) the output returned is a base64 string. This fix converts the base64 string to Json. 

[//]: #  (A description of the change that you made and the new user experience that it creates)

**Description of how you validated changes**
This change was tested locally - running agc with updated index.py allows for seamless use. Tested by removing main.wdl which causes 500.

[//]: #  (A description of you validated your changes and any relevant logs that show your change works)


**Checklist**

- [x] If this change would make any existing documentation invalid, I have included those updates within this PR
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have linted my code before raising the PR
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
