### PR TITLE
fix: temporary MANIFEST.json is created and combined with file path from --inputsFile

### DIFF
--- a/packages/cli/internal/pkg/cli/workflow/manager.go
+++ b/packages/cli/internal/pkg/cli/workflow/manager.go
@@ -119,6 +119,12 @@ type workflowOutputProps struct {
 	workflowRunLogOutputs map[string]interface{}
 }
 
+type manifestProps struct {
+	mainWorkFlowURL string   `json:"mainWorkFlowURL"`
+	inputFileURLs   []string `json:"inputFileURLs"`
+	engineOptions	string	 `json:"engineOptions"`
+}
+
 type Manager struct {
 	Project     storage.ProjectClient
 	Config      storage.ConfigClient
@@ -312,7 +318,7 @@ func (m *Manager) uploadWorkflowToS3() {
 	if m.err != nil {
 		return
 	}
-	err := copyFileRecursivelyToLocation("extra", m.path)
+	err := copyFileRecursivelyToLocation("extra", filepath.Join(m.path, "MANIFEST.json"))
 
 	if err != nil {
 		m.err = err

--- a/packages/cli/internal/pkg/cli/workflow/manager.go
+++ b/packages/cli/internal/pkg/cli/workflow/manager.go
@@ -73,6 +73,7 @@ type runProps struct {
 	path                 string
 	packPath             string
 	workflowUrl          string
+	manifestPath         string
 	inputsPath           string
 	input                Input
 	optionFileUrl        string
@@ -309,6 +310,12 @@ func (m *Manager) calculateFinalLocation() {
 
 func (m *Manager) uploadWorkflowToS3() {
 	if m.err != nil {
+		return
+	}
+	err := copyFileRecursivelyToLocation("extra", m.path)
+
+	if err != nil {
+		m.err = err
 		return
 	}
 	objectKey := fmt.Sprintf("%s/%s", m.baseWorkflowKey, workflowZip)

--- a/packages/cli/internal/pkg/cli/workflow/workflow_run.go
+++ b/packages/cli/internal/pkg/cli/workflow/workflow_run.go
@@ -20,6 +20,7 @@ func (m *Manager) RunWorkflow(contextName, workflowName, inputsFileUrl string, o
 	}
 	m.calculateFinalLocation()
 	m.readInput(inputsFileUrl)
+	m.parseAndAddToManifest()
 	m.uploadInputsToS3()
 	m.parseInputToArguments()
 	m.readOptionFile(optionFileUrl)


### PR DESCRIPTION
<!-- Title format: type(scope): Short description (72 chars max for line) -->
<!-- `(scope)` is optional and `type` is one of: build, ci, chore, docs, feat, fix, perf, refactor, revert, style, test -->
<!-- Available types:
- fix: A bug fix  -->

Issue #, if available: 474

**Description of Changes**

[//]: #  (A description of the change that you made and the new user experience that it creates)

added new function `parseAndAddToManifest()`that allows users to use a MANIFEST.json file and include a file with the --inputsFile flag without any overriding.

**Description of how you validated changes**

[//]: #  (A description of you validated your changes and any relevant logs that show your change works)

Various calls of `make` and `workflow run` were used to test creation of new file, as well as its eventual deletion.

**Checklist**

- [ ] If this change would make any existing documentation invalid, I have included those updates within this PR
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have linted my code before raising the PR
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
