### PR TITLE
feat: reduce permissions related to APIGateway for recommended user role

### DIFF
--- a/extras/agc-minimal-permissions/lib/policy-statements.ts
+++ b/extras/agc-minimal-permissions/lib/policy-statements.ts
@@ -595,10 +595,15 @@ export class AgcPermissions {
             }),
             new PolicyStatement({
                 effect: Effect.ALLOW,
-                actions: actions("apigateway", "*"),
+                actions: actions("apigateway", "GET", "POST", "PUT", "DELETE", "PATCH"),
                 resources: [
                     this.arn({service: "apigateway", region: "*", account: "", resource: "*"}),
-                ]
+                ],
+                conditions: {
+                    "StringEquals": {
+                        "aws:ResourceTag/application-name": "agc"
+                    }
+                },
             })
         ]
     }

--- a/extras/agc-minimal-permissions/lib/policy-statements.ts
+++ b/extras/agc-minimal-permissions/lib/policy-statements.ts
@@ -597,7 +597,7 @@ export class AgcPermissions {
                 effect: Effect.ALLOW,
                 actions: actions("apigateway", "GET", "POST", "PUT", "DELETE", "PATCH"),
                 resources: [
-                    this.arn({service: "apigateway", region: "*", account: "", resource: "*"}),
+                    this.arn({service: "apigateway", region: "*", resource: "*"}),
                 ],
                 conditions: {
                     "StringEquals": {


### PR DESCRIPTION
#524 

**Description of Changes**

Reduces `resources` scope to APIG resources in the account and adds tag based condition to 

**Description of how you validated changes**

The generated policy statement is now:

```
...
{
            "Condition": {
                "StringEquals": {
                    "aws:ResourceTag/application-name": "agc"
                }
            },
            "Action": [
                "apigateway:GET",
                "apigateway:POST",
                "apigateway:PUT",
                "apigateway:DELETE",
                "apigateway:PATCH"
            ],
            "Resource": "arn:aws:apigateway:*:581254785006:*",
            "Effect": "Allow"
}, ...
```

Working on this issue reveals that this package should be update to CDK v2 and further validated. Tracking in #537 

**Checklist**

- [] If this change would make any existing documentation invalid, I have included those updates within this PR
- [] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have linted my code before raising the PR
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
