### PR TITLE
fix:bump toil commit

### DIFF
--- a/packages/cli/internal/pkg/environment/environment.go
+++ b/packages/cli/internal/pkg/environment/environment.go
@@ -45,7 +45,7 @@ var DefaultTags = map[string]string{
 	constants.MINIWDL:   "v0.1.11",
 	constants.NEXTFLOW:  "21.04.3",
 	constants.SNAKEMAKE: "internal-fork",
-	constants.TOIL:      "5.7.0a1-f77554b28bbda7b112c5b058b31d5041299c38c9",
+	constants.TOIL:      "5.7.0a1-91d37b0a91320bd7e718adc30d910885457f1a73",
 	constants.WES:       "0.1.0",
 }
 

--- a/packages/engines/toil/Dockerfile
+++ b/packages/engines/toil/Dockerfile
@@ -45,7 +45,7 @@ RUN npm install -g concurrently@7.0.0
 # Install Toil
 COPY THIRD-PARTY /opt/
 
-ARG TOIL_VERSION="f77554b28bbda7b112c5b058b31d5041299c38c9"
+ARG TOIL_VERSION="91d37b0a91320bd7e718adc30d910885457f1a73"
 RUN python3 -m pip install git+https://github.com/DataBiosphere/toil.git@${TOIL_VERSION}#egg=toil[aws,cwl,server]
 
 # copy the entrypoint script to the image

--- a/packages/engines/toil/buildspec.yml
+++ b/packages/engines/toil/buildspec.yml
@@ -5,7 +5,7 @@ env:
   variables:
     TOIL_IMAGE_NAME: "toil"
     TOIL_VERSION_PREFIX: "5.7.0a1-"
-    TOIL_VERSION: "f77554b28bbda7b112c5b058b31d5041299c38c9"
+    TOIL_VERSION: "91d37b0a91320bd7e718adc30d910885457f1a73"
 phases:
   pre_build:
     commands:


### PR DESCRIPTION
<!-- Title format: type(scope): Short description (72 chars max for line) -->
<!-- `(scope)` is optional and `type` is one of: build, ci, chore, docs, feat, fix, perf, refactor, revert, style, test -->
<!-- Available types:
- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit -->

Issue #, if available:

**Description of Changes**

[//]: #  (A description of the change that you made and the new user experience that it creates)

use a commit of Toil that resolves bug in workflow stop

**Description of how you validated changes**

[//]: #  (A description of you validated your changes and any relevant logs that show your change works)

Custom build of the Toil container

```bash
cd packages/engines/toil
docker build -t toil-agc:latest .
docker tag toil-age:latest 123412341234.dkr.ecr.us-west-2.amazonaws.com/toil-agc:latest
docker push 123412341234.dkr.ecr.us-west-2.amazonaws.com/toil-agc:latest
```
Set environment variables to use custom container on context deploy

```bash
export ECR_TOIL_ACCOUNT_ID=123412341234
export ECR_TOIL_REGION=us-west-2
export ECR_TOIL_REPOSITORY=toil-agc
export ECR_TOIL_TAG=latest
```

Deploy context and run workflows

```bash
$ agc context deploy myContext
2022-05-21T03:29:29Z 𝒊  Deploying context(s)
$ agc workflow run -c myContext hello
2022-05-21T03:41:58Z 𝒊  Running workflow. Workflow name: 'hello', InputsFile: '', OptionFile: '', Context: 'myContext'
run-7a6e8f5971d3486a9c9ec6a412e6d260
$ agc workflow status
2022-05-21T03:43:04Z 𝒊  Showing workflow run(s). Max Runs: 20
WORKFLOWINSTANCE	myContext	run-7a6e8f5971d3486a9c9ec6a412e6d260	true	{"workflow_type":"CWL","workflow_type_version":"v1.2","workflow_url":"s3://agc-123412341234-us-west-2/project/CWLDemo/userid/user1OSxTC/context/myContext/workflow/hello/workflow.zip"}	RUNNING	2022-05-21T03:41:58Z	hello
$ agc workflow run -c myContext nontrivial
2022-05-21T03:44:42Z 𝒊  Running workflow. Workflow name: 'nontrivial', InputsFile: '', OptionFile: '', Context: 'myContext'
run-7df18ed9ea1a4caca6aa428fc271aa98
$ agc workflow stop run-7df18ed9ea1a4caca6aa428fc271aa98
2022-05-21T03:45:07Z 𝒊  Stopping workflow. Workflow instance id: 'run-7df18ed9ea1a4caca6aa428fc271aa98'
$ agc workflow status
2022-05-21T03:45:11Z 𝒊  Showing workflow run(s). Max Runs: 20
WORKFLOWINSTANCE	myContext	run-7df18ed9ea1a4caca6aa428fc271aa98	true	{"workflow_type":"CWL","workflow_type_version":"v1.2","workflow_url":"s3://agc-123412341234-us-west-2/project/CWLDemo/userid/user1OSxTC/context/myContext/workflow/nontrivial/workflow.zip"}	CANCELING	2022-05-21T03:44:42Z	nontrivial
WORKFLOWINSTANCE	myContext	run-7a6e8f5971d3486a9c9ec6a412e6d260	true	{"workflow_type":"CWL","workflow_type_version":"v1.2","workflow_url":"s3://agc-123412341234-us-west-2/project/CWLDemo/userid/user1OSxTC/context/myContext/workflow/hello/workflow.zip"}	RUNNING	2022-05-21T03:41:58Z	hello
$ agc context destroy myContext
2022-05-21T03:46:13Z 𝒊  Destroying context(s)'
```

**Checklist**

- [ ] If this change would make any existing documentation invalid, I have included those updates within this PR
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have linted my code before raising the PR
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
