### PR TITLE
fix: Revision tag in Nextflow rnaseq example

### DIFF
--- a/examples/demo-nextflow-project/workflows/rnaseq/MANIFEST.json
+++ b/examples/demo-nextflow-project/workflows/rnaseq/MANIFEST.json
@@ -3,5 +3,5 @@
   "inputFileURLs": [
     "inputs.json"
   ],
-  "engineOptions": "-resume"
+  "engineOptions": "-resume -r v1.2"
 }


### PR DESCRIPTION
The rnaseq workflow in `demo-nextflow-project` is currently broken because of changes to the workflow in the Nextflow repository, in particular it specifies a recent development version of Nextflow. Specifying the version tag avoids this and ensures the workflow is functional. 

Issue #, if available:

**Description of Changes**

Added the `"engineOptions": "-resume -r v1.2"` in the `MANIFEST.json` file for the rnaseq workflow. 

**Description of how you validated changes**

Running example workflow with proposed changes runs to completion. 

**Checklist**

- [ ] If this change would make any existing documentation invalid, I have included those updates within this PR
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have linted my code before raising the PR
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
