### PR TITLE
docs: Fix shown procedures for Toil Docker

### DIFF
--- a/packages/engines/toil/README.md
+++ b/packages/engines/toil/README.md
@@ -7,7 +7,7 @@ A Toil mono-container WES server for use with Amazon Genomics CLI.
 Go to this directory and run:
 
 ```bash
-docker build . -f Dockerfile -t adamnovak/toil-agc
+docker build . -f Dockerfile -t toil-agc
 ```
 
 ### Running for Testing
@@ -15,13 +15,13 @@ docker build . -f Dockerfile -t adamnovak/toil-agc
 Having built the container, run:
 
 ```bash
-docker run -ti --rm -p "127.0.0.1:8000:8000" adamnovak/toil-agc
+docker run --name toil-agc-test -ti --rm -p "127.0.0.1:8000:8000" toil-agc
 ```
 
 This will start the containerized server and make it available on port 8000 on the loopback interface. You can inspect the port mapping with:
 
 ```bash
-docker port "$(docker ps | grep adamnovak/toil-agc | rev | cut -f1 -d' ' | rev)"
+docker port toil-agc-test
 ```
 
 Then you can talk to it with e.g.:
@@ -33,7 +33,7 @@ curl -vvv "http://localhost:8000/ga4gh/wes/v1/service-info"
 For debugging, you can get inside the container with:
 
 ```bash
-docker exec -ti "$(docker ps | grep adamnovak/toil-agc | rev | cut -f1 -d' ' | rev)" /bin/bash
+docker exec -ti toil-agc-test /bin/bash
 ```
 
 ### Deploying
@@ -46,6 +46,7 @@ AWS_ACCOUNT=<your-account-number> # For example, 123456789012
 ECR_REPO=<your-ecr-repo> # For example, yourname/toil-agc. Needs to be created in the ECR console.
 aws ecr get-login-password --region ${AWS_REGION} | docker login --username AWS --password-stdin ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com
 docker build -t ${ECR_REPO} .
-docker tag adamnovak/toil-agc:latest ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/${ECR_REPO}:latest
+docker tag ${ECR_REPO}:latest ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/${ECR_REPO}:latest
 docker push ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/${ECR_REPO}:latest
 ```
+


### PR DESCRIPTION
<!-- Title format: type(scope): Short description (72 chars max for line) -->
<!-- `(scope)` is optional and `type` is one of: build, ci, chore, docs, feat, fix, perf, refactor, revert, style, test -->
<!-- Available types:
- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit -->

Issue #, if available:

**Description of Changes**

[//]: #  (A description of the change that you made and the new user experience that it creates)

I fixed the instructions for pushing a Docker container for Toil to ECR so they can be followed as written; I'd previously broken them when removing the actual WAS account numbers/names I use.

I also changed the local testing instructions to use a more generic tag without my name in it, and to use Docker container names instead of grep to find the test container while it is running.

**Description of how you validated changes**

[//]: #  (A description of you validated your changes and any relevant logs that show your change works)

I ran through the commands suggested in the file to test them. They worked.

**Checklist**

- [X] If this change would make any existing documentation invalid, I have included those updates within this PR
- N/A I have added unit tests that prove my fix is effective or that my feature works
- N/A I have linted my code before raising the PR
- [X] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
