### PR TITLE
fix: grant GetObject permissions in AgcPermissionStack user policy

### DIFF
--- a/extras/agc-minimal-permissions/lib/policy-statements.ts
+++ b/extras/agc-minimal-permissions/lib/policy-statements.ts
@@ -118,6 +118,8 @@ export class AgcPermissions {
                 "GetBucketPolicy",
                 "GetBucketLocation",
                 "ListBucket",
+                "GetObject",
+                "GetObjectVersion",             
                 "ListObjectVersions",
                 "ListBucketVersions",
             ),


### PR DESCRIPTION
<!-- Title format: type(scope): Short description (72 chars max for line) -->
<!-- `(scope)` is optional and `type` is one of: build, ci, chore, docs, feat, fix, perf, refactor, revert, style, test -->
<!-- Available types:
- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests or correcting existing tests
- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- chore: Other changes that don't modify src or test files
- revert: Reverts a previous commit -->

**Description of Changes**

Added `GetObject` and `GetObjectVersion' permissions on the agc project bucket to be granted as part of  the `AgcPermissionStack`. This permissions was omitted in the `userpolicy` despite being able to perform most other operations including delete destructive ones.


[//]: #  (A description of the change that you made and the new user experience that it creates)

**Description of how you validated changes**

I ran the CDK locally and validated that the user assigned the policy: `AgcPermissionStack-agcuserpolicy*` was able to read objects from the s3 bucket directly.

[//]: #  (A description of you validated your changes and any relevant logs that show your change works)


**Checklist**

- [ ] If this change would make any existing documentation invalid, I have included those updates within this PR
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have linted my code before raising the PR
- [-] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
