### PR TITLE
fix: Removed unused and redundant targets in `packages/cli` make file

### DIFF
--- a/packages/cli/Makefile
+++ b/packages/cli/Makefile
@@ -1,6 +1,5 @@
 BINARY_NAME=agc
 PACKAGES=./internal...
-SOURCE_DOCS=${PWD}/site
 VERSION_FILE=../../version.json
 GOBIN=${PWD}/bin/tools
 COVERAGE=coverage.out
@@ -17,14 +16,6 @@ all: format test build
 build: compile-local
 
 release: compile-darwin compile-linux compile-windows
-
-release-docker:
-	docker build -t aws/rosalind . &&\
-	docker create -ti --name amazon-rosalind-builder aws/rosalind &&\
-	docker cp amazon-rosalind-builder:/rosalind/bin/local/ . &&\
-	docker rm -f amazon-rosalind-builder
-	@echo "Built binaries under ./local/"
-
 
 compile-local:
 	go build -ldflags "${LINKER_FLAGS}" -o ${DESTINATION} ./cmd/application
@@ -60,18 +51,6 @@ run-integ-test:
 tools:
 	GOBIN=${GOBIN} go install github.com/golang/mock/mockgen@v1.6.0
 	GOBIN=${GOBIN} go install golang.org/x/tools/cmd/goimports@v0.1.12
-
-start-docs:
-	cd ${SOURDE_DOCS} &&\
-	git submodule update --init --recursive &&\
-	hugo server -D
-
-build-docs:
-	cd ${SOURDE_DOCS} &&\
-	git submodule update --init --recursive &&\
-	npm install &&\
-	hugo &&\
-	cd ..
 
 gen-mocks:
 	${GOBIN}/mockgen -source=./internal/pkg/mocks/aws/interfaces.go -package=awsmocks -destination=./internal/pkg/mocks/aws/mock_interfaces.go


### PR DESCRIPTION
**Description of Changes**

* Removed the docker build target as we don't build the CLI as a container and haven't for a long time
* Removed redundant (and incorrect) docs targets as they are now in the top level make and not the `cli` package

**Description of how you validated changes**

`make init && make`
`make start-docs`


**Checklist**

- [ ] If this change would make any existing documentation invalid, I have included those updates within this PR
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have linted my code before raising the PR
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
