### PR TITLE
fix: UX regressions where CDK logs show when --verbose flag is not used

### DIFF
--- a/packages/cdk/npm-shrinkwrap.json
+++ b/packages/cdk/npm-shrinkwrap.json
@@ -1265,36 +1265,29 @@
       },
       "dependencies": {
         "@balena/dockerignore": {
-          "version": "1.0.2",
-          "bundled": true
+          "version": "1.0.2"
         },
         "at-least-node": {
-          "version": "1.0.0",
-          "bundled": true
+          "version": "1.0.0"
         },
         "balanced-match": {
-          "version": "1.0.2",
-          "bundled": true
+          "version": "1.0.2"
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
         "case": {
-          "version": "1.6.3",
-          "bundled": true
+          "version": "1.6.3"
         },
         "concat-map": {
-          "version": "0.0.1",
-          "bundled": true
+          "version": "0.0.1"
         },
         "fs-extra": {
           "version": "9.1.0",
-          "bundled": true,
           "requires": {
             "at-least-node": "^1.0.0",
             "graceful-fs": "^4.2.0",
@@ -1303,61 +1296,50 @@
           }
         },
         "graceful-fs": {
-          "version": "4.2.8",
-          "bundled": true
+          "version": "4.2.8"
         },
         "ignore": {
-          "version": "5.1.9",
-          "bundled": true
+          "version": "5.1.9"
         },
         "jsonfile": {
           "version": "6.1.0",
-          "bundled": true,
           "requires": {
             "graceful-fs": "^4.1.6",
             "universalify": "^2.0.0"
           }
         },
         "jsonschema": {
-          "version": "1.4.0",
-          "bundled": true
+          "version": "1.4.0"
         },
         "lru-cache": {
           "version": "6.0.0",
-          "bundled": true,
           "requires": {
             "yallist": "^4.0.0"
           }
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "punycode": {
-          "version": "2.1.1",
-          "bundled": true
+          "version": "2.1.1"
         },
         "semver": {
           "version": "7.3.5",
-          "bundled": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
         },
         "universalify": {
-          "version": "2.0.0",
-          "bundled": true
+          "version": "2.0.0"
         },
         "yallist": {
-          "version": "4.0.0",
-          "bundled": true
+          "version": "4.0.0"
         },
         "yaml": {
-          "version": "1.10.2",
-          "bundled": true
+          "version": "1.10.2"
         }
       }
     },

--- a/packages/cli/internal/pkg/aws/cdk/progress.go
+++ b/packages/cli/internal/pkg/aws/cdk/progress.go
@@ -194,12 +194,6 @@ func runProgressBar(ctx context.Context, description string, numberOfChannels in
 				if len(keyWithSteps) == numberOfChannels {
 					bar.SetCurrent(int64(currentStep))
 				}
-
-				if progressEvent.StepDescription != "" {
-					bar.Set("description", progressEvent.StepDescription)
-				} else {
-					bar.Set("description", description)
-				}
 			case <-ctx.Done():
 				close(receiver)
 				bar.SetCurrent(bar.Total()).Finish()


### PR DESCRIPTION
**Description of Changes**

Removed code that caused CDK logs to be shown when `-v (--verbose)` flag has NOT been set.

**Description of how you validated changes**

[//]: #  (A description of you validated your changes and any relevant logs that show your change works)

Account activation and context deployment shows only the progress bouncer:

```
agc account activate
2022-05-13T12:12:28-04:00 𝒊  Activating AGC with bucket '' and VPC ''
Bootstrapping CDK... [o---] 1m18s
Activating account... [o---] 4m16s
88665a2eaed7:amazon-genomics-cli mrschre$ cd examples/demo-cwl-project/
88665a2eaed7:demo-cwl-project mrschre$ agc context deploy myContext
2022-05-13T12:20:06-04:00 𝒊  Deploying context(s)
Deploying resources for context(s) [myContext] [---o] 37m52s                                                                                                                                     2022-05-13T12:58:03-04:00 𝒊  Successfully deployed context(s) [myContext]
```

Full logs (and no bouncer) are shown when `-v` is used

```
agc context deploy spotCtx -v
2022-05-13T13:14:28-04:00 ↓  Checking AGC version...
2022-05-13T13:14:28-04:00 𝒊  Deploying context(s)
2022-05-13T13:14:29-04:00 ↓  executeCDKClearContext(/Users/mrschre/.agc/cdk/apps/context)
2022-05-13T13:14:29-04:00 ↓  executeCDKCommand(/Users/mrschre/.agc/cdk/apps/context, [context --clear])
2022-05-13T13:14:30-04:00 ↓
2022-05-13T13:14:30-04:00 ↓  > cdk@0.1.0 cdk /Users/mrschre/devel/amazon-genomics-cli/packages/cdk
2022-05-13T13:14:30-04:00 ↓  > cd $INIT_CWD && cdk "context" "--clear"
2022-05-13T13:14:30-04:00 ↓
2022-05-13T13:14:31-04:00 ↓  verifying presence of 'aws/toil-mirror:5.7.0a1-f77554b28bbda7b112c5b058b31d5041299c38c9' in region: 'us-east-1' of registry (account): '680431765560'
2022-05-13T13:14:32-04:00 ↓  executeCDKCommand(/Users/mrschre/.agc/cdk/apps/context, [deploy --all --profile  --require-approval never --toolkit-stack-name Agc-CDKToolkit --output /Users/mrschre/.agc/cdk/apps/context/cdk-output2204762002 -c PROJECT=CWLDemo -c ENGINE_NAME=toil -c FILESYSTEM_TYPE= -c FS_PROVISIONED_THROUGHPUT=0 -c READ_BUCKET_ARNS= -c OUTPUT_BUCKET=agc-581254785006-us-east-1 -c AGC_VERSION=1.4.0 -c ENGINE_DESIGNATION=toil -c ENGINE_REPOSITORY= -c ADAPTER_DESIGNATION= -c ADAPTER_REPOSITORY= -c BATCH_COMPUTE_INSTANCE_TYPES= -c PUBLIC_SUBNETS=false -c CONTEXT=spotCtx -c USER_EMAIL=mrschre@amazon.com -c CUSTOM_TAGS= -c ENGINE_HEALTH_CHECK_PATH= -c READ_WRITE_BUCKET_ARNS= -c MAX_V_CPUS=256 -c USER_ID=mrschre4GqyMA -c ADAPTER_NAME= -c ARTIFACT_BUCKET=agc-581254785006-us-east-1 -c REQUEST_SPOT_INSTANCES=true -c ECR_TOIL_ACCOUNT_ID=680431765560 -c ECR_TOIL_REGION=us-east-1 -c ECR_TOIL_TAG=5.7.0a1-f77554b28bbda7b112c5b058b31d5041299c38c9 -c ECR_TOIL_REPOSITORY=aws/toil-mirror])
2022-05-13T13:14:33-04:00 ↓
2022-05-13T13:14:33-04:00 ↓  > cdk@0.1.0 cdk /Users/mrschre/devel/amazon-genomics-cli/packages/cdk
2022-05-13T13:14:33-04:00 ↓  > cd $INIT_CWD && cdk "deploy" "--all" "--profile" "" "--require-approval" "never" "--toolkit-stack-name" "Agc-CDKToolkit" "--output" "/Users/mrschre/.agc/cdk/apps/context/cdk-output2204762002" "-c" "PROJECT=CWLDemo" "-c" "ENGINE_NAME=toil" "-c" "FILESYSTEM_TYPE=" "-c" "FS_PROVISIONED_THROUGHPUT=0" "-c" "READ_BUCKET_ARNS=" "-c" "OUTPUT_BUCKET=agc-581254785006-us-east-1" "-c" "AGC_VERSION=1.4.0" "-c" "ENGINE_DESIGNATION=toil" "-c" "ENGINE_REPOSITORY=" "-c" "ADAPTER_DESIGNATION=" "-c" "ADAPTER_REPOSITORY=" "-c" "BATCH_COMPUTE_INSTANCE_TYPES=" "-c" "PUBLIC_SUBNETS=false" "-c" "CONTEXT=spotCtx" "-c" "USER_EMAIL=mrschre@amazon.com" "-c" "CUSTOM_TAGS=" "-c" "ENGINE_HEALTH_CHECK_PATH=" "-c" "READ_WRITE_BUCKET_ARNS=" "-c" "MAX_V_CPUS=256" "-c" "USER_ID=mrschre4GqyMA" "-c" "ADAPTER_NAME=" "-c" "ARTIFACT_BUCKET=agc-581254785006-us-east-1" "-c" "REQUEST_SPOT_INSTANCES=true" "-c" "ECR_TOIL_ACCOUNT_ID=680431765560" "-c" "ECR_TOIL_REGION=us-east-1" "-c" "ECR_TOIL_TAG=5.7.0a1-f77554b28bbda7b112c5b058b31d5041299c38c9" "-c" "ECR_TOIL_REPOSITORY=aws/toil-mirror"
2022-05-13T13:14:33-04:00 ↓
2022-05-13T13:14:37-04:00 𝒊  npx: installed 16 in 2.594s
2022-05-13T13:14:48-04:00 𝒊  npx: installed 16 in 1.983s
2022-05-13T13:15:00-04:00 𝒊  npx: installed 16 in 2.085s
2022-05-13T13:15:07-04:00 𝒊  ✨  Synthesis time: 33.33s
2022-05-13T13:15:07-04:00 𝒊  Agc-Context-CWLDemo-mrschre4GqyMA-spotCtx: deploying...
2022-05-13T13:15:08-04:00 𝒊  [0%] start: Publishing 7d9fc702d4702236fb7857f419a086f544b0f8e100f8429d1bf011073923f26c:581254785006-us-east-1
2022-05-13T13:15:09-04:00 𝒊  [100%] success: Published 7d9fc702d4702236fb7857f419a086f544b0f8e100f8429d1bf011073923f26c:581254785006-us-east-1
2022-05-13T13:15:09-04:00 𝒊  Agc-Context-CWLDemo-mrschre4GqyMA-spotCtx: creating CloudFormation changeset...
2022-05-13T13:15:31-04:00 𝒊  Agc-Context-CWLDemo-mrschre4GqyMA-spotCtx |  0/34 | 1:15:10 PM | REVIEW_IN_PROGRESS   | AWS::CloudFormation::Stack                | Agc-Context-CWLDemo-mrschre4GqyMA-spotCtx User Initiated
2022-05-13T13:15:31-04:00 𝒊  Agc-Context-CWLDemo-mrschre4GqyMA-spotCtx |  0/34 | 1:15:26 PM | CREATE_IN_PROGRESS   | AWS::CloudFormation::Stack                | Agc-Context-CWLDemo-mrschre4GqyMA-spotCtx User Initiated
2022-05-13T13:15:36-04:00 𝒊  Agc-Context-CWLDemo-mrschre4GqyMA-spotCtx |  0/34 | 1:15:34 PM | CREATE_IN_PROGRESS   | AWS::EC2::SecurityGroup                   | toil/Engine/Resource/Service/SecurityGroup (toilEngineServiceSecurityGroup5F5039B3)
2022-05-13T13:15:36-04:00 𝒊  Agc-Context-CWLDemo-mrschre4GqyMA-spotCtx |  0/34 | 1:15:35 PM | CREATE_IN_PROGRESS   | AWS::CDK::Metadata                        | CDKMetadata/Default (CDKMetadata)
2022-05-13T13:15:36-04:00 𝒊  Agc-Context-CWLDemo-mrschre4GqyMA-spotCtx |  0/34 | 1:15:35 PM | CREATE_IN_PROGRESS   | AWS::Logs::LogGroup                       | toil/ApiProxy/AccessLogGroup (toilApiProxyAccessLogGroupEDEF88B2)
...
```


**Checklist**

- [ ] If this change would make any existing documentation invalid, I have included those updates within this PR
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have linted my code before raising the PR
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
