### PR TITLE
fix: bump nextflow version to 23.04.1 #609

### DIFF
--- a/examples/demo-nextflow-project/workflows/words/nextflow.config
+++ b/examples/demo-nextflow-project/workflows/words/nextflow.config
@@ -1,6 +1,6 @@
 manifest {
     name = "Demo - words with vowels"
-    nextflowVersion = '>=22.04.0'
+    nextflowVersion = '>=23.04.1'
 }
 
 process {

--- a/packages/cli/internal/pkg/environment/environment.go
+++ b/packages/cli/internal/pkg/environment/environment.go
@@ -43,7 +43,7 @@ var DefaultRepositories = map[string]string{
 var DefaultTags = map[string]string{
 	constants.CROMWELL:  "64",
 	constants.MINIWDL:   "v0.7.0",
-	constants.NEXTFLOW:  "22.04.3",
+	constants.NEXTFLOW:  "23.04.1",
 	constants.SNAKEMAKE: "internal-fork",
 	constants.TOIL:      "5.7.0a1-d831f74e918c4a01e961e3b45504a92d1827b8b3",
 	constants.WES:       "0.1.0",

--- a/packages/engines/nextflow/buildspec.yml
+++ b/packages/engines/nextflow/buildspec.yml
@@ -5,7 +5,7 @@ env:
   variables:
     # These variables may be over-ridden as appropriate by the CI/CD pipeline
     NEXTFLOW_IMAGE_NAME: "nextflow"
-    NEXTFLOW_VERSION: "22.04.3"
+    NEXTFLOW_VERSION: "23.04.1"
 
 phases:
   pre_build:


### PR DESCRIPTION
Issue #, if available:
#609 

**Description of Changes**

Bump Nextflow to the latest version as of the time of this writing (23.04.1)

**Description of how you validated changes**


**Checklist**

- [ ] If this change would make any existing documentation invalid, I have included those updates within this PR
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x ] I have linted my code before raising the PR
- [x ] Title of this Pull Request follows Conventional Commits standard: https://www.conventionalcommits.org/en/v1.0.0/

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
