### PR TITLE
fix: do not set WorkflowEngineParameters when empty

### DIFF
--- a/packages/cli/internal/pkg/wes/client.go
+++ b/packages/cli/internal/pkg/wes/client.go
@@ -10,11 +10,11 @@ import (
 )
 
 type Client struct {
-	wes *wes.APIClient
+	wes apiClient
 }
 
 func New(wesBaseUrl string, profile string) (*Client, error) {
-	wesApiClient, err := EstablishWesConnection(wesBaseUrl+"ga4gh/wes/v1", profile)
+	wesApiClient, err := establishWesConnection(wesBaseUrl+"ga4gh/wes/v1", profile)
 	if err != nil {
 		return nil, err
 	}
@@ -29,12 +29,12 @@ func (c *Client) RunWorkflow(ctx context.Context, options ...option.Func) (strin
 			return "", err
 		}
 	}
-	runId, _, err := c.wes.WorkflowExecutionServiceApi.RunWorkflow(ctx, params)
+	runId, _, err := c.wes.RunWorkflow(ctx, params)
 	return runId.RunId, err
 }
 
 func (c *Client) StopWorkflow(ctx context.Context, id string) error {
-	runId, response, err := c.wes.WorkflowExecutionServiceApi.CancelRun(ctx, id)
+	runId, response, err := c.wes.CancelRun(ctx, id)
 	if err != nil {
 		log.Error().Msgf("Error stopping workflow instance '%s', the workflow engine is unable to find and/or stop the specified instance", id)
 		return err
@@ -44,16 +44,16 @@ func (c *Client) StopWorkflow(ctx context.Context, id string) error {
 }
 
 func (c *Client) GetRunStatus(ctx context.Context, runId string) (string, error) {
-	runStatus, _, err := c.wes.WorkflowExecutionServiceApi.GetRunStatus(ctx, runId)
+	runStatus, _, err := c.wes.GetRunStatus(ctx, runId)
 	return string(runStatus.State), err
 }
 
 func (c *Client) GetRunLog(ctx context.Context, runId string) (wes.RunLog, error) {
-	runLog, _, err := c.wes.WorkflowExecutionServiceApi.GetRunLog(ctx, runId)
+	runLog, _, err := c.wes.GetRunLog(ctx, runId)
 	return runLog, err
 }
 
 func (c *Client) GetRunLogData(ctx context.Context, runId string, dataUrl string) (*io.ReadCloser, error) {
-	runLogDataStream, _, err := c.wes.WorkflowExecutionServiceApi.GetRunLogData(ctx, runId, dataUrl)
+	runLogDataStream, _, err := c.wes.GetRunLogData(ctx, runId, dataUrl)
 	return runLogDataStream, err
 }

--- a/packages/cli/internal/pkg/wes/client_test.go
+++ b/packages/cli/internal/pkg/wes/client_test.go
@@ -1,0 +1,98 @@
+package wes
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/antihax/optional"
+	"github.com/aws/amazon-genomics-cli/internal/pkg/wes/option"
+	wes "github.com/rsc/wes_client"
+	"github.com/stretchr/testify/assert"
+)
+
+type testApi struct {
+	t                       *testing.T
+	expectedWorkflowRunOpts *wes.RunWorkflowOpts
+}
+
+func (api testApi) CancelRun(ctx context.Context, runId string) (wes.RunId, *http.Response, error) {
+	return wes.RunId{}, nil, nil
+}
+func (api testApi) GetRunLog(ctx context.Context, runId string) (wes.RunLog, *http.Response, error) {
+	return wes.RunLog{}, nil, nil
+}
+func (api testApi) GetRunStatus(ctx context.Context, runId string) (wes.RunStatus, *http.Response, error) {
+	return wes.RunStatus{}, nil, nil
+}
+func (api testApi) GetServiceInfo(ctx context.Context) (wes.ServiceInfo, *http.Response, error) {
+	return wes.ServiceInfo{}, nil, nil
+}
+func (api testApi) ListRuns(ctx context.Context, localVarOptionals *wes.ListRunsOpts) (wes.RunListResponse, *http.Response, error) {
+	return wes.RunListResponse{}, nil, nil
+}
+func (api testApi) RunWorkflow(ctx context.Context, localVarOptionals *wes.RunWorkflowOpts) (wes.RunId, *http.Response, error) {
+	assert.Equal(api.t, api.expectedWorkflowRunOpts, localVarOptionals)
+	return wes.RunId{}, nil, nil
+}
+func (api testApi) GetRunLogData(ctx context.Context, runId string, dataUrl string) (*io.ReadCloser, *http.Response, error) {
+	return nil, nil, nil
+}
+
+func TestClient_RunWorkflow(t *testing.T) {
+	testCases := map[string]struct {
+		setupMocks   func(*testing.T) testApi
+		inputOptions []option.Func
+		expectedErr  error
+	}{
+		"sets WorkflowEngineParameters": {
+			inputOptions: []option.Func{option.WorkflowEngineParams(map[string]string{"key1": "val1"})},
+			setupMocks: func(t *testing.T) testApi {
+				return testApi{
+					t: t,
+					expectedWorkflowRunOpts: &wes.RunWorkflowOpts{
+						WorkflowEngineParameters: optional.NewString("{\"key1\":\"val1\"}"),
+					},
+				}
+			},
+		},
+		"skips WorkflowEngineParameters when nil": {
+			inputOptions: []option.Func{option.WorkflowEngineParams(nil)},
+			setupMocks: func(t *testing.T) testApi {
+				return testApi{
+					t: t,
+					expectedWorkflowRunOpts: &wes.RunWorkflowOpts{
+						WorkflowEngineParameters: optional.String{},
+					},
+				}
+			},
+		},
+		"skips WorkflowEngineParameters when empty": {
+			inputOptions: []option.Func{option.WorkflowEngineParams(map[string]string{})},
+			setupMocks: func(t *testing.T) testApi {
+				return testApi{
+					t: t,
+					expectedWorkflowRunOpts: &wes.RunWorkflowOpts{
+						WorkflowEngineParameters: optional.String{},
+					},
+				}
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			mockApi := tc.setupMocks(t)
+			client := &Client{wes: mockApi}
+
+			_, err := client.RunWorkflow(context.Background(), tc.inputOptions...)
+
+			if tc.expectedErr != nil {
+				assert.Error(t, err, tc.expectedErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/packages/cli/internal/pkg/wes/option/workflow_engine_params.go
+++ b/packages/cli/internal/pkg/wes/option/workflow_engine_params.go
@@ -9,10 +9,15 @@ import (
 
 func WorkflowEngineParams(params map[string]string) Func {
 	return func(opts *wes.RunWorkflowOpts) error {
+		if len(params) == 0 {
+			return nil
+		}
+
 		workflowEngineParamsJsonBytes, err := json.Marshal(params)
 		if err != nil {
 			return err
 		}
+
 		opts.WorkflowEngineParameters = optional.NewString(string(workflowEngineParamsJsonBytes))
 		return nil
 	}


### PR DESCRIPTION
<!-- Title format: type(scope): Short description (72 chars max for line) -->
<!-- `(scope)` is optional and `type` is one of: build, ci, chore, docs, feat, fix, perf, refactor, revert, style, test -->
<!-- Available types:
- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit -->

**Description of Changes**

If the engineOptions attribute is not defined in a workflow MANIFEST.json a literal null is sent as a command line option to the engine.

If the map is empty or null, we will not populate the WorkflowEngineParameters field.

**Description of how you validated changes**

Added tests to ensure nothing is sent across when null or empty map passed.

**Checklist**

- [x] If this change would make any existing documentation invalid, I have included those updates within this PR
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have linted my code before raising the PR
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
