### PR TITLE
test: Update words with vowels to have the same "shape" as haplotype caller

### DIFF
--- a/examples/demo-wdl-project/workflows/words/words-with-vowels.wdl
+++ b/examples/demo-wdl-project/workflows/words/words-with-vowels.wdl
@@ -9,8 +9,15 @@ workflow Words_With_Vowels {
 		call FindWordsWithLetter {input: vowel = vowel, word_file = word_file}
 	}
 
+	call SumWords {
+		input:
+			count_files = FindWordsWithLetter.count_file
+
+	}
+
 	output{
 		Array[File] words_w_vowel = FindWordsWithLetter.filtered_file
+		File sum_file = SumWords.sum_file
 	}
 }
 
@@ -22,6 +29,7 @@ task FindWordsWithLetter {
 	command {
 		touch "words_with_~{vowel}.txt"
 		grep ~{vowel} ~{word_file} > "words_with_~{vowel}.txt"
+		wc -l "words_with_~{vowel}.txt" | cut -f1 -d " " > "~{vowel}-count.txt"
 	}
 	runtime {
 		docker: "public.ecr.aws/amazonlinux/amazonlinux:2"
@@ -30,5 +38,28 @@ task FindWordsWithLetter {
 		#miniwdl retry
 		maxRetries: 3
 	}
-	output { File filtered_file = "words_with_~{vowel}.txt" }
+	output {
+		File filtered_file = "words_with_~{vowel}.txt"
+		File count_file = "~{vowel}-count.txt"
+	}
+}
+
+task SumWords {
+	input {
+		Array[File] count_files
+	}
+	command <<<
+		awk '{ sum += $1 } END { print sum }' ~{sep=' ' count_files} > sum.txt
+	>>>
+	runtime {
+		docker: "public.ecr.aws/amazonlinux/amazonlinux:2"
+		#cromwell retry
+		awsBatchRetryAttempts: 3
+		#miniwdl retry
+		maxRetries: 3
+	}
+   output {
+	   File sum_file = "sum.txt"
+       String out = read_string( "sum.txt" )
+   }
 }


### PR DESCRIPTION
Issue #, if available:

**Description of Changes**

Updated words with vowels workflow to have a full "scatter - gather shape" so as to give a quick workflow testing most actions that will occur on the infrastructure.

**Description of how you validated changes**

* `agc context deploy myContext` (Cromwell)
* `agc context deploy miniContext` (miniwdl)
* `agc workflow run -c myContext words-with-vowels`
* `agc workflow run -c miniContext words-with-vowels`


**Checklist**

- [ ] If this change would make any existing documentation invalid, I have included those updates within this PR
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have linted my code before raising the PR
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
