### PR TITLE
fix: Add s3:GetBucketLocation permission for Toil

### DIFF
--- a/packages/cdk/lib/roles/toil-job-role.ts
+++ b/packages/cdk/lib/roles/toil-job-role.ts
@@ -96,6 +96,7 @@ export class ToilJobRole extends Role {
                 "s3:GetBucketVersioning",
                 "s3:PutBucketVersioning",
                 "s3:HeadBucket",
+                "s3:GetBucketLocation",
                 "s3:HeadObject",
                 "s3:GetObject",
                 "s3:GetObjectVersion",


### PR DESCRIPTION
<!-- Title format: type(scope): Short description (72 chars max for line) -->
<!-- `(scope)` is optional and `type` is one of: build, ci, chore, docs, feat, fix, perf, refactor, revert, style, test -->
<!-- Available types:
- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit -->

Issue #, if available:

**Description of Changes**

[//]: #  (A description of the change that you made and the new user experience that it creates)

This adds the  `s3:GetBucketLocation` permission to those granted to Toil. Without it, running CWL workflows with Toil will produce an error:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/toil/jobStores/aws/jobStore.py", line 704, in _bindBucket
    self.s3_client.head_bucket(Bucket=bucket_name)
  File "/usr/local/lib/python3.7/site-packages/botocore/client.py", line 401, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/usr/local/lib/python3.7/site-packages/botocore/client.py", line 731, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (404) when calling the HeadBucket operation: Not Found

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/toil/jobStores/aws/jobStore.py", line 153, in initialize
    self._bind(create=True)
  File "/usr/local/lib/python3.7/site-packages/toil/jobStores/aws/jobStore.py", line 189, in _bind
    check_versioning_consistency=check_versioning_consistency)
  File "/usr/local/lib/python3.7/site-packages/toil/jobStores/aws/jobStore.py", line 725, in _bindBucket
    get_bucket_region(bucket_name) == self.region
  File "/usr/local/lib/python3.7/site-packages/toil/lib/aws/utils.py", line 215, in get_bucket_region
    loc = s3_client.get_bucket_location(Bucket=bucket_name)
  File "/usr/local/lib/python3.7/site-packages/botocore/client.py", line 401, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/usr/local/lib/python3.7/site-packages/botocore/client.py", line 731, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (AccessDenied) when calling the GetBucketLocation operation: Access Denied
```

**Description of how you validated changes**

[//]: #  (A description of you validated your changes and any relevant logs that show your change works)

I ran the `nontrivial` workflow in `examples/demo-cwl-project` with and without this change.

**Checklist**

- [X] If this change would make any existing documentation invalid, I have included those updates within this PR
- N/A I have added unit tests that prove my fix is effective or that my feature works
- [X] I have linted my code before raising the PR
- [X] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
