### PR TITLE
Fix: Typo for the TypeScript link description on Website

### DIFF
--- a/site/content/en/docs/Contribution guidelines/_index.md
+++ b/site/content/en/docs/Contribution guidelines/_index.md
@@ -21,7 +21,7 @@ feature requests, code of conduct and license terms.
 
 * [Github Hello World!](https://guides.github.com/activities/hello-world/): A basic introduction to GitHub concepts and workflow.
 * [Golang](https://golang.org): Information about the Go language
-* [TypeScript](https://typescriptlang.org): Information about the Go language
+* [TypeScript](https://typescriptlang.org): Information about the TypeScript language
 * [AWS CDK](https://docs.aws.amazon.com/cdk/latest/guide/home.html): Developer guide to the AWS Cloud Development Kit (CDK)
 * [AWS SDK for Go v2](https://aws.github.io/aws-sdk-go-v2/docs/): Developer guide for the AWS SDK for Go v2
 * [Docsy user guide](https://www.docsy.dev/docs/): All about Docsy, including how it manages navigation, look and feel, and multi-language support.


### PR DESCRIPTION
Why
---
There is a typo in the description of TypeScript link in the `Useful resources` section of the page `Documentation/Contribution Guidelines`. The description for TypeScript is `Information about the Go language`. 

How
---
Update the `amazon-genomics-cli/site/content/en/docs/Contribution guidelines /_index.md` file with a line `Information about the TypeScript language` for TypeScript under `Useful resource` section.
