### PR TITLE
fix: miniwdl wdl1.1support

### DIFF
--- a/examples/demo-wdl-project/agc-project.yaml
+++ b/examples/demo-wdl-project/agc-project.yaml
@@ -5,7 +5,7 @@ workflows:
   hello:
     type:
       language: wdl
-      version: 1.0
+      version: 1.1
     sourceURL: workflows/hello/hello.wdl
   read:
     type:

--- a/examples/demo-wdl-project/workflows/hello/hello.wdl
+++ b/examples/demo-wdl-project/workflows/hello/hello.wdl
@@ -1,4 +1,4 @@
-version 1.0
+version 1.1
 workflow hello_agc {
     call hello {}
 }

--- a/packages/cdk/npm-shrinkwrap.json
+++ b/packages/cdk/npm-shrinkwrap.json
@@ -1283,6 +1283,24 @@
               "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.0.tgz",
               "integrity": "sha512-/YgW6pRMr6M7C+4o8kS+B/2myEpHCrxO4PEWnqJNBFMjn7EWXqlQ4tGwL6xTHeRplwuZmcAncdvfOad1nT2yMw==",
               "dev": true
+            },
+            "lru-cache": {
+              "version": "6.0.0",
+              "dev": true,
+              "requires": {
+                "yallist": "^4.0.0"
+              }
+            },
+            "semver": {
+              "version": "7.3.5",
+              "dev": true,
+              "requires": {
+                "lru-cache": "^6.0.0"
+              }
+            },
+            "yallist": {
+              "version": "4.0.0",
+              "dev": true
             }
           }
         },
@@ -1309,6 +1327,26 @@
           "requires": {
             "@aws-cdk/cloud-assembly-schema": "2.10.0",
             "semver": "^7.3.5"
+          },
+          "dependencies": {
+            "lru-cache": {
+              "version": "6.0.0",
+              "dev": true,
+              "requires": {
+                "yallist": "^4.0.0"
+              }
+            },
+            "semver": {
+              "version": "7.3.5",
+              "dev": true,
+              "requires": {
+                "lru-cache": "^6.0.0"
+              }
+            },
+            "yallist": {
+              "version": "4.0.0",
+              "dev": true
+            }
           }
         },
         "@aws-cdk/region-info": {
@@ -1679,11 +1717,6 @@
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
-        },
-        "colors": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78",
-          "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
         },
         "compress-commons": {
           "version": "4.1.1",
@@ -2206,11 +2239,6 @@
             "graceful-fs": "^4.1.6",
             "universalify": "^2.0.0"
           }
-        },
-        "jsonschema": {
-          "version": "1.4.0",
-          "resolved": false,
-          "integrity": "sha512-/YgW6pRMr6M7C+4o8kS+B/2myEpHCrxO4PEWnqJNBFMjn7EWXqlQ4tGwL6xTHeRplwuZmcAncdvfOad1nT2yMw=="
         },
         "lazystream": {
           "version": "1.0.1",

--- a/packages/cdk/npm-shrinkwrap.json
+++ b/packages/cdk/npm-shrinkwrap.json
@@ -1286,6 +1286,7 @@
             },
             "lru-cache": {
               "version": "6.0.0",
+              "resolved": "",
               "dev": true,
               "requires": {
                 "yallist": "^4.0.0"
@@ -1293,6 +1294,7 @@
             },
             "semver": {
               "version": "7.3.5",
+              "resolved": "",
               "dev": true,
               "requires": {
                 "lru-cache": "^6.0.0"
@@ -1300,6 +1302,7 @@
             },
             "yallist": {
               "version": "4.0.0",
+              "resolved": "",
               "dev": true
             }
           }
@@ -1331,6 +1334,7 @@
           "dependencies": {
             "lru-cache": {
               "version": "6.0.0",
+              "resolved": "",
               "dev": true,
               "requires": {
                 "yallist": "^4.0.0"
@@ -1338,6 +1342,7 @@
             },
             "semver": {
               "version": "7.3.5",
+              "resolved": "",
               "dev": true,
               "requires": {
                 "lru-cache": "^6.0.0"
@@ -1345,6 +1350,7 @@
             },
             "yallist": {
               "version": "4.0.0",
+              "resolved": "",
               "dev": true
             }
           }

--- a/packages/wes_adapter/README.md
+++ b/packages/wes_adapter/README.md
@@ -20,7 +20,7 @@ Run `make init`, this will create a venv and install the packages required for W
 Override the required environment variables at `./start-local-server.sh` to point the service to access correct AWS resources
 
 ```bash
-export ENGINE_NAME= # nextflow or cromwell
+export ENGINE_NAME= # nextflow, snakemake, miniwdl or cromwell
 export JOB_QUEUE= 
 export JOB_DEFINITION= 
 export ENGINE_LOG_GROUP=

--- a/packages/wes_adapter/amazon_genomics/wes/adapters/MiniWdlWESAdapter.py
+++ b/packages/wes_adapter/amazon_genomics/wes/adapters/MiniWdlWESAdapter.py
@@ -67,7 +67,7 @@ class MiniWdlWESAdapter(BatchAdapter):
 
     @property
     def workflow_type_versions(self):
-        return {"WDL": WorkflowTypeVersion(["1.0", "draft-2"])}
+        return {"WDL": WorkflowTypeVersion(["1.1", "1.0", "draft-2"])}
 
     def get_service_info(self):
         """Get information about Workflow Execution Service.


### PR DESCRIPTION
Issue #, if available:

#358 

**Description of Changes**

added 1.1 to the list of allowed versions in the `miniwdlWesAdapter`. The miniwdl engine already supports 1.1

**Description of how you validated changes**

* Update `hello.wdl` to declare it's version as 1.1
* Update `agc-project.yaml` to declare it's version as 1.1
* `agc account activate`
* `agc context deploy miniContext`
* `agc workflow run hello -c miniContext`
* Workflow accepted and succeeded

Also check to make sure v1.0 workflows still work.

**Checklist**

- [x] If this change would make any existing documentation invalid, I have included those updates within this PR
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have linted my code before raising the PR
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
