### PR TITLE
fix: Store workflow state in S3 through restart

### DIFF
--- a/packages/engines/toil/Dockerfile
+++ b/packages/engines/toil/Dockerfile
@@ -45,7 +45,7 @@ RUN npm install -g concurrently@7.0.0
 # Install Toil
 COPY THIRD-PARTY /opt/
 
-ARG TOIL_VERSION="62cf1054e5af2c2c483396e651cd0e7be85330fe"
+ARG TOIL_VERSION="f77554b28bbda7b112c5b058b31d5041299c38c9"
 RUN python3 -m pip install git+https://github.com/DataBiosphere/toil.git@${TOIL_VERSION}#egg=toil[aws,cwl,server]
 
 # copy the entrypoint script to the image

--- a/packages/engines/toil/toil.aws.sh
+++ b/packages/engines/toil/toil.aws.sh
@@ -23,6 +23,6 @@ export TOIL_WES_JOB_STORE_TYPE="aws"
 concurrently -n rabbitmq,celery,toil \
     "rabbitmq-server" \
     "celery --broker=${TOIL_WES_BROKER_URL} -A toil.server.celery_app worker --loglevel=INFO" \
-    "toil server --debug --host=0.0.0.0 --port=8000 --dest_bucket_base=${ROOT_DIR} --opt=--batchSystem=aws_batch '--opt=--awsBatchQueue=${JOB_QUEUE_ARN}' '--opt=--awsBatchRegion=${AWS_REGION}' --opt=--disableCaching"
+    "toil server --debug --host=0.0.0.0 --port=8000 --dest_bucket_base=${ROOT_DIR}/output --state_store=${ROOT_DIR}/state --opt=--batchSystem=aws_batch '--opt=--awsBatchQueue=${JOB_QUEUE_ARN}' '--opt=--awsBatchRegion=${AWS_REGION}' --opt=--disableCaching"
 
 


### PR DESCRIPTION
<!-- Title format: type(scope): Short description (72 chars max for line) -->
<!-- `(scope)` is optional and `type` is one of: build, ci, chore, docs, feat, fix, perf, refactor, revert, style, test -->
<!-- Available types:
- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit -->

Issue #, if available:

**Description of Changes**

This uses a Toil that can return a state for a workflow that was run through a previous execution of the server. State is stored in S3 in the persistent AGC bucket, and so lives beyond the lifetime of the Toil server container and beyond the lifetime of the context.

This allows `agc context destroy` or `agc workflow status` to still work even if the Toil container is restarted.

Additionally, since AGC seems to leave workflow entries in DynamoDB even after the context they belong to is destroyed, this will allow `agc context destroy` to work on a context that was created with the same name as a previously destroyed context.

[//]: #  (A description of the change that you made and the new user experience that it creates)

**Description of how you validated changes**

I set up a context with this version of Toil, and ran a workflow. Then I deleted the Toil server task on ECS, and waited for it to start again. After that, I ran `agc workflow status --context-name myContext`, which still worked, and `agc -v context destroy --context myContext`, which also worked.

Since testing, I've moved the output and state paths in S3 that are passed to the server, so that output files cannot clobber internal Toil state information. I've also rebased from on top of #423 to on top of `main`.

[//]: #  (A description of you validated your changes and any relevant logs that show your change works)


**Checklist**

- [X] If this change would make any existing documentation invalid, I have included those updates within this PR
- N/A I have added unit tests that prove my fix is effective or that my feature works
- [X] I have linted my code before raising the PR
- [X] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
