### PR TITLE
fix: input files should be resolved as relative to the location of the inputs JSON file

### DIFF
--- a/packages/cli/internal/pkg/cli/workflow/input.go
+++ b/packages/cli/internal/pkg/cli/workflow/input.go
@@ -4,11 +4,12 @@ import (
 	"encoding/json"
 )
 
-type inputKey = string
-type inputUrl = interface{}
-type Input map[inputKey]inputUrl
+type Input map[string]interface{}
 
-func (i Input) ToString() (string, error) {
+func (i Input) String() string {
 	jsonBytes, err := json.Marshal(i)
-	return string(jsonBytes), err
+	if err != nil {
+		panic(err)
+	}
+	return string(jsonBytes)
 }

--- a/packages/cli/internal/pkg/cli/workflow/manager.go
+++ b/packages/cli/internal/pkg/cli/workflow/manager.go
@@ -338,6 +338,7 @@ func (m *Manager) uploadInputsToS3() {
 	absInputsPath, err := filepath.Abs(m.inputsPath)
 	if err != nil {
 		m.err = err
+		return
 	}
 	baseLocation := filepath.Dir(absInputsPath)
 	updateInputs, err := m.InputClient.UpdateInputs(baseLocation, m.input, m.bucketName, objectKey)

--- a/packages/cli/internal/pkg/cli/workflow/manager.go
+++ b/packages/cli/internal/pkg/cli/workflow/manager.go
@@ -73,7 +73,7 @@ type runProps struct {
 	path                 string
 	packPath             string
 	workflowUrl          string
-	inputUrl             string
+	inputsPath           string
 	input                Input
 	optionFileUrl        string
 	options              map[string]string
@@ -308,7 +308,7 @@ func (m *Manager) readInput(inputUrl string) {
 		return
 	}
 	log.Debug().Msgf("Input file override URL: %s", inputUrl)
-	m.inputUrl = inputUrl
+	m.inputsPath = osutils.StripFileURLPrefix(inputUrl) // We actually support only local files
 	bytes, err := m.Storage.ReadAsBytes(inputUrl)
 	if err != nil {
 		m.err = err
@@ -326,11 +326,7 @@ func (m *Manager) parseInputToArguments() {
 	if m.err != nil || m.input == nil {
 		return
 	}
-	arguments, err := m.input.ToString()
-	if err != nil {
-		m.err = err
-		return
-	}
+	arguments := m.input.String()
 	m.arguments = []string{arguments}
 }
 
@@ -339,7 +335,12 @@ func (m *Manager) uploadInputsToS3() {
 		return
 	}
 	objectKey := awsresources.RenderBucketDataKey(m.projectSpec.Name, m.userId)
-	updateInputs, err := m.InputClient.UpdateInputs(m.Project.GetLocation(), m.input, m.bucketName, objectKey)
+	absInputsPath, err := filepath.Abs(m.inputsPath)
+	if err != nil {
+		m.err = err
+	}
+	baseLocation := filepath.Dir(absInputsPath)
+	updateInputs, err := m.InputClient.UpdateInputs(baseLocation, m.input, m.bucketName, objectKey)
 	if err != nil {
 		m.err = fmt.Errorf("unable to sync s3://%s/%s: %w", m.bucketName, objectKey, err)
 		return
@@ -446,7 +447,7 @@ func (m *Manager) setWorkflowParameters() {
 		return
 	}
 	m.workflowParams = make(map[string]string)
-	if m.inputUrl == "" {
+	if m.inputsPath == "" {
 		return
 	}
 	m.workflowParams["workflowInputs"] = filepath.Base(m.attachments[0])
@@ -484,7 +485,7 @@ func (m *Manager) saveAttachments() {
 		return
 	}
 
-	namePattern := fmt.Sprintf("%s_*", filepath.Base(m.inputUrl))
+	namePattern := fmt.Sprintf("%s_*", filepath.Base(m.inputsPath))
 	for _, arg := range m.arguments {
 		fileName, err := writeToTmp(namePattern, arg)
 		if err != nil {

--- a/packages/cli/internal/pkg/cli/workflow_run.go
+++ b/packages/cli/internal/pkg/cli/workflow_run.go
@@ -60,9 +60,9 @@ func BuildWorkflowRunCommand() *cobra.Command {
 This command prints a run Id for the created workflow instance.
 `,
 		Example: `
-Run the workflow named "example-workflow", against the "prod" context,
-using input parameters contained in file "file:///Users/ec2-user/myproj/test-args.json"
-/code $ agc workflow run example-workflow --context prod --inputsFile file:///Users/ec2-user/myproj/test-args.json`,
+Run the workflow named "myworkflow", against the "prod" context,
+using input parameters contained in file "/home/ec2-user/myproj/workflows/myworkflow/myworkflow.inputs.json"
+/code $ agc workflow run myworkflow --context prod --inputsFile workflows/myworkflow/myworkflow.inputs.json`,
 		Args: cobra.ExactArgs(1),
 		RunE: runCmdE(func(cmd *cobra.Command, args []string) error {
 			vars.WorkflowName = args[0]

--- a/packages/cli/internal/pkg/mocks/storage/mock_interfaces.go
+++ b/packages/cli/internal/pkg/mocks/storage/mock_interfaces.go
@@ -351,17 +351,3 @@ func (mr *MockInputClientMockRecorder) UpdateInputs(initialProjectDirectory, inp
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateInputs", reflect.TypeOf((*MockInputClient)(nil).UpdateInputs), initialProjectDirectory, inputFile, bucketName, baseS3Key)
 }
-
-// UpdateInputsInFile mocks base method.
-func (m *MockInputClient) UpdateInputsInFile(initialProjectDirectory string, inputFile map[string]interface{}, bucketName, baseS3Key, fileLocation string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateInputsInFile", initialProjectDirectory, inputFile, bucketName, baseS3Key, fileLocation)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdateInputsInFile indicates an expected call of UpdateInputsInFile.
-func (mr *MockInputClientMockRecorder) UpdateInputsInFile(initialProjectDirectory, inputFile, bucketName, baseS3Key, fileLocation interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateInputsInFile", reflect.TypeOf((*MockInputClient)(nil).UpdateInputsInFile), initialProjectDirectory, inputFile, bucketName, baseS3Key, fileLocation)
-}

--- a/packages/cli/internal/pkg/osutils/utils.go
+++ b/packages/cli/internal/pkg/osutils/utils.go
@@ -107,3 +107,11 @@ func getAndCreateRelativePath(currentPath string, sourcePath string, destination
 
 	return relativePath, nil
 }
+
+func StripFileURLPrefix(filename string) string {
+	if strings.HasPrefix(filename, "file://") {
+		runes := []rune(filename)
+		filename = string(runes[7:])
+	}
+	return filename
+}

--- a/packages/cli/internal/pkg/osutils/utils_test.go
+++ b/packages/cli/internal/pkg/osutils/utils_test.go
@@ -252,6 +252,25 @@ func TestGetAndCreateRelativePath(t *testing.T) {
 	}
 }
 
+func TestStripFileURLPrefix(t *testing.T) {
+	tests := map[string]struct {
+		url      string
+		expected string
+	}{
+		"NoPrefixAbs":   {"/home/user/file", "/home/user/file"},
+		"NoPrefixRel":   {"user/file", "user/file"},
+		"WithPrefixAbs": {"file:///home/user/file", "/home/user/file"},
+		"WithPrefixRel": {"file://user/file", "user/file"},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			actual := StripFileURLPrefix(test.url)
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}
+
 type MockUtils struct {
 	ctrl   *gomock.Controller
 	mockOs *iomocks.MockOS

--- a/packages/cli/internal/pkg/storage/input_client.go
+++ b/packages/cli/internal/pkg/storage/input_client.go
@@ -52,7 +52,7 @@ func (ic *InputInstance) UpdateInputReferencesAndUploadToS3(initialProjectDirect
 			return actionableerror.New(err, fmt.Sprintf("Please validate that the input JSON file %s exists", inputLocation))
 		}
 
-		err = ic.UpdateInputsInFile(initialProjectDirectory, inputFile, bucketName, baseS3Key, fileLocation)
+		err = ic.updateInputsInFile(initialProjectDirectory, inputFile, bucketName, baseS3Key, fileLocation)
 		if err != nil {
 			return err
 		}
@@ -105,7 +105,7 @@ func (ic *InputInstance) UpdateInputs(initialProjectDirectory string, inputFile 
 	return updatedInputReferenceFile, nil
 }
 
-func (ic *InputInstance) UpdateInputsInFile(initialProjectDirectory string, inputFile map[string]interface{}, bucketName string, baseS3Key string, fileLocation string) error {
+func (ic *InputInstance) updateInputsInFile(initialProjectDirectory string, inputFile map[string]interface{}, bucketName string, baseS3Key string, fileLocation string) error {
 	updatedInputReferenceFile, err := ic.UpdateInputs(initialProjectDirectory, inputFile, bucketName, baseS3Key)
 	if err != nil {
 		return err

--- a/packages/cli/internal/pkg/storage/input_client_test.go
+++ b/packages/cli/internal/pkg/storage/input_client_test.go
@@ -108,7 +108,7 @@ func (ic *InputClientTestSuite) TestUpdateInputsInFile_WriteFileFails() {
 	expectedErr := errors.New("FileNotFound")
 	ic.mockFileWriter.EXPECT().WriteFile(tempProjectDirectory, inputFileString, os.FileMode(0644)).Return(expectedErr)
 
-	err := ic.inputInstance.UpdateInputsInFile(initialProjectDirectory, inputFile, "bucketName", baseS3Key, tempProjectDirectory)
+	err := ic.inputInstance.updateInputsInFile(initialProjectDirectory, inputFile, "bucketName", baseS3Key, tempProjectDirectory)
 	ic.Assert().Equal(err, expectedErr)
 }
 
@@ -120,7 +120,7 @@ func (ic *InputClientTestSuite) TestUpdateInputsInFile_UploadFileFails() {
 	expectedErr := errors.New("FileNotFound")
 	ic.mockS3Client.EXPECT().UploadFile("bucketName", baseS3Key+"/"+testFile1, "dir/"+testFile1).AnyTimes().Return(expectedErr)
 
-	err := ic.inputInstance.UpdateInputsInFile(initialProjectDirectory, inputFile, "bucketName", baseS3Key, tempProjectDirectory)
+	err := ic.inputInstance.updateInputsInFile(initialProjectDirectory, inputFile, "bucketName", baseS3Key, tempProjectDirectory)
 	ic.Assert().Equal(err, expectedErr)
 }
 
@@ -132,7 +132,7 @@ func (ic *InputClientTestSuite) TestUpdateInputsInFile_MarshallFails() {
 	expectedErr := errors.New("FileNotFound")
 	ic.mockJson.EXPECT().Marshal(inputFile).Return(nil, expectedErr)
 
-	err := ic.inputInstance.UpdateInputsInFile(initialProjectDirectory, inputFile, "bucketName", baseS3Key, tempProjectDirectory)
+	err := ic.inputInstance.updateInputsInFile(initialProjectDirectory, inputFile, "bucketName", baseS3Key, tempProjectDirectory)
 	ic.Assert().Equal(err, expectedErr)
 }
 

--- a/packages/cli/internal/pkg/storage/interfaces.go
+++ b/packages/cli/internal/pkg/storage/interfaces.go
@@ -37,5 +37,4 @@ type ConfigClient interface {
 type InputClient interface {
 	UpdateInputReferencesAndUploadToS3(initialProjectDirectory string, tempProjectDirectory string, bucketName string, baseS3Key string) error
 	UpdateInputs(initialProjectDirectory string, inputFile map[string]interface{}, bucketName string, baseS3Key string) (map[string]interface{}, error)
-	UpdateInputsInFile(initialProjectDirectory string, inputFile map[string]interface{}, bucketName string, baseS3Key string, fileLocation string) error
 }

--- a/packages/cli/internal/pkg/storage/storage_client.go
+++ b/packages/cli/internal/pkg/storage/storage_client.go
@@ -6,8 +6,8 @@ package storage
 import (
 	"fmt"
 	"path/filepath"
-	"strings"
 
+	"github.com/aws/amazon-genomics-cli/internal/pkg/osutils"
 	"github.com/spf13/afero"
 )
 
@@ -30,7 +30,7 @@ func NewStorageInstance(fsOptional ...afero.Fs) (*StorageInstance, error) {
 // The filename can be a URL that is of the form file://<absolute-file-path> or
 // simply a filename.
 func (si *StorageInstance) ReadAsBytes(url string) ([]byte, error) {
-	data, err := si.fsUtils.ReadFile(stripFileURLPrefix(url))
+	data, err := si.fsUtils.ReadFile(osutils.StripFileURLPrefix(url))
 	if err != nil {
 		return nil, fmt.Errorf("couldn't read file %s: %w", url, err)
 	}
@@ -41,7 +41,7 @@ func (si *StorageInstance) ReadAsBytes(url string) ([]byte, error) {
 // The filename can be a URL that is of the form file://<absolute-file-path> or
 // simply a filename.
 func (si *StorageInstance) ReadAsString(url string) (string, error) {
-	data, err := si.ReadAsBytes(stripFileURLPrefix(url))
+	data, err := si.ReadAsBytes(osutils.StripFileURLPrefix(url))
 	return string(data), err
 }
 
@@ -51,7 +51,7 @@ func (si *StorageInstance) ReadAsString(url string) (string, error) {
 // if it does already exist. The directory that the file is in is created if it doesn't
 // already exist.
 func (si *StorageInstance) WriteFromBytes(url string, data []byte) error {
-	filename := stripFileURLPrefix(url)
+	filename := osutils.StripFileURLPrefix(url)
 	if err := si.fsUtils.MkdirAll(filepath.Dir(filename), 0755 /* -rwxr-xr-x */); err != nil {
 		return fmt.Errorf("couldn't create directories for file %s: %w", filename, err)
 	}
@@ -68,12 +68,4 @@ func (si *StorageInstance) WriteFromBytes(url string, data []byte) error {
 // already exist.
 func (si *StorageInstance) WriteFromString(url string, data string) error {
 	return si.WriteFromBytes(url, []byte(data))
-}
-
-func stripFileURLPrefix(filename string) string {
-	if strings.HasPrefix(filename, "file://") {
-		runes := []rune(filename)
-		filename = string(runes[7:])
-	}
-	return filename
 }


### PR DESCRIPTION
<!-- Title format: type(scope): Short description (72 chars max for line) -->
<!-- `(scope)` is optional and `type` is one of: build, ci, chore, docs, feat, fix, perf, refactor, revert, style, test -->
<!-- Available types:
- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit -->

Issue #, if available:

**Description of Changes**

Behavior of --args (--inputsFile) was broken. The resources referenced in the inputs JSON file were resolved as relative to the current directory instead of the location of the inputs JSON file.

Example:
data file: examples/demo-wdl-project/workflows/read/hello.txt
inputs JSON file: `examples/demo-wdl-project/workflows/read/read.inputs.json`
`read.inputs.json` contents:
```json
{
  "ReadFile.input_file": "./hello.txt"
}
```
Then the workflow run like `agc workflow run read --context myContext --inputsFile workflows/read/read.inputs.json` would fail with `EXECUTOR_ERROR` error.

This change fixes this behavior and AGC will be able to find data file and upload it to S3.

[//]: #  (A description of the change that you made and the new user experience that it creates)

**Description of how you validated changes**

* Build and unit tests:
```
$ make
...
go test -race -cover -count=1 -coverprofile coverage.out ./internal...
ok      github.com/aws/amazon-genomics-cli/internal/pkg/aws     0.063s  coverage: 91.8% of statements
ok      github.com/aws/amazon-genomics-cli/internal/pkg/aws/batch       0.036s  coverage: 90.9% of statements
ok      github.com/aws/amazon-genomics-cli/internal/pkg/aws/cdk 0.255s  coverage: 52.8% of statements
ok      github.com/aws/amazon-genomics-cli/internal/pkg/aws/cfn 0.041s  coverage: 88.6% of statements
ok      github.com/aws/amazon-genomics-cli/internal/pkg/aws/cwl 0.036s  coverage: 92.2% of statements
?       github.com/aws/amazon-genomics-cli/internal/pkg/aws/ddb [no test files]
ok      github.com/aws/amazon-genomics-cli/internal/pkg/aws/ecr 0.031s  coverage: 81.8% of statements
ok      github.com/aws/amazon-genomics-cli/internal/pkg/aws/s3  0.047s  coverage: 94.9% of statements
ok      github.com/aws/amazon-genomics-cli/internal/pkg/aws/ssm 0.091s  coverage: 91.7% of statements
ok      github.com/aws/amazon-genomics-cli/internal/pkg/aws/sts 0.020s  coverage: 85.7% of statements
ok      github.com/aws/amazon-genomics-cli/internal/pkg/aws/util        0.029s  coverage: 100.0% of statements
ok      github.com/aws/amazon-genomics-cli/internal/pkg/cli     0.084s  coverage: 48.4% of statements
?       github.com/aws/amazon-genomics-cli/internal/pkg/cli/awsresources        [no test files]
ok      github.com/aws/amazon-genomics-cli/internal/pkg/cli/clierror    0.067s  coverage: 58.3% of statements
ok      github.com/aws/amazon-genomics-cli/internal/pkg/cli/clierror/actionableerror    0.054s  coverage: 100.0% of statements
ok      github.com/aws/amazon-genomics-cli/internal/pkg/cli/config      0.023s  coverage: 58.7% of statements
ok      github.com/aws/amazon-genomics-cli/internal/pkg/cli/context     0.059s  coverage: 91.0% of statements
ok      github.com/aws/amazon-genomics-cli/internal/pkg/cli/format      0.059s  coverage: 80.9% of statements
?       github.com/aws/amazon-genomics-cli/internal/pkg/cli/group       [no test files]
ok      github.com/aws/amazon-genomics-cli/internal/pkg/cli/spec        0.114s  coverage: 57.9% of statements
?       github.com/aws/amazon-genomics-cli/internal/pkg/cli/types       [no test files]
ok      github.com/aws/amazon-genomics-cli/internal/pkg/cli/workflow    0.111s  coverage: 81.3% of statements
ok      github.com/aws/amazon-genomics-cli/internal/pkg/cli/zipfile     0.061s  coverage: 86.7% of statements
?       github.com/aws/amazon-genomics-cli/internal/pkg/constants       [no test files]
?       github.com/aws/amazon-genomics-cli/internal/pkg/environment     [no test files]
?       github.com/aws/amazon-genomics-cli/internal/pkg/logging [no test files]
?       github.com/aws/amazon-genomics-cli/internal/pkg/mocks/aws       [no test files]
?       github.com/aws/amazon-genomics-cli/internal/pkg/mocks/context   [no test files]
?       github.com/aws/amazon-genomics-cli/internal/pkg/mocks/io        [no test files]
?       github.com/aws/amazon-genomics-cli/internal/pkg/mocks/manager   [no test files]
?       github.com/aws/amazon-genomics-cli/internal/pkg/mocks/storage   [no test files]
?       github.com/aws/amazon-genomics-cli/internal/pkg/mocks/wes       [no test files]
?       github.com/aws/amazon-genomics-cli/internal/pkg/mocks/workflow  [no test files]
ok      github.com/aws/amazon-genomics-cli/internal/pkg/osutils 0.041s  coverage: 55.8% of statements
ok      github.com/aws/amazon-genomics-cli/internal/pkg/storage 0.041s  coverage: 81.9% of statements
ok      github.com/aws/amazon-genomics-cli/internal/pkg/term/color      0.028s  coverage: 100.0% of statements
ok      github.com/aws/amazon-genomics-cli/internal/pkg/unicode 0.032s  coverage: 100.0% of statements
ok      github.com/aws/amazon-genomics-cli/internal/pkg/version 0.053s  coverage: 90.2% of statements
ok      github.com/aws/amazon-genomics-cli/internal/pkg/wes     0.029s  coverage: 11.3% of statements
?       github.com/aws/amazon-genomics-cli/internal/pkg/wes/option      [no test files]
go build -ldflags "-X github.com/aws/amazon-genomics-cli/internal/pkg/version.Version=1.4.0" -o ./bin/local/agc ./cmd/application

```


* Manual test:
```
$ agc workflow run read --context myContext --inputsFile workflows/read/read.inputs.json
$ agc workflow run read --context myContext --inputsFile file://workflows/read/read.inputs.json
$ agc workflow status
2022-05-04T22:50:02Z �  Showing workflow run(s). Max Runs: 20
WORKFLOWINSTANCE        myContext       7adde6cf-b204-4c2e-a90b-1fc4fa8b28cb    true    {"workflow_type":"WDL","workflow_type_version":"1.0"}   COMPLETE        2022-05-04T21:38:36Z    read
WORKFLOWINSTANCE        myContext       427a08e0-0ff1-4f8d-8a36-899e06a80cf4    true    {"workflow_type":"WDL","workflow_type_version":"1.0"}   COMPLETE        2022-05-04T21:38:15Z    read
```

[//]: #  (A description of you validated your changes and any relevant logs that show your change works)


**Checklist**

- [x] If this change would make any existing documentation invalid, I have included those updates within this PR
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have linted my code before raising the PR
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
