### PR TITLE
Merge pull request #516 from aws/vishnuvalleru/install-which-on-nextflow

### DIFF
--- a/packages/engines/nextflow/Dockerfile
+++ b/packages/engines/nextflow/Dockerfile
@@ -12,6 +12,7 @@ RUN yum update -y \
   && yum install -y \
   curl \
   hostname \
+  which \
   "java-11-amazon-corretto-headless(x86-64)" \
   unzip \
   jq \


### PR DESCRIPTION
<!-- Title format: type(scope): Short description (72 chars max for line) -->
<!-- `(scope)` is optional and `type` is one of: build, ci, chore, docs, feat, fix, perf, refactor, revert, style, test -->
fix: Install which utility for Nextflow image

Issue #, if available: N/A

**Description of Changes**

[//]: # No change in user experience. The new AL2 image doesn't come with `which` utility anymore. This change installs the `which` utility during Nextflow image build.  

**Description of how you validated changes**

[//]: #  Ran build successfully.


**Checklist**

- [N] If this change would make any existing documentation invalid, I have included those updates within this PR
- [N/A] I have added unit tests that prove my fix is effective or that my feature works
- [Y] I have linted my code before raising the PR
- [Y] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
