### PR TITLE
Remove spot context from Integration tests

### DIFF
--- a/examples/demo-cwl-project/agc-project.yaml
+++ b/examples/demo-cwl-project/agc-project.yaml
@@ -35,9 +35,3 @@ contexts:
     engines:
       - type: cwl
         engine: toil
-
-  spotCtx:
-    requestSpotInstances: true
-    engines:
-      - type: cwl
-        engine: toil

--- a/examples/demo-nextflow-project/agc-project.yaml
+++ b/examples/demo-nextflow-project/agc-project.yaml
@@ -25,9 +25,3 @@ contexts:
     engines:
       - type: nextflow
         engine: nextflow
-
-  spotContext:
-    requestSpotInstances: true
-    engines:
-      - type: nextflow
-        engine: nextflow

--- a/examples/demo-wdl-project/agc-project.yaml
+++ b/examples/demo-wdl-project/agc-project.yaml
@@ -33,8 +33,3 @@ contexts:
       - type: wdl
         engine: miniwdl
 
-  spotCtx:
-    requestSpotInstances: true
-    engines:
-      - type: wdl
-        engine: cromwell

--- a/examples/gatk-best-practices-project-miniwdl/agc-project.yaml
+++ b/examples/gatk-best-practices-project-miniwdl/agc-project.yaml
@@ -63,10 +63,3 @@ contexts:
     engines:
       - type: wdl
         engine: miniwdl
-
-  # The spot context uses EC2 spot instances which are usually cheaper but may be interrupted
-  spotCtx:
-    requestSpotInstances: true
-    engines:
-      - type: wdl
-        engine: miniwdl

--- a/examples/gatk-best-practices-project/agc-project.yaml
+++ b/examples/gatk-best-practices-project/agc-project.yaml
@@ -63,10 +63,3 @@ contexts:
     engines:
       - type: wdl
         engine: cromwell
-
-  # The spot context uses EC2 spot instances which are usually cheaper but may be interrupted
-  spotCtx:
-    requestSpotInstances: true
-    engines:
-      - type: wdl
-        engine: cromwell


### PR DESCRIPTION
test: Removes Spot Context configuration from the example workflows.

Issue #, if available: N/A

**Description of Changes**

Having integration tests for the spot context causing sporadic failures as the spot context may be interrupted. This change removes the spot context configuration from the example workflows.

**Description of how you validated changes**

[//]: #  (A description of you validated your changes and any relevant logs that show your change works)


**Checklist**

- [N] If this change would make any existing documentation invalid, I have included those updates within this PR
- [N/A] I have added unit tests that prove my fix is effective or that my feature works
- [N/A] I have linted my code before raising the PR
- [Y] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
