### PR TITLE
fix: AGC run fails when empty strings in inputs.json file

### DIFF
--- a/packages/cli/internal/pkg/storage/input_client.go
+++ b/packages/cli/internal/pkg/storage/input_client.go
@@ -132,7 +132,7 @@ func (ic *InputInstance) uploadReferencesToS3(inputLocations []string, baseDirec
 	for index, input := range inputLocations {
 		trimmedInput := strings.TrimSpace(input)
 		inputWithDirectory := fmt.Sprintf("%s/%s", baseDirectory, trimmedInput)
-		if _, err := stat(inputWithDirectory); err == nil {
+		if fInfo, err := stat(inputWithDirectory); err == nil && !fInfo.IsDir() {
 			log.Debug().Msgf("input value '%s' can be resolved to a file at '%s'", trimmedInput, inputWithDirectory)
 			var formattedInputName string
 			if strings.HasPrefix(trimmedInput, "./") {

--- a/packages/cli/internal/pkg/storage/input_client_test.go
+++ b/packages/cli/internal/pkg/storage/input_client_test.go
@@ -170,21 +170,21 @@ func (ic *InputClientTestSuite) TestUpdateInputs_HappyCase() {
 
 func (ic *InputClientTestSuite) TestUpdateInputs_EmptyString() {
 	inputFile := map[string]interface{}{
-		"a":"",
-		"b":testFile1,
+		"a": "",
+		"b": testFile1,
 	}
 	expectedUpdatedInputFile := map[string]interface{}{
-		"a":"",
-		"b":"s3://bucketName/some/key/testFile.json",
+		"a": "",
+		"b": "s3://bucketName/some/key/testFile.json",
 	}
 
 	mockFileInfo1 := iomocks.NewMockFileInfo(ic.ctrl)
 	mockFileInfo1.EXPECT().IsDir().Return(true)
-	ic.mockOs.EXPECT().Stat("dir/").Return(mockFileInfo1,nil)
+	ic.mockOs.EXPECT().Stat("dir/").Return(mockFileInfo1, nil)
 
 	mockFileInfo2 := iomocks.NewMockFileInfo(ic.ctrl)
 	mockFileInfo2.EXPECT().IsDir().Return(false)
-	ic.mockOs.EXPECT().Stat("dir/"+testFile1).Return(mockFileInfo2,nil)
+	ic.mockOs.EXPECT().Stat("dir/"+testFile1).Return(mockFileInfo2, nil)
 	ic.mockS3Client.EXPECT().UploadFile("bucketName", gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
 
 	actualUpdatedInputFile, err := ic.inputInstance.UpdateInputs(initialProjectDirectory, inputFile, "bucketName", baseS3Key)


### PR DESCRIPTION
<!-- Title format: type(scope): Short description (72 chars max for line) -->
<!-- `(scope)` is optional and `type` is one of: build, ci, chore, docs, feat, fix, perf, refactor, revert, style, test -->
<!-- Available types:
- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit -->

Issue #, if available: https://github.com/aws/amazon-genomics-cli/issues/547

**Description of Changes**

If the inptus.json of a workflow contains empty strings, the workflow will now run and will not crash.

A check is added before uploading a file to S3 that the path is actually a file and not a directory.

[//]: #  (A description of the change that you made and the new user experience that it creates)

**Description of how you validated changes**

Wrote a new unit test. All existing unit test and integration tests pass.

[//]: #  (A description of you validated your changes and any relevant logs that show your change works)


**Checklist**

- [x] If this change would make any existing documentation invalid, I have included those updates within this PR
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have linted my code before raising the PR
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
