### PR TITLE
fix: Added valid time unit for the ECS_CONTAINER_STOP_TIMEOUT env var

### DIFF
--- a/packages/cdk/lib/artifacts/batch-artifacts/ecs-additions/ecs-additions-common.sh
+++ b/packages/cdk/lib/artifacts/batch-artifacts/ecs-additions/ecs-additions-common.sh
@@ -6,7 +6,7 @@ echo ECS_ENABLE_SPOT_INSTANCE_DRAINING=true >> /etc/ecs/ecs.config
 # cache already pulled container images and reduce network traffic
 echo ECS_IMAGE_PULL_BEHAVIOR=prefer-cached >> /etc/ecs/ecs.config
 # increase docker stop timeout so that containers can perform cleanup actions
-echo ECS_CONTAINER_STOP_TIMEOUT=60 >> /etc/ecs/ecs.config
+echo ECS_CONTAINER_STOP_TIMEOUT=60s >> /etc/ecs/ecs.config
 
 # add fetch and run batch helper script
 chmod a+x /opt/ecs-additions/fetch_and_run.sh


### PR DESCRIPTION
**Description of Changes**

[//]: # I've added a time unit for the ECS_CONTAINER_STOP_TIMEOUT environment variable value for a user data "ecs-additions-common.sh" script.

**Description of how you validated changes**

[//]: # After running "sudo docker logs <ecs-agent-container-id>" the issue related to the incorrect time unit for the ECS_CONTAINER_STOP_TIMEOUT is no longer raised.


**Checklist**

- [] If this change would make any existing documentation invalid, I have included those updates within this PR
- [] I have added unit tests that prove my fix is effective or that my feature works
- [] I have linted my code before raising the PR
- [x] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
