### PR TITLE
Merge pull request #518 from aws/vishnuvalleru/fix-nextflow-versions

### DIFF
--- a/examples/demo-nextflow-project/workflows/words/nextflow.config
+++ b/examples/demo-nextflow-project/workflows/words/nextflow.config
@@ -1,6 +1,6 @@
 manifest {
     name = "Demo - words with vowels"
-    nextflowVersion = '>=21.04.0'
+    nextflowVersion = '>=22.04.0'
 }
 
 process {

--- a/packages/cli/internal/pkg/environment/environment.go
+++ b/packages/cli/internal/pkg/environment/environment.go
@@ -43,7 +43,7 @@ var DefaultRepositories = map[string]string{
 var DefaultTags = map[string]string{
 	constants.CROMWELL:  "64",
 	constants.MINIWDL:   "v0.1.11",
-	constants.NEXTFLOW:  "21.04.3",
+	constants.NEXTFLOW:  "22.04.3",
 	constants.SNAKEMAKE: "internal-fork",
 	constants.TOIL:      "5.7.0a1-d831f74e918c4a01e961e3b45504a92d1827b8b3",
 	constants.WES:       "0.1.0",


### PR DESCRIPTION
fix: update nextflow version environment variable

Issue #, if available:

Even after the recent Nextflow version update to 22.04.3 the image is still being resolved for the older version. Fixing the manifest file to pickup the new version.

Description of how you validated changes
Integration tests will be run on this change after merge.

Checklist

    [N] If this change would make any existing documentation invalid, I have included those updates within this PR
    [N/A] I have added unit tests that prove my fix is effective or that my feature works
    [N/A] I have linted my code before raising the PR
    [Y] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/
