### PR TITLE
feat: Support and use Toil 5.8's WES task output

### DIFF
--- a/packages/engines/toil/Dockerfile
+++ b/packages/engines/toil/Dockerfile
@@ -34,6 +34,7 @@ RUN curl -fsSL https://rpm.nodesource.com/setup_16.x | bash - \
     && yum install -y \
     python3 \
     rabbitmq-server \
+    erlang \
     nodejs \
     git \
     && yum clean -y all \
@@ -45,7 +46,7 @@ RUN npm install -g concurrently@7.0.0
 # Install Toil
 COPY THIRD-PARTY /opt/
 
-ARG TOIL_VERSION="d831f74e918c4a01e961e3b45504a92d1827b8b3"
+ARG TOIL_VERSION="bf2c046b5b1d38bdfc3043a4ea05f72db279ab64"
 RUN python3 -m pip install git+https://github.com/DataBiosphere/toil.git@${TOIL_VERSION}#egg=toil[aws,cwl,server]
 
 # copy the entrypoint script to the image

--- a/packages/engines/toil/README.md
+++ b/packages/engines/toil/README.md
@@ -2,7 +2,7 @@
 
 A Toil mono-container WES server for use with Amazon Genomics CLI.
 
-### Building the Container Manually
+### Building the Container Manually (on AMD64)
 
 Go to this directory and run:
 
@@ -10,7 +10,7 @@ Go to this directory and run:
 docker build . -f Dockerfile -t toil-agc
 ```
 
-### Running for Testing
+### Running for Testing (on AMD64)
 
 Having built the container, run:
 
@@ -36,7 +36,7 @@ For debugging, you can get inside the container with:
 docker exec -ti toil-agc-test /bin/bash
 ```
 
-### Deploying
+### Deploying (from AMD64)
 
 To push this to an Amazon ECR repo, where AGC can get at it, you can do something like:
 
@@ -50,3 +50,41 @@ docker tag ${ECR_REPO}:latest ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com
 docker push ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/${ECR_REPO}:latest
 ```
 
+### Building and Deploying on ARM
+
+If you are running on an ARM architecture system, `docker build` will try and build a Docker image for an ARM host. This will not work for two reasons. First, AGC uses AMD64 hosts and needs an AMD64 image. Second, the build will fail because the Erlang packages used by RabbitMQ are only available for AMD64. On ARM, the Erlang dependency will not be satisfiable:
+
+```
+#10 28.22 --> Processing Dependency: erlang >= 23.2 for package: rabbitmq-server-3.10.0-1.el7.noarch
+#10 28.24 --> Finished Dependency Resolution
+#10 28.26  You could try using --skip-broken to work around the problem
+#10 28.26 Error: Package: rabbitmq-server-3.10.0-1.el7.noarch (rabbitmq_server)
+#10 28.26            Requires: erlang >= 23.2
+#10 28.27  You could try running: rpm -Va --nofiles --nodigest
+------
+executor failed running [/bin/sh -c curl -fsSL https://rpm.nodesource.com/setup_16.x | bash -     && yum update -y     && yum install -y     python3     rabbitmq-server     erlang     nodejs     git     && yum clean -y all     && rm -rf /var/cache/yum]: exit code: 1
+```
+
+To work around this, you will need to make sure that you have `docker buildx` installed and configured to be able to build AMD64 images, and then run:
+
+```bash
+AWS_REGION=<your-deployment-region> # For example, us-west-2
+AWS_ACCOUNT=<your-account-number> # For example, 123456789012
+ECR_REPO=<your-ecr-repo> # For example, yourname/toil-agc. Needs to be created in the ECR console.
+docker buildx build --platform linux/amd64 --push --tag=${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/${ECR_REPO}:latest -f Dockerfile .
+```
+
+This will build and push the image for the required architecture as a single operation.
+
+### Using in AGC
+
+To use a custom image in an AGC context, go to the directory for the project you want to use it with, set the environment variables, and deploy the context:
+
+```bash
+cd ../../../examples/demo-cwl-project/
+export ECR_TOIL_ACCOUNT_ID="${AWS_ACCOUNT}"
+export ECR_TOIL_TAG=latest
+export ECR_TOIL_REPOSITORY="${ECR_REPO}"
+export ECR_TOIL_REGION="${AWS_REGION}"
+agc context deploy --context myContext
+```

--- a/packages/engines/toil/README.md
+++ b/packages/engines/toil/README.md
@@ -52,7 +52,7 @@ docker push ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/${ECR_REPO}:lates
 
 ### Building and Deploying on ARM
 
-If you are running on an ARM architecture system, `docker build` will try and build a Docker image for an ARM host. This will not work for two reasons. First, AGC uses AMD64 hosts and needs an AMD64 image. Second, the build will fail because the Erlang packages used by RabbitMQ are only available for AMD64. On ARM, the Erlang dependency will not be satisfiable:
+If you are running on an ARM architecture system, `docker build` will try and build a Docker image for an ARM host. This will not work for two reasons. First, Amazon Genomics CLI uses AMD64 hosts and needs an AMD64 image. Second, the build will fail because the Erlang packages used by RabbitMQ are only available for AMD64. On ARM, the Erlang dependency will not be satisfiable:
 
 ```
 #10 28.22 --> Processing Dependency: erlang >= 23.2 for package: rabbitmq-server-3.10.0-1.el7.noarch

--- a/packages/engines/toil/buildspec.yml
+++ b/packages/engines/toil/buildspec.yml
@@ -4,8 +4,8 @@ env:
   shell: bash
   variables:
     TOIL_IMAGE_NAME: "toil"
-    TOIL_VERSION_PREFIX: "5.7.0a1-"
-    TOIL_VERSION: "d831f74e918c4a01e961e3b45504a92d1827b8b3"
+    TOIL_VERSION_PREFIX: "5.8.0a1-"
+    TOIL_VERSION: "bf2c046b5b1d38bdfc3043a4ea05f72db279ab64"
 phases:
   pre_build:
     commands:

--- a/packages/engines/toil/toil.aws.sh
+++ b/packages/engines/toil/toil.aws.sh
@@ -23,6 +23,6 @@ export TOIL_WES_JOB_STORE_TYPE="aws"
 concurrently -n rabbitmq,celery,toil \
     "rabbitmq-server" \
     "celery --broker=${TOIL_WES_BROKER_URL} -A toil.server.celery_app worker --loglevel=INFO" \
-    "toil server --debug --host=0.0.0.0 --port=8000 --dest_bucket_base=${ROOT_DIR}/output --state_store=${ROOT_DIR}/state --opt=--batchSystem=aws_batch '--opt=--awsBatchQueue=${JOB_QUEUE_ARN}' '--opt=--awsBatchRegion=${AWS_REGION}' --opt=--disableCaching"
+    "toil server --debug --host=0.0.0.0 --port=8000 --dest_bucket_base=${ROOT_DIR}/output --state_store=${ROOT_DIR}/state --wes_dialect agc --opt=--batchSystem=aws_batch '--opt=--awsBatchQueue=${JOB_QUEUE_ARN}' '--opt=--awsBatchRegion=${AWS_REGION}' --opt=--disableCaching"
 
 


### PR DESCRIPTION
<!-- Title format: type(scope): Short description (72 chars max for line) -->
<!-- `(scope)` is optional and `type` is one of: build, ci, chore, docs, feat, fix, perf, refactor, revert, style, test -->
<!-- Available types:
- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit -->

Issue #, if available:

**Description of Changes**

[//]: #  (A description of the change that you made and the new user experience that it creates)

As of https://github.com/DataBiosphere/toil/pull/4166, due to be released in Toil 5.8, Toil will now report tasks in its WES run log output.

Unfortunately, AGC will crash if it sees a task in WES output where the task name does not end in `|` and then an AWS Batch job ID. By default Toil does not apply this transformation to task names, even when running against Amazon Batch, because it really only makes sense to do for AGC. So Toil's server now has a `--wes_dialect` option that can be set to `agc` to force it to adjust task names to meet this constraint.

This PR updates the Toil version that the Toil engine container is set to be built against, and adjusts the container's script to launch the Toil server with `--wes_dialect agc` to constrain it to produce only task names that meet AGC's particular requirements.

**Description of how you validated changes**

[//]: #  (A description of you validated your changes and any relevant logs that show your change works)

I built the Toil server container as specified and ran the `hello` demo CWL workflow using it, and I was able to see the task information from Toil in `agc logs workflow`:

```
[anovak@swords demo-cwl-project]% agc logs workflow hello            
2022-08-11T11:40:44-04:00 𝒊  Showing the logs for 'hello'
Assume Role MFA token code: 444071
2022-08-11T11:40:54-04:00 𝒊  Showing logs for the latest run of the workflow. Run id: 'run-06839418265146ccabb3b56d0c0f39a1'
RunId: run-06839418265146ccabb3b56d0c0f39a1
State: COMPLETE
Tasks: 
    Name		JobId					StartTime	StopTimeExitCode
    hello.cwl	3b0f03f4-1106-496f-9f9c-3b0997e2dcd2	<nil>		<nil>	0
    
Run Standard Output:
{
    "output": {
        "location": "s3://agc-318423852362-us-west-2/project/CWLDemo/userid/anovak4rBHiA/context/myContext/toil-execution/output/run-06839418265146ccabb3b56d0c0f39a1/output.txt",
        "basename": "output.txt",
        "nameroot": "output",
        "nameext": ".txt",
        "class": "File",
        "checksum": "sha1$47a013e660d408619d894b20806b1d5086aab03b",
        "size": 13
    }
}
Run Standard Error:
[2022-08-11T15:34:25+0000] [MainThread] [I] [cwltool] Resolved '/opt/work/workflows/run-06839418265146ccabb3b56d0c0f39a1/execution/hello.cwl' to 'file:///opt/work/workflows/run-06839418265146ccabb3b56d0c0f39a1/execution/hello.cwl'
[2022-08-11T15:34:26+0000] [MainThread] [I] [toil] Using default docker registry of quay.io/ucsc_cgl as TOIL_DOCKER_REGISTRY is not set.
[2022-08-11T15:34:26+0000] [MainThread] [I] [toil] Using default docker name of toil as TOIL_DOCKER_NAME is not set.
[2022-08-11T15:34:26+0000] [MainThread] [I] [toil] Using default docker appliance of quay.io/ucsc_cgl/toil:5.8.0a1-bf2c046b5b1d38bdfc3043a4ea05f72db279ab64-py3.7 as TOIL_APPLIANCE_SELF is not set.
[2022-08-11T15:34:26+0000] [MainThread] [I] [toil.job] Saving graph of 1 jobs, 1 new
[2022-08-11T15:34:26+0000] [MainThread] [I] [toil.job] Processing job 'CWLJob' hello.cwl 19736ad2-87df-40cc-93eb-5c639a8e8e94 v0
[2022-08-11T15:34:27+0000] [MainThread] [I] [toil] Running Toil version 5.8.0a1-bf2c046b5b1d38bdfc3043a4ea05f72db279ab64 on host ip-10-0-159-188.us-west-2.compute.internal.
[2022-08-11T15:34:27+0000] [MainThread] [I] [toil.leader] Issued job 'CWLJob' hello.cwl 19736ad2-87df-40cc-93eb-5c639a8e8e94 v1 with job batch system ID: 0 and cores: 1, disk: 3.0 Gi, and memory: 2.0 Gi
[2022-08-11T15:34:29+0000] [MainThread] [I] [toil.leader] 0 jobs are running, 1 jobs are issued and waiting to run
[2022-08-11T15:37:56+0000] [MainThread] [I] [toil.leader] Finished toil run successfully.
[2022-08-11T15:37:57+0000] [MainThread] [I] [toil.common] Successfully deleted the job store: <toil.jobStores.aws.jobStore.AWSJobStore object at 0x7ff311ba6ed0>
```

Toil doesn't yet report task start and stop times, but when it gains that feature they should become visible automatically.

Also included is documentation of the steps needed to build the Toil engine container on an ARM host, because the existing instructions assumed that the user was working from an AMD64 machine.

This can't really be unit tested; it needs a whole running Toil-based context to be seen. Unit tests already exist that mock the WES responses, AFAIK.

**Checklist**

- [X] If this change would make any existing documentation invalid, I have included those updates within this PR
- N/A I have added unit tests that prove my fix is effective or that my feature works
- [X] I have linted my code before raising the PR
- [X] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
