### PR TITLE
fix: make agc logs adapter handle Toil

### DIFF
--- a/packages/cli/internal/pkg/constants/engines.go
+++ b/packages/cli/internal/pkg/constants/engines.go
@@ -4,5 +4,6 @@ const (
 	CROMWELL  = "cromwell"
 	NEXTFLOW  = "nextflow"
 	MINIWDL   = "miniwdl"
+	TOIL      = "toil"
 	SNAKEMAKE = "snakemake"
 )


### PR DESCRIPTION
<!-- Title format: type(scope): Short description (72 chars max for line) -->
<!-- `(scope)` is optional and `type` is one of: build, ci, chore, docs, feat, fix, perf, refactor, revert, style, test -->
<!-- Available types:
- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit -->

Issue #, if available: #430

**Description of Changes**

[//]: #  (A description of the change that you made and the new user experience that it creates)

This changes `agc logs adapter` so that it doesn't try to fetch anything for a Toil context, and instead tells the user that there's no adapter.

**Description of how you validated changes**

[//]: #  (A description of you validated your changes and any relevant logs that show your change works)

I added a test, and I also tried them on the command line:

```
[anovak@courtyard demo-cwl-project]$ agc logs adapter -c myContext
Error: Context does not use an adapter because it is using the Toil engine
```

**Checklist**

- [X] If this change would make any existing documentation invalid, I have included those updates within this PR
- [X] I have added unit tests that prove my fix is effective or that my feature works
- [X] I have linted my code before raising the PR
- [X] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
