### PR TITLE
fix: Add safety checks in optional manifest fields

### DIFF
--- a/packages/engines/miniwdl/miniwdl.aws.sh
+++ b/packages/engines/miniwdl/miniwdl.aws.sh
@@ -76,7 +76,7 @@ if [[ "$MINIWDL_PROJECT" =~ ^s3://.* ]]; then
         MINIWDL_PROJECT="${MINIWDL_PROJECT_DIRECTORY}/${MINIWDL_PROJECT}"
       fi
       MINIWDL_PARAMS="${MINIWDL_PARAMS} $(cat $MANIFEST_JSON | jq -r '.engineOptions // empty')"
-      INPUT_FILE="${MINIWDL_PROJECT_DIRECTORY}/$(cat $MANIFEST_JSON | jq -r '.inputFileURLs[0] // empty')"
+      INPUT_FILE="$(cat $MANIFEST_JSON | jq -r '.inputFileURLs[0] // empty')"
       if [[ -n "$INPUT_FILE" ]] ; then
          INPUT_JSON="${MINIWDL_PROJECT_DIRECTORY}/${INPUT_FILE}"
       fi

--- a/packages/engines/miniwdl/miniwdl.aws.sh
+++ b/packages/engines/miniwdl/miniwdl.aws.sh
@@ -76,7 +76,10 @@ if [[ "$MINIWDL_PROJECT" =~ ^s3://.* ]]; then
         MINIWDL_PROJECT="${MINIWDL_PROJECT_DIRECTORY}/${MINIWDL_PROJECT}"
       fi
       MINIWDL_PARAMS="${MINIWDL_PARAMS} $(cat $MANIFEST_JSON | jq -r '.engineOptions // empty')"
-      INPUT_JSON="${MINIWDL_PROJECT_DIRECTORY}/$(cat $MANIFEST_JSON | jq -r '.inputFileURLs[0]')"
+      INPUT_FILE="${MINIWDL_PROJECT_DIRECTORY}/$(cat $MANIFEST_JSON | jq -r '.inputFileURLs[0] // empty')"
+      if [[ -n "$INPUT_FILE" ]] ; then
+         INPUT_JSON="${MINIWDL_PROJECT_DIRECTORY}/${INPUT_FILE}"
+      fi
     else
       WDL_FILES=( $MINIWDL_PROJECT_DIRECTORY/*.wdl )
       if [ "${#WDL_FILES[@]}" -eq 1 ]; then

--- a/packages/engines/new-engine-template/<engine-name>.aws.sh
+++ b/packages/engines/new-engine-template/<engine-name>.aws.sh
@@ -37,7 +37,7 @@ function handleManifest() {
       if [[ $ENGINE_PROJECT != *"://"* ]] ; then
         ENGINE_PROJECT="${ENGINE_PROJECT_DIRECTORY}/${ENGINE_PROJECT}"
       fi
-      ENGINE_OPTIONS="$(cat $MANIFEST_JSON | jq -r '.engineOptions')" 
+      ENGINE_OPTIONS="$(cat $MANIFEST_JSON | jq -r '.engineOptions // empty')"
       if [[ -n "$ENGINE_OPTIONS" ]] ; then
          ENGINE_PARAMS="${ENGINE_OPTIONS}"
       fi

--- a/packages/engines/nextflow/nextflow.aws.sh
+++ b/packages/engines/nextflow/nextflow.aws.sh
@@ -132,8 +132,11 @@ if [[ "$NEXTFLOW_PROJECT" =~ ^s3://.* ]]; then
       if [[ $NEXTFLOW_PROJECT != *"://"* ]] ; then
         NEXTFLOW_PROJECT="${NEXTFLOW_PROJECT_DIRECTORY}/${NEXTFLOW_PROJECT}"
       fi
-      NEXTFLOW_PARAMS="$(cat $MANIFEST_JSON | jq -r '.engineOptions')"
-      INPUT_JSON="${NEXTFLOW_PROJECT_DIRECTORY}/$(cat $MANIFEST_JSON | jq -r '.inputFileURLs[0]')"
+      NEXTFLOW_PARAMS="$(cat $MANIFEST_JSON | jq -r '.engineOptions // empty')"
+      INPUT_FILE="${NEXTFLOW_PROJECT_DIRECTORY}/$(cat $MANIFEST_JSON | jq -r '.inputFileURLs[0] // empty')"
+      if [[ -n "$INPUT_FILE" ]] ; then
+         INPUT_JSON="${NEXTFLOW_PROJECT_DIRECTORY}/${INPUT_FILE}"
+      fi
       if test -f "$INPUT_JSON"; then
         echo "cat $INPUT_JSON"
         cat $INPUT_JSON

--- a/packages/engines/nextflow/nextflow.aws.sh
+++ b/packages/engines/nextflow/nextflow.aws.sh
@@ -133,7 +133,7 @@ if [[ "$NEXTFLOW_PROJECT" =~ ^s3://.* ]]; then
         NEXTFLOW_PROJECT="${NEXTFLOW_PROJECT_DIRECTORY}/${NEXTFLOW_PROJECT}"
       fi
       NEXTFLOW_PARAMS="$(cat $MANIFEST_JSON | jq -r '.engineOptions // empty')"
-      INPUT_FILE="${NEXTFLOW_PROJECT_DIRECTORY}/$(cat $MANIFEST_JSON | jq -r '.inputFileURLs[0] // empty')"
+      INPUT_FILE="$(cat $MANIFEST_JSON | jq -r '.inputFileURLs[0] // empty')"
       if [[ -n "$INPUT_FILE" ]] ; then
          INPUT_JSON="${NEXTFLOW_PROJECT_DIRECTORY}/${INPUT_FILE}"
       fi

--- a/packages/engines/snakemake/snakemake.aws.sh
+++ b/packages/engines/snakemake/snakemake.aws.sh
@@ -33,7 +33,7 @@ function handleManifest() {
       cat $MANIFEST_JSON
       # Get correct url of project root location
       ENGINE_PROJECT="$(cat $MANIFEST_JSON | jq -r '.mainWorkflowURL')"
-      ENGINE_OPTIONS="$(cat $MANIFEST_JSON | jq -r '.engineOptions')" 
+      ENGINE_OPTIONS="$(cat $MANIFEST_JSON | jq -r '.engineOptions // empty')"
       if [[ -n "$ENGINE_OPTIONS" ]] ; then
          ENGINE_PARAMS="${ENGINE_PARAMS} ${ENGINE_OPTIONS}"
       fi


### PR DESCRIPTION
fixes: https://github.com/aws/amazon-genomics-cli/issues/397

**Description of Changes**

The [manifest file definition allows engineOptions and inputFileURLs to be optional](https://github.com/aws/amazon-genomics-cli/blob/884308fc2b7e00d918c57e8a912957076309dde2/site/content/en/docs/Concepts/workflows.md#manifestjson-structure). When parsed by `jq`, these fields will return `"null"` when not present in the file. This can break launching of the workflow from the head job. I have added `// empty` to the `jq` command, allowing it to return nothing if not present, which will allow the in place null checks to succeed.

**Description of how you validated changes**

[//]: #  (A description of you validated your changes and any relevant logs that show your change works)


**Checklist**

- [ ] If this change would make any existing documentation invalid, I have included those updates within this PR
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have linted my code before raising the PR
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
