### PR TITLE
docs: Adds snakemake to our online documentation

### DIFF
--- a/site/content/en/docs/Concepts/contexts.md
+++ b/site/content/en/docs/Concepts/contexts.md
@@ -195,7 +195,7 @@ base storage. Additionally, Cromwell is deployed with a standard EFS volume for 
 relatively small the amount of metadata will expand as more workflows are run. The volume is destroyed when the context is destroyed. An estimated
 cost for both components is available via [this link](https://calculator.aws/#/estimate?id=8ccc606c1b267e2933a6d683c0b98fcf11e4cbab)
 
-Contexts using the "miniwdl" engine use EFS volumes as scratch space for workflow intermediates, caches and temporary files. Because many genomics
+Contexts using the "miniwdl" or "snakemake" engines use EFS volumes as scratch space for workflow intermediates, caches and temporary files. Because many genomics
 workflows can accumulate several GB of intermediates per run we recommend destroying these contexts when not in use. An estimated cost assuming a
 total of 500 GB of workflow artifacts is available via [this link](https://calculator.aws/#/estimate?id=4d19b43aa86fcc3af199c425bfcc55193592cbb4)
 

--- a/site/content/en/docs/Concepts/engines.md
+++ b/site/content/en/docs/Concepts/engines.md
@@ -15,11 +15,12 @@ to Amazon Genomics CLI through which it will submit workflows and workflow comma
 
 Currently, Amazon Genomics CLI's officially supported engines can be used to run the following workflows:
 
-| Engine                                                 | Language                                                        | Language Versions                                                                                                       | Run Mode     |
-|--------------------------------------------------------|-----------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------|--------------|
-| [Cromwell](https://cromwell.readthedocs.io/en/stable/) | [WDL](https://openwdl.org)                                      | All versions up to 1.0                                                                                                  | Server       |
-| [Nextflow](https://www.nextflow.io)                    | [Nextflow DSL](https://www.nextflow.io/docs/latest/script.html) | Standard and DSL 2                                                                                                      | Head Process |
-| [miniwdl](https://miniwdl.readthedocs.io/en/latest/)   | [WDL](https://openwdl.org)                                      | [documented here](https://miniwdl.readthedocs.io/en/latest/runner_reference.html?highlight=errata#wdl-interoperability) | Head Process |
+| Engine                                                    | Language                                                                                   | Language Versions                                                                                                       | Run Mode     |
+|-----------------------------------------------------------|--------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------|--------------|
+| [Cromwell](https://cromwell.readthedocs.io/en/stable/)    | [WDL](https://openwdl.org)                                                                 | All versions up to 1.0                                                                                                  | Server       |
+| [Nextflow](https://www.nextflow.io)                       | [Nextflow DSL](https://www.nextflow.io/docs/latest/script.html)                            | Standard and DSL 2                                                                                                      | Head Process |
+| [miniwdl](https://miniwdl.readthedocs.io/en/latest/)      | [WDL](https://openwdl.org)                                                                 | [documented here](https://miniwdl.readthedocs.io/en/latest/runner_reference.html?highlight=errata#wdl-interoperability) | Head Process |
+| [Snakemake](https://snakemake.readthedocs.io/en/stable/)  | [Snakemake](https://snakemake.readthedocs.io/en/stable/snakefiles/writing_snakefiles.html) | All versions                                                                                                            | Head Process |
 
 Overtime we plan to add additional engine and language support and provide the ability for third party developers to 
 develop engine plugins.

--- a/site/content/en/docs/Workflow engines/snakemake.md
+++ b/site/content/en/docs/Workflow engines/snakemake.md
@@ -1,0 +1,77 @@
+---
+title: "Snakemake"
+date: 2021-10-01T17:27:31-04:00
+draft: false
+weight: 30
+description: >
+    Details on the Snakemake engine deployed by Amazon Genomics CLI
+---
+
+## Description
+
+[Snakemake](https://snakemake.readthedocs.io/en/stable/) is free open source software distributed under the MIT licence 
+developed by [Johannes Köster and their team](https://snakemake.readthedocs.io/en/stable/project_info/authors.html). 
+
+The source code for snakemake is available on [GitHub](https://github.com/snakemake/snakemake). When deployed with
+Amazon Genomics CLI snakemake uses Batch to distribute the underlying tasks.
+
+## Architecture
+
+There are four components of a snakemake engine as deployed in an Amazon Genomics CLI context:
+
+### WES Adapter
+
+Amazon Genomics CLI communicates with the snakemake engine via a GA4GH [WES](https://github.com/ga4gh/workflow-execution-service-schemas) REST service. The WES Adapter implements
+the WES standard and translates WES calls into calls to the snakemake head process.
+
+### Engine Batch Job
+
+For every workflow submitted, the WES adapter will create a new AWS Batch Job that contains the snakemake process responsible
+for running that workflow. These snakemake "head" jobs are run in an "On-demand" AWS Fargate compute environment even when the actual workflow
+tasks run in a Spot environment. This is to prevent Spot interruptions from terminating the workflow coordinator. 
+
+### Compute Environment
+
+Workflow tasks are submitted by the snakemake head job to an AWS Batch queue and run in containers using an AWS Compute Environment.
+Container characteristics are defined by the resources requested in the workflow configuration. AWS Batch coordinates the elastic provisioning of EC2 instances (container hosts)
+based on the available work in the queue. Batch will place containers on container hosts as space allows.
+
+#### EFS scratch space and S3 localization
+
+Any context with a snakemake engine will use an Amazon Elastic File System (EFS) volume as scratch space. Inputs from the workflow
+are localized to the volume by jobs that the snakemake engine spawns to copy these files to the volume. Outputs are copied back 
+to S3 after the workflow is complete. Workflow tasks access the EFS volume to obtain inputs and write intermediates and outputs.
+
+The EFS volume can used by all snakemake engine "head" jobs to store metadata necessary for dependency caching by specifying an argument 
+for the conda workspace that is common across all executions. An example of this is `--conda-prefix /mnt/efs/snakemake/conda`.
+
+The EFS volume will remain in your account for the lifetime of the context and are destroyed when contexts are destroyed.
+Because the volume will grow in size as you run more workflows we recommend destroying the context when done to avoid on going EFS
+charges.
+
+## Using Snakemake as a Context Engine
+
+You may declare snakemake to be the `engine` for any contexts `snakemake` type engine. For example:
+
+```yaml
+contexts:
+  onDemandCtx:
+    requestSpotInstances: false
+    engines:
+      - type: snakemake
+        engine: snakemake
+```
+
+## Conda Dependency Caching
+
+Dependency caching is disabled by default so that each workflow can be run independently. If you would like workflow
+runs to re-use the Conda cache then please specify a folder under "/mnt/efs" which is where the EFS storage space is
+attached. This will enable snakemake to re-use the dependency which will decrease the time that subsequent workflow runs
+will take.
+
+To disable call caching you can provide the `--conda-prefix` engine option. You may do this in a workflows `MANIFEST.json` by
+adding the following key/ value pair.
+
+```
+  "engineOptions": "-j 10 --conda-prefix /mnt/efs/snakemake/conda"
+```


### PR DESCRIPTION
<!-- Title format: type(scope): Short description (72 chars max for line) -->
<!-- `(scope)` is optional and `type` is one of: build, ci, chore, docs, feat, fix, perf, refactor, revert, style, test -->
<!-- Available types:
- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit -->

Issue #, if available:

**Description of Changes**

This change adds snakemake to our documentation.

**Description of how you validated changes**

Tested using Hugo.

```
hugo server -D
Start building sites …
hugo v0.92.1+extended darwin/amd64 BuildDate=unknown
WARN 2022/02/28 12:36:46 .Path when the page is backed by a file is deprecated and will be removed in a future release. We plan to use Path for a canonical source path and you probably want to check the source is a file. To get the current behaviour, you can use a construct similar to the one below:

  {{ $path := "" }}
  {{ with .File }}
	{{ $path = .Path }}
  {{ else }}
	{{ $path = .Path }}
  {{ end }}


Re-run Hugo with the flag --panicOnWarning to get a better error message.

                   | EN
-------------------+-----
  Pages            | 96
  Paginator pages  |  0
  Non-page files   |  2
  Static files     | 49
  Processed images |  4
  Aliases          |  0
  Sitemaps         |  1
  Cleaned          |  0

Built in 735 ms
Watching for changes in /Users/elliotsm/workspace/github/amazon-genomics-cli/site/{archetypes,assets,content,layouts,package.json,static,themes}
Watching for config changes in /Users/elliotsm/workspace/github/amazon-genomics-cli/site/config.toml, /Users/elliotsm/workspace/github/amazon-genomics-cli/site/themes/docsy/config.toml
Environment: "development"
Serving pages from memory
Running in Fast Render Mode. For full rebuilds on change: hugo server --disableFastRender
Web Server is available at http://localhost:1313/amazon-genomics-cli/ (bind address 127.0.0.1)
Press Ctrl+C to stop
```


**Checklist**

- [x] If this change would make any existing documentation invalid, I have included those updates within this PR
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have linted my code before raising the PR
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
