### PR TITLE
feat: ensures vpcId is recalled (if available) on account_activate

### DIFF
--- a/packages/cdk/lib/constants.ts
+++ b/packages/cdk/lib/constants.ts
@@ -8,6 +8,7 @@ export const USER_ID_TAG_KEY = `${APP_NAME}-user-id`;
 export const USER_EMAIL_TAG_KEY = `${APP_NAME}-user-email`;
 export const AGC_VERSION_KEY = `${APP_NAME}-version`;
 export const VPC_PARAMETER_NAME = "vpc";
+export const VPC_PARAMETER_ID = "VpcId";
 export const WES_KEY_PARAMETER_NAME = "WesAdapterZipKeyParameter";
 export const WES_BUCKET_NAME = "WesAdapterZipBucket";
 

--- a/packages/cdk/lib/stacks/core-stack.ts
+++ b/packages/cdk/lib/stacks/core-stack.ts
@@ -81,8 +81,6 @@ export class CoreStack extends Stack {
         "idempotency-key": props.idempotencyKey,
       },
     });
-
-    console.log("context passed in App :point_right:", this.node.tryGetContext("fromApp"));
     new CfnOutput(this, VPC_PARAMETER_ID, { value: this.vpc.vpcId });
 
     const asset = new Asset(this, "WesAdapter", {

--- a/packages/cdk/lib/stacks/core-stack.ts
+++ b/packages/cdk/lib/stacks/core-stack.ts
@@ -4,7 +4,7 @@ import { StringParameter, IParameter } from "aws-cdk-lib/aws-ssm";
 import { GatewayVpcEndpointAwsService, InterfaceVpcEndpointService, IVpc, Vpc } from "aws-cdk-lib/aws-ec2";
 import { Bucket, BucketEncryption, IBucket } from "aws-cdk-lib/aws-s3";
 import { Construct } from "constructs";
-import { PRODUCT_NAME, APP_NAME, VPC_PARAMETER_NAME, WES_KEY_PARAMETER_NAME, WES_BUCKET_NAME } from "../constants";
+import { PRODUCT_NAME, APP_NAME, VPC_PARAMETER_NAME, WES_KEY_PARAMETER_NAME, WES_BUCKET_NAME, VPC_PARAMETER_ID } from "../constants";
 import { BucketDeployment, Source } from "aws-cdk-lib/aws-s3-deployment";
 import * as path from "path";
 import { homedir } from "os";
@@ -81,6 +81,9 @@ export class CoreStack extends Stack {
         "idempotency-key": props.idempotencyKey,
       },
     });
+
+    console.log("context passed in App :point_right:", this.node.tryGetContext("fromApp"));
+    new CfnOutput(this, VPC_PARAMETER_ID, { value: this.vpc.vpcId });
 
     const asset = new Asset(this, "WesAdapter", {
       path: path.join(homedir(), ".agc", "wes", "wes_adapter.zip"),

--- a/packages/cli/internal/pkg/aws/cfn/get_stack_exports.go
+++ b/packages/cli/internal/pkg/aws/cfn/get_stack_exports.go
@@ -1,8 +1,6 @@
 package cfn
 
-import "github.com/aws/amazon-genomics-cli/internal/pkg/cli/clierror/actionableerror"
-
 func (c Client) GetStackOutputs(stackName string) (map[string]string, error) {
 	info, err := c.GetStackInfo(stackName)
-	return info.Outputs, actionableerror.FindSuggestionForError(err, actionableerror.AwsErrorMessageToSuggestedActionMap)
+	return info.Outputs, err
 }

--- a/packages/cli/internal/pkg/cli/account_activate.go
+++ b/packages/cli/internal/pkg/cli/account_activate.go
@@ -188,7 +188,7 @@ func displayProgress(progressStream cdk.ProgressStream, displayMsg string) error
 			}
 			lastEvent = event
 		}
-		log.Info().Msg(strings.Join(lastEvent.Outputs, "\n"))
+		log.Debug().Msg(strings.Join(lastEvent.Outputs, "\n"))
 	} else {
 		return progressStream.DisplayProgress(displayMsg)
 	}

--- a/packages/cli/internal/pkg/cli/account_activate.go
+++ b/packages/cli/internal/pkg/cli/account_activate.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/aws/amazon-genomics-cli/internal/pkg/cli/awsresources"
 	"path/filepath"
 	"strings"
 
@@ -17,6 +16,7 @@ import (
 	"github.com/aws/amazon-genomics-cli/internal/pkg/aws/ecr"
 	"github.com/aws/amazon-genomics-cli/internal/pkg/aws/s3"
 	"github.com/aws/amazon-genomics-cli/internal/pkg/aws/sts"
+	"github.com/aws/amazon-genomics-cli/internal/pkg/cli/awsresources"
 	"github.com/aws/amazon-genomics-cli/internal/pkg/cli/clierror"
 	"github.com/aws/amazon-genomics-cli/internal/pkg/constants"
 	"github.com/aws/amazon-genomics-cli/internal/pkg/logging"

--- a/packages/cli/internal/pkg/cli/account_activate_test.go
+++ b/packages/cli/internal/pkg/cli/account_activate_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/aws/amazon-genomics-cli/internal/pkg/aws/cfn"
 	"github.com/aws/amazon-genomics-cli/internal/pkg/aws/ecr"
 	"github.com/aws/amazon-genomics-cli/internal/pkg/constants"
 	"github.com/aws/amazon-genomics-cli/internal/pkg/logging"
@@ -22,6 +23,7 @@ const (
 	testCromwellRepository = "test-cromwell-repo"
 	testNextflowRepository = "test-nextflow-repo"
 	testMiniwdlRepository  = "test-miniwdl-repo"
+	testCoreStackName      = "Agc-Core"
 )
 
 var (
@@ -71,6 +73,11 @@ func TestAccountActivateOpts_Execute(t *testing.T) {
 				defer close(mocks.progressStream)
 				mocks.stsMock.EXPECT().GetAccount().Return(testAccountId, nil)
 				mocks.s3Mock.EXPECT().BucketExists("agc-test-account-id-test-account-region").Return(false, nil)
+				mocks.cfnMock.EXPECT().GetStackOutputs(testCoreStackName).Return(
+					map[string]string{
+						"": testAccountVpcId,
+					}, cfn.StackDoesNotExistError,
+				)
 				vars := []string{
 					fmt.Sprintf("%s=agc-%s-%s", constants.AgcBucketNameEnvKey, testAccountId, testAccountRegion),
 					fmt.Sprintf("%s=%t", constants.CreateBucketEnvKey, true),
@@ -91,13 +98,29 @@ func TestAccountActivateOpts_Execute(t *testing.T) {
 			},
 			expectedErr: fmt.Errorf("some account error"),
 		},
+		"vpc error": {
+			vpcId: "",
+			setupMocks: func(t *testing.T) mockClients {
+				mocks := createMocks(t)
+				defer close(mocks.progressStream)
+				mocks.stsMock.EXPECT().GetAccount().Return(testAccountId, nil)
+				mocks.s3Mock.EXPECT().BucketExists("agc-test-account-id-test-account-region").Return(false, nil)
+				mocks.cfnMock.EXPECT().GetStackOutputs(testCoreStackName).Return(nil, fmt.Errorf("some vpcId exists error"))
+				return mocks
+			},
+			expectedErr: fmt.Errorf("some vpcId exists error"),
+		},
 		"new bucket with no default VPC": {
 			bucketName: testAccountBucketName,
-			vpcId:      "",
 			setupMocks: func(t *testing.T) mockClients {
 				mocks := createMocks(t)
 				defer close(mocks.progressStream)
 				mocks.s3Mock.EXPECT().BucketExists(testAccountBucketName).Return(false, nil)
+				mocks.cfnMock.EXPECT().GetStackOutputs(testCoreStackName).Return(
+					map[string]string{
+						"": testAccountVpcId,
+					}, cfn.StackDoesNotExistError,
+				)
 				vars := []string{
 					fmt.Sprintf("%s=%s", constants.AgcBucketNameEnvKey, testAccountBucketName),
 					fmt.Sprintf("%s=%t", constants.CreateBucketEnvKey, true),
@@ -110,11 +133,11 @@ func TestAccountActivateOpts_Execute(t *testing.T) {
 		},
 		"existing bucket with no default VPC": {
 			bucketName: testAccountBucketName,
-			vpcId:      "",
 			setupMocks: func(t *testing.T) mockClients {
 				mocks := createMocks(t)
 				defer close(mocks.progressStream)
 				mocks.s3Mock.EXPECT().BucketExists(testAccountBucketName).Return(true, nil)
+				mocks.cfnMock.EXPECT().GetStackOutputs(testCoreStackName).Return(nil, cfn.StackDoesNotExistError)
 				vars := []string{
 					fmt.Sprintf("%s=%s", constants.AgcBucketNameEnvKey, testAccountBucketName),
 					fmt.Sprintf("%s=%t", constants.CreateBucketEnvKey, false),
@@ -143,6 +166,68 @@ func TestAccountActivateOpts_Execute(t *testing.T) {
 				return mocks
 			},
 		},
+		"custom VPC with existing stack updates": {
+			vpcId: testAccountVpcId,
+			setupMocks: func(t *testing.T) mockClients {
+				mocks := createMocks(t)
+				defer close(mocks.progressStream)
+				mocks.stsMock.EXPECT().GetAccount().Return(testAccountId, nil)
+				mocks.s3Mock.EXPECT().BucketExists("agc-test-account-id-test-account-region").Return(false, nil)
+				vars := []string{
+					fmt.Sprintf("AGC_BUCKET_NAME=agc-%s-%s", testAccountId, testAccountRegion),
+					fmt.Sprintf("CREATE_AGC_BUCKET=%t", true),
+					fmt.Sprintf("AGC_VERSION=%s", version.Version),
+					fmt.Sprintf("VPC_ID=%s", testAccountVpcId),
+				}
+				mocks.cdkMock.EXPECT().Bootstrap(gomock.Any(), vars, "bootstrap").Return(mocks.progressStream, nil)
+				mocks.cdkMock.EXPECT().DeployApp(gomock.Any(), vars, "activate").Return(mocks.progressStream, nil)
+				return mocks
+			},
+		},
+		"no custom VPC with existing stack updates with existing vpc id value": {
+			setupMocks: func(t *testing.T) mockClients {
+				mocks := createMocks(t)
+				defer close(mocks.progressStream)
+				mocks.stsMock.EXPECT().GetAccount().Return(testAccountId, nil)
+				mocks.s3Mock.EXPECT().BucketExists("agc-test-account-id-test-account-region").Return(false, nil)
+				existingVpc := "existing-vpc"
+				mocks.cfnMock.EXPECT().GetStackOutputs(testCoreStackName).Return(
+					map[string]string{
+						"VpcId": existingVpc,
+					}, cfn.StackDoesNotExistError,
+				)
+				vars := []string{
+					fmt.Sprintf("AGC_BUCKET_NAME=agc-%s-%s", testAccountId, testAccountRegion),
+					fmt.Sprintf("CREATE_AGC_BUCKET=%t", true),
+					fmt.Sprintf("AGC_VERSION=%s", version.Version),
+				}
+				mocks.cdkMock.EXPECT().Bootstrap(gomock.Any(), vars, "bootstrap").Return(mocks.progressStream, nil)
+				mocks.cdkMock.EXPECT().DeployApp(gomock.Any(), vars, "activate").Return(mocks.progressStream, nil)
+				return mocks
+			},
+		},
+		"no Custom VPC with existing stack deployed that does not contain a VpcId in outputs": {
+			setupMocks: func(t *testing.T) mockClients {
+				mocks := createMocks(t)
+				defer close(mocks.progressStream)
+				mocks.stsMock.EXPECT().GetAccount().Return(testAccountId, nil)
+				mocks.s3Mock.EXPECT().BucketExists("agc-test-account-id-test-account-region").Return(false, nil)
+				existingVpc := ""
+				mocks.cfnMock.EXPECT().GetStackOutputs(testCoreStackName).Return(
+					map[string]string{
+						"": existingVpc,
+					}, cfn.StackDoesNotExistError,
+				)
+				vars := []string{
+					fmt.Sprintf("AGC_BUCKET_NAME=agc-%s-%s", testAccountId, testAccountRegion),
+					fmt.Sprintf("CREATE_AGC_BUCKET=%t", true),
+					fmt.Sprintf("AGC_VERSION=%s", version.Version),
+				}
+				mocks.cdkMock.EXPECT().Bootstrap(gomock.Any(), vars, "bootstrap").Return(mocks.progressStream, nil)
+				mocks.cdkMock.EXPECT().DeployApp(gomock.Any(), vars, "activate").Return(mocks.progressStream, nil)
+				return mocks
+			},
+		},
 		"bucket exists error": {
 			bucketName: testAccountBucketName,
 			setupMocks: func(t *testing.T) mockClients {
@@ -159,6 +244,7 @@ func TestAccountActivateOpts_Execute(t *testing.T) {
 				mocks := createMocks(t)
 				defer close(mocks.progressStream)
 				mocks.s3Mock.EXPECT().BucketExists(testAccountBucketName).Return(true, nil)
+				mocks.cfnMock.EXPECT().GetStackOutputs(testCoreStackName).Return(nil, cfn.StackDoesNotExistError)
 				vars := []string{
 					fmt.Sprintf("%s=%s", constants.AgcBucketNameEnvKey, testAccountBucketName),
 					fmt.Sprintf("%s=%t", constants.CreateBucketEnvKey, false),
@@ -182,6 +268,7 @@ func TestAccountActivateOpts_Execute(t *testing.T) {
 					fmt.Sprintf("%s=%s", constants.AgcVersionEnvKey, version.Version),
 				}
 				mocks.s3Mock.EXPECT().BucketExists(testAccountBucketName).Return(true, nil)
+				mocks.cfnMock.EXPECT().GetStackOutputs(testCoreStackName).Return(nil, cfn.StackDoesNotExistError)
 				mocks.cdkMock.EXPECT().Bootstrap(gomock.Any(), vars, "bootstrap").Return(nil, fmt.Errorf("some bootstrap error"))
 				return mocks
 			},
@@ -202,6 +289,7 @@ func TestAccountActivateOpts_Execute(t *testing.T) {
 				s3Client:  mocks.s3Mock,
 				cdkClient: mocks.cdkMock,
 				ecrClient: mocks.ecrMock,
+				cfnClient: mocks.cfnMock,
 				imageRefs: testImageRefs,
 				region:    testAccountRegion,
 			}

--- a/packages/cli/internal/pkg/cli/awsresources/awsresources.go
+++ b/packages/cli/internal/pkg/cli/awsresources/awsresources.go
@@ -11,6 +11,10 @@ func RenderContextStackName(projectName, contextName, userId string) string {
 	return fmt.Sprintf("%s-Context-%s-%s-%s", constants.ProductName, projectName, userId, contextName)
 }
 
+func RenderCoreStackName() string {
+	return fmt.Sprintf("%s-%s", constants.ProductName, "Core")
+}
+
 func RenderContextStackNameRegexp(projectName, userId string) string {
 	return fmt.Sprintf("^%s-Context-%s-%s-([^\\-]+)$", constants.ProductName, projectName, userId)
 }

--- a/packages/cli/internal/pkg/mocks/aws/mock_interfaces.go
+++ b/packages/cli/internal/pkg/mocks/aws/mock_interfaces.go
@@ -408,6 +408,21 @@ func (mr *MockCfnClientMockRecorder) DeleteStack(stackId interface{}) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteStack", reflect.TypeOf((*MockCfnClient)(nil).DeleteStack), stackId)
 }
 
+// DescribeStack mocks base method.
+func (m *MockCfnClient) DescribeStack(stackName string) (cfn.StackInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeStack", stackName)
+	ret0, _ := ret[0].(cfn.StackInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeStack indicates an expected call of DescribeStack.
+func (mr *MockCfnClientMockRecorder) DescribeStack(stackName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeStack", reflect.TypeOf((*MockCfnClient)(nil).DescribeStack), stackName)
+}
+
 // GetStackInfo mocks base method.
 func (m *MockCfnClient) GetStackInfo(stackName string) (cfn.StackInfo, error) {
 	m.ctrl.T.Helper()

--- a/site/content/en/docs/Concepts/accounts.md
+++ b/site/content/en/docs/Concepts/accounts.md
@@ -58,12 +58,11 @@ modify the network topology of the specified VPC.
 Issuing account activate commands more than once effectively updates the core infrastructure with the difference between
 the two commands. For example, if you had previously activated the account using `agc account activate` and later invoked
 `agc account activate --bucket my-existing-bucket --vpc my-existing-vpc-id` then Amazon Genomics CLI will update to use `my-existing-bucket`
-and the identified VPC. The old VPC and related infrastructure will be destroyed. S3 buckets will be *retained* according
-to their retention policy.
+and the identified VPC. The old VPC and S3 buckets will be *retained* according to their retention policy.
 
-If you initially activated the account with `agc account activate --bucket my-existing-bucket --vpc my-existing-vpc-id`
-and later invoked `agc account activate` then Amazon Genomics CLI will stop using the previous specified bucket and VPC. *ALL* of the 
-pre-existing S3 and VPC infrastructure will be retained and a new bucket and VPC will be created for use by Amazon Genomics CLI.
+If you initially activated the account with `agc account activate --bucket my-existing-bucket --vpc my-existing-vpc-id` 
+and later invoked `agc account activate` then Amazon Genomics CLI will stop using the previous specified bucket, however the VPC will be recalled and re-used.
+*ALL* of the pre-existing S3 and VPC infrastructure will be retained and a new bucket will be created for use by Amazon Genomics CLI.
 
 ### `deactivate`
 

--- a/site/content/en/docs/Concepts/accounts.md
+++ b/site/content/en/docs/Concepts/accounts.md
@@ -61,8 +61,8 @@ the two commands. For example, if you had previously activated the account using
 and the identified VPC. The old VPC and S3 buckets will be *retained* according to their retention policy.
 
 If you initially activated the account with `agc account activate --bucket my-existing-bucket --vpc my-existing-vpc-id` 
-and later invoked `agc account activate` then Amazon Genomics CLI will stop using the previous specified bucket, however the VPC will be recalled and re-used.
-*ALL* of the pre-existing S3 and VPC infrastructure will be retained and a new bucket will be created for use by Amazon Genomics CLI.
+and later invoked `agc account activate` then Amazon Genomics CLI will stop using the previous specified bucket, however the VPC will 
+be recalled and re-used. *ALL* of the pre-existing S3 and VPC infrastructure will be retained and a new bucket will be created for use by Amazon Genomics CLI.
 
 ### `deactivate`
 


### PR DESCRIPTION
<!-- Title format: type(scope): Short description (72 chars max for line) -->
<!-- `(scope)` is optional and `type` is one of: build, ci, chore, docs, feat, fix, perf, refactor, revert, style, test -->
<!-- Available types:
- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit -->

Issue #, if available:

**Description of Changes**
Previously, `account activate` did not recall any existing vpcIds and users had to add it in manually. Now, if a vpcId exists, it will recall and use it in-place of generating a new one. 

[//]: #  (A description of the change that you made and the new user experience that it creates)

**Description of how you validated changes**
Added unit tests as well as linted using `make`. 


[//]: #  (A description of you validated your changes and any relevant logs that show your change works)
![Screen Shot 2022-03-08 at 2 09 08 PM](https://user-images.githubusercontent.com/52179349/157342667-59b4cd9e-fb0c-4b47-80ae-29470ae241f9.png)

**Checklist**

- [ ] If this change would make any existing documentation invalid, I have included those updates within this PR
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have linted my code before raising the PR
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
