### PR TITLE
fix: Correct Dockerfile location and version arg for Toil buildspec.yml

### DIFF
--- a/packages/engines/toil/buildspec.yml
+++ b/packages/engines/toil/buildspec.yml
@@ -11,7 +11,7 @@ phases:
       - TOIL_IMAGE_URI=${TOIL_IMAGE_NAME}:${TOIL_VERSION}
   build:
     commands:
-      - docker build -t ${TOIL_IMAGE_URI} ./
+      - docker build -t ${TOIL_IMAGE_URI} --build-arg TOIL_VERSION=${TOIL_VERSION} ./packages/engines/toil
   post_build:
     commands:
       - docker save -o toil_image.tar ${TOIL_IMAGE_URI}

--- a/packages/engines/toil/buildspec.yml
+++ b/packages/engines/toil/buildspec.yml
@@ -4,11 +4,12 @@ env:
   shell: bash
   variables:
     TOIL_IMAGE_NAME: "toil"
-    TOIL_VERSION: "5.7.0a1-f77554b28bbda7b112c5b058b31d5041299c38c9"
+    TOIL_VERSION_PREFIX: "5.7.0a1-"
+    TOIL_VERSION: "f77554b28bbda7b112c5b058b31d5041299c38c9"
 phases:
   pre_build:
     commands:
-      - TOIL_IMAGE_URI=${TOIL_IMAGE_NAME}:${TOIL_VERSION}
+      - TOIL_IMAGE_URI=${TOIL_IMAGE_NAME}:${TOIL_VERSION_PREFIX}${TOIL_VERSION}
   build:
     commands:
       - docker build -t ${TOIL_IMAGE_URI} --build-arg TOIL_VERSION=${TOIL_VERSION} ./packages/engines/toil


### PR DESCRIPTION

**Description of Changes**

Updated Dockerfile path and include version as Docker build argument

**Description of how you validated changes**

Setup AmazonGenomicsCICDK pipeline with linkages to my AGC fork and published updates to my AGC fork. Observed that Toil engine container built as expected.


**Checklist**

- [ ] If this change would make any existing documentation invalid, I have included those updates within this PR
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have linted my code before raising the PR
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
