### PR TITLE
fix: updates cromwell exit_code

### DIFF
--- a/packages/wes_adapter/amazon_genomics/wes/adapters/CromwellWESAdapter.py
+++ b/packages/wes_adapter/amazon_genomics/wes/adapters/CromwellWESAdapter.py
@@ -339,7 +339,7 @@ class CromwellWESAdapter(AbstractWESAdapter):  # inherit from ABC to enforce int
                     "end_time": task.get("end"),
                     "stdout": task.get("stdout"),
                     "stderr": task.get("stderr"),
-                    "exit_code": task.get("returnCode")
+                    "exit_code": task.get("returnCode"),
                 }
                 task_logs.append(log)
 

--- a/packages/wes_adapter/amazon_genomics/wes/adapters/CromwellWESAdapter.py
+++ b/packages/wes_adapter/amazon_genomics/wes/adapters/CromwellWESAdapter.py
@@ -339,11 +339,7 @@ class CromwellWESAdapter(AbstractWESAdapter):  # inherit from ABC to enforce int
                     "end_time": task.get("end"),
                     "stdout": task.get("stdout"),
                     "stderr": task.get("stderr"),
-                    "exit_code": (
-                        ""
-                        if task.get("returnCode") == None
-                        else str(task.get("returnCode"))
-                    ),
+                    "exit_code": task.get("returnCode")
                 }
                 task_logs.append(log)
 


### PR DESCRIPTION
<!-- Title format: type(scope): Short description (72 chars max for line) -->
<!-- `(scope)` is optional and `type` is one of: build, ci, chore, docs, feat, fix, perf, refactor, revert, style, test -->
<!-- Available types:
- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit -->

Issue #, if available:

**Description of Changes**

Updates Cromwell to handle exit_code conversion (previously missed on #314)

[//]: #  (A description of the change that you made and the new user experience that it creates)

**Description of how you validated changes**


[//]: #  (A description of you validated your changes and any relevant logs that show your change works)

Steps to reproduce [using cromwell]
```
account activate -c
context deploy -c myContext -v 
workflow run words-with-vowels -c myContext -v
logs workflow words-with-vowels -r <RunId>
```
Returns

<img width="1346" alt="Screen Shot 2022-04-08 at 12 07 04 PM" src="https://user-images.githubusercontent.com/52179349/162511664-88bd52cb-0810-4fef-a53d-d53111b07346.png">


**Checklist**

- [x] If this change would make any existing documentation invalid, I have included those updates within this PR
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have linted my code before raising the PR
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
