### PR TITLE
feat: add assignPublicIp to engine batch job def 

### DIFF
--- a/packages/cdk/lib/constructs/batch.ts
+++ b/packages/cdk/lib/constructs/batch.ts
@@ -107,6 +107,7 @@ export class Batch extends Construct {
   public readonly role: IRole;
   public readonly computeEnvironment: IComputeEnvironment;
   public readonly jobQueue: IJobQueue;
+  public readonly assignPublicIp?: boolean;
 
   constructor(scope: Construct, id: string, props: BatchProps) {
     super(scope, id);
@@ -122,6 +123,8 @@ export class Batch extends Construct {
         },
       ],
     });
+
+    this.assignPublicIp = props.usePublicSubnets;
   }
 
   public grantJobAdministration(grantee: IGrantable, jobDefinitionName = "*"): Grant {

--- a/packages/cdk/lib/constructs/engines/miniwdl/miniwdl-engine.ts
+++ b/packages/cdk/lib/constructs/engines/miniwdl/miniwdl-engine.ts
@@ -54,6 +54,7 @@ export class MiniWdlEngine extends Engine {
         },
         volumes: [this.toVolume(this.fileSystem, accessPoint, this.volumeName)],
         mountPoints: [this.toMountPoint("/mnt/efs", this.volumeName)],
+        assignPublicIp: engineBatch.assignPublicIp,
       },
     });
   }

--- a/packages/cdk/lib/constructs/engines/snakemake/snakemake-engine.ts
+++ b/packages/cdk/lib/constructs/engines/snakemake/snakemake-engine.ts
@@ -55,6 +55,7 @@ export class SnakemakeEngine extends Engine {
         },
         volumes: [this.toVolume(this.fileSystem, this.fsap, this.volumeName)],
         mountPoints: [this.toMountPoint("/mnt/efs", this.volumeName)],
+        assignPublicIp: engineBatch.assignPublicIp,
       },
     });
   }

--- a/packages/cdk/lib/stacks/context-stack.ts
+++ b/packages/cdk/lib/stacks/context-stack.ts
@@ -67,17 +67,11 @@ export class ContextStack extends Stack {
         if (filesystemType != "EFS") {
           throw Error(`'MiniWDL' requires filesystem type 'EFS'`);
         }
-        if (contextParameters.usePublicSubnets) {
-          throw Error(`'miniwdl is not currently supported using public subnets, please file a github issue detailing your use case'`);
-        }
         this.renderMiniwdlStack(props);
         break;
       case ENGINE_SNAKEMAKE:
         if (filesystemType != "EFS") {
           throw Error(`'Snakemake' requires filesystem type 'EFS'`);
-        }
-        if (contextParameters.usePublicSubnets) {
-          throw Error(`'snakemake is not currently supported using public subnets, please file a github issue detailing your use case'`);
         }
         this.renderSnakemakeStack(props);
         break;

--- a/packages/cdk/lib/stacks/engines/miniwdl-engine-construct.ts
+++ b/packages/cdk/lib/stacks/engines/miniwdl-engine-construct.ts
@@ -148,6 +148,7 @@ export class MiniwdlEngineConstruct extends EngineConstruct {
       resourceTags: Stack.of(this).tags.tagValues(),
       workflowOrchestrator: ENGINE_MINIWDL,
       computeEnvImage,
+      usePublicSubnets: appParams.usePublicSubnets,
     });
   }
 

--- a/packages/cdk/lib/stacks/engines/snakemake-engine-construct.ts
+++ b/packages/cdk/lib/stacks/engines/snakemake-engine-construct.ts
@@ -181,6 +181,7 @@ export class SnakemakeEngineConstruct extends EngineConstruct {
       resourceTags: Stack.of(this).tags.tagValues(),
       workflowOrchestrator: ENGINE_SNAKEMAKE,
       computeEnvImage,
+      usePublicSubnets: appParams.usePublicSubnets,
     });
   }
 

--- a/site/content/en/docs/Concepts/accounts.md
+++ b/site/content/en/docs/Concepts/accounts.md
@@ -115,8 +115,7 @@ contexts:
 
 {{% alert title="Warning" color="warning" %}}
 Currently, use of public subnets is only supported for contexts that use the Nextflow engine. Use of public IPs with the
-Cromwell server creates a security risk and will fail. Assignment of public IPs to AWS Batch Fargate tasks (as used by miniwdl and SnakeMake)
-is possible but will require changes to the WES adapters of those engines. If you need this please file a [feature request](https://github.com/aws/amazon-genomics-cli/issues/new?labels=enhancement) with your use case
+Cromwell server creates a security risk and will fail.
 {{% /alert %}}
 
 ##### Security Considerations


### PR DESCRIPTION
<!-- Title format: type(scope): Short description (72 chars max for line) -->
<!-- `(scope)` is optional and `type` is one of: build, ci, chore, docs, feat, fix, perf, refactor, revert, style, test -->
<!-- Available types:
- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit -->

Issue #, if available:

**Description of Changes**

For Snakemake and miniwdl engines, set `assignPublicIp` = `usePublicSubnets` on Batch job definition.

**Description of how you validated changes**

Verified the results of all example workflows for Snakemake and miniwdl.

**Checklist**

- [X] If this change would make any existing documentation invalid, I have included those updates within this PR
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [X] I have linted my code before raising the PR
- [X] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
