### PR TITLE
fix: Update github-pages.yaml

### DIFF
--- a/.github/workflows/github-pages.yaml
+++ b/.github/workflows/github-pages.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: Generate Docs
         run: >
           (cd packages/cli && go mod vendor) &&
-          (cd site && mkdir -p themes && cd themes && git clone --recurse-submodules --depth 1 https://github.com/google/docsy.git && cd docsy && sudo npm install -D --save autoprefixer && sudo npm install -D --save postcss-cli) &&
+          (cd site && mkdir -p themes && cd themes && git clone --recurse-submodules --depth 1 https://github.com/google/docsy.git) &&
           make docs
 
       - name: Deploy To Pages


### PR DESCRIPTION
**Description of Changes**

Removed redundant `npm install` commands from github-pages workflow to correct npm package conflicts. The required npm install happens in `make docs` which now also pins the desired hash of docsy.

**Description of how you validated changes**

triggered github-pages action in my fork of this repo and observed that it ran to completion


**Checklist**

- [ ] If this change would make any existing documentation invalid, I have included those updates within this PR
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have linted my code before raising the PR
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
