### PR TITLE
fix: Comment out Lambda return value to avoid nodejs14.x

### DIFF
--- a/packages/cdk/lib/stacks/engines/cromwell-engine-construct.ts
+++ b/packages/cdk/lib/stacks/engines/cromwell-engine-construct.ts
@@ -71,10 +71,7 @@ export class CromwellEngineConstruct extends EngineConstruct {
       userId: params.userId,
       engineEndpoint: this.engine.loadBalancer.loadBalancerDnsName,
     });
-    // Referencing the Lambda's logGroup property causes a deprecated
-    // NodeJS14.x custom resource Lambda to be created in the background
-    // Do not reference the Lambda's logGroup or the CFT stack creation will fail
-    // this.adapterLogGroup = lambda.logGroup;
+    this.adapterLogGroup = LogGroup.fromLogGroupName(this, "CromwellAdapterLogGroup", "/aws/lambda/" + lambda.functionName);
 
     this.apiProxy = new ApiProxy(this, {
       apiName: `${params.projectName}${params.contextName}${engineContainer.serviceName}ApiProxy`,

--- a/packages/cdk/lib/stacks/engines/cromwell-engine-construct.ts
+++ b/packages/cdk/lib/stacks/engines/cromwell-engine-construct.ts
@@ -71,7 +71,10 @@ export class CromwellEngineConstruct extends EngineConstruct {
       userId: params.userId,
       engineEndpoint: this.engine.loadBalancer.loadBalancerDnsName,
     });
-    this.adapterLogGroup = lambda.logGroup;
+    // Referencing the Lambda's logGroup property causes a deprecated
+    // NodeJS14.x custom resource Lambda to be created in the background
+    // Do not reference the Lambda's logGroup or the CFT stack creation will fail
+    // this.adapterLogGroup = lambda.logGroup;
 
     this.apiProxy = new ApiProxy(this, {
       apiName: `${params.projectName}${params.contextName}${engineContainer.serviceName}ApiProxy`,

--- a/packages/cdk/lib/stacks/engines/miniwdl-engine-construct.ts
+++ b/packages/cdk/lib/stacks/engines/miniwdl-engine-construct.ts
@@ -96,8 +96,11 @@ export class MiniwdlEngineConstruct extends EngineConstruct {
       vpc: props.contextParameters.usePublicSubnets ? undefined : props.vpc,
       vcpSubnets: props.contextParameters.usePublicSubnets ? undefined : props.subnets,
     });
-    this.adapterLogGroup = lambda.logGroup;
-
+    // Referencing the Lambda's logGroup property causes a deprecated
+    // NodeJS14.x custom resource Lambda to be created in the background
+    // Do not reference the Lambda's logGroup or the CFT stack creation will fail
+    // this.adapterLogGroup = lambda.logGroup;
+    
     this.apiProxy = new ApiProxy(this, {
       apiName: `${params.projectName}${params.userId}${params.contextName}MiniWdlApiProxy`,
       lambda,

--- a/packages/cdk/lib/stacks/engines/miniwdl-engine-construct.ts
+++ b/packages/cdk/lib/stacks/engines/miniwdl-engine-construct.ts
@@ -3,7 +3,7 @@ import { Bucket, IBucket } from "aws-cdk-lib/aws-s3";
 import { ApiProxy, Batch } from "../../constructs";
 import { EngineConstruct, EngineOutputs } from "./engine-construct";
 import { Effect, IRole, ManagedPolicy, PolicyDocument, PolicyStatement, Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
-import { ILogGroup } from "aws-cdk-lib/aws-logs";
+import { LogGroup, ILogGroup } from "aws-cdk-lib/aws-logs";
 import { MiniWdlEngine } from "../../constructs/engines/miniwdl/miniwdl-engine";
 import { IMachineImage, IVpc, SubnetSelection } from "aws-cdk-lib/aws-ec2";
 import { ENGINE_MINIWDL } from "../../constants";
@@ -96,10 +96,7 @@ export class MiniwdlEngineConstruct extends EngineConstruct {
       vpc: props.contextParameters.usePublicSubnets ? undefined : props.vpc,
       vcpSubnets: props.contextParameters.usePublicSubnets ? undefined : props.subnets,
     });
-    // Referencing the Lambda's logGroup property causes a deprecated
-    // NodeJS14.x custom resource Lambda to be created in the background
-    // Do not reference the Lambda's logGroup or the CFT stack creation will fail
-    // this.adapterLogGroup = lambda.logGroup;
+    this.adapterLogGroup = LogGroup.fromLogGroupName(this, "MiniWdlAdapterLogGroup", "/aws/lambda/" + lambda.functionName);
     
     this.apiProxy = new ApiProxy(this, {
       apiName: `${params.projectName}${params.userId}${params.contextName}MiniWdlApiProxy`,

--- a/packages/cdk/lib/stacks/engines/nextflow-engine-construct.ts
+++ b/packages/cdk/lib/stacks/engines/nextflow-engine-construct.ts
@@ -4,7 +4,7 @@ import { EngineOptions } from "../../types";
 import { Bucket } from "aws-cdk-lib/aws-s3";
 import { ApiProxy } from "../../constructs";
 import { EngineOutputs, EngineConstruct } from "./engine-construct";
-import { ILogGroup } from "aws-cdk-lib/aws-logs";
+import { LogGroup, ILogGroup } from "aws-cdk-lib/aws-logs";
 import { IJobQueue } from "@aws-cdk/aws-batch-alpha";
 import { NextflowEngineRole } from "../../roles/nextflow-engine-role";
 import { NextflowAdapterRole } from "../../roles/nextflow-adapter-role";
@@ -71,10 +71,7 @@ export class NextflowEngineConstruct extends EngineConstruct {
       vpc: props.contextParameters.usePublicSubnets ? undefined : props.vpc,
       subnets: props.contextParameters.usePublicSubnets ? undefined : props.subnets,
     });
-    // Referencing the Lambda's logGroup property causes a deprecated
-    // NodeJS14.x custom resource Lambda to be created in the background
-    // Do not reference the Lambda's logGroup or the CFT stack creation will fail
-    // this.adapterLogGroup = lambda.logGroup;
+    this.adapterLogGroup = LogGroup.fromLogGroupName(this, "NextflowAdapterLogGroup", "/aws/lambda/" + lambda.functionName);
     
     this.apiProxy = new ApiProxy(this, {
       apiName: `${params.projectName}${params.userId}${params.contextName}NextflowApiProxy`,

--- a/packages/cdk/lib/stacks/engines/nextflow-engine-construct.ts
+++ b/packages/cdk/lib/stacks/engines/nextflow-engine-construct.ts
@@ -71,8 +71,11 @@ export class NextflowEngineConstruct extends EngineConstruct {
       vpc: props.contextParameters.usePublicSubnets ? undefined : props.vpc,
       subnets: props.contextParameters.usePublicSubnets ? undefined : props.subnets,
     });
-    this.adapterLogGroup = lambda.logGroup;
-
+    // Referencing the Lambda's logGroup property causes a deprecated
+    // NodeJS14.x custom resource Lambda to be created in the background
+    // Do not reference the Lambda's logGroup or the CFT stack creation will fail
+    // this.adapterLogGroup = lambda.logGroup;
+    
     this.apiProxy = new ApiProxy(this, {
       apiName: `${params.projectName}${params.userId}${params.contextName}NextflowApiProxy`,
       lambda,

--- a/packages/cdk/lib/stacks/engines/snakemake-engine-construct.ts
+++ b/packages/cdk/lib/stacks/engines/snakemake-engine-construct.ts
@@ -61,7 +61,10 @@ export class SnakemakeEngineConstruct extends EngineConstruct {
       fsapId: this.snakemakeEngine.fsap.accessPointId,
       outputBucket: params.getEngineBucketPath(),
     });
-    this.adapterLogGroup = lambda.logGroup;
+    // Referencing the Lambda's logGroup property causes a deprecated
+    // NodeJS14.x custom resource Lambda to be created in the background
+    // Do not reference the Lambda's logGroup or the CFT stack creation will fail
+    // this.adapterLogGroup = lambda.logGroup;
 
     // Generate our api gateway proxy
     this.apiProxy = this.createApiProxy(params, lambda);

--- a/packages/cdk/lib/stacks/engines/snakemake-engine-construct.ts
+++ b/packages/cdk/lib/stacks/engines/snakemake-engine-construct.ts
@@ -3,7 +3,7 @@ import { SnakemakeEngine } from "../../constructs/engines/snakemake/snakemake-en
 import { EngineOptions } from "../../types";
 import { ApiProxy, Batch } from "../../constructs";
 import { EngineOutputs, EngineConstruct } from "./engine-construct";
-import { ILogGroup } from "aws-cdk-lib/aws-logs";
+import { LogGroup, ILogGroup } from "aws-cdk-lib/aws-logs";
 import { ComputeResourceType } from "@aws-cdk/aws-batch-alpha";
 import { ENGINE_SNAKEMAKE } from "../../constants";
 import { Construct } from "constructs";
@@ -61,10 +61,7 @@ export class SnakemakeEngineConstruct extends EngineConstruct {
       fsapId: this.snakemakeEngine.fsap.accessPointId,
       outputBucket: params.getEngineBucketPath(),
     });
-    // Referencing the Lambda's logGroup property causes a deprecated
-    // NodeJS14.x custom resource Lambda to be created in the background
-    // Do not reference the Lambda's logGroup or the CFT stack creation will fail
-    // this.adapterLogGroup = lambda.logGroup;
+    this.adapterLogGroup = LogGroup.fromLogGroupName(this, "SnakemakeAdapterLogGroup", "/aws/lambda/" + lambda.functionName);
 
     // Generate our api gateway proxy
     this.apiProxy = this.createApiProxy(params, lambda);


### PR DESCRIPTION
Issue #, if available:
Closes #624 

**Description of Changes**

# Background
Lambda Functions in CDK, by default, do not create Log Groups at CDK deploy time. Log Groups are typically find-or-created when the Lambda executes for the first time.

HOWEVER, there are certain scenarios where the CloudFormation stack needs to know what the Log Group will be. For example, if the Function's log retention needs to be set to a specific value, or if some other resource needs to know the Log Group's properties.

In THESE cases, CDK will generate a `Custom::LogRetention` resource in the background, intended to set retention and return metadata about a Lambda's Log Group. You guessed it, this Custom Resource is itself a Lambda with a runtime of...drumroll...`nodejs14.x` (at least in CDK `2.50.0`). So that's where our problems lies.

# Diving Deep
The question is...why does this get created in this case at all? There's no mention of log retention ANYWHERE in this CDK application. However, careful readers may have picked up on this already: the custom resource also gets created if we're ever reading Log Group metadata. Which we're doing in each of the 4 engine constructs (eg. https://github.com/aws/amazon-genomics-cli/blob/d92ddc0b1e8634480eed743d9bb21fb8350d3111/packages/cdk/lib/stacks/engines/cromwell-engine-construct.ts#L74). That seemingly inoffensive line of code is causing huge deployment issues down the line.

# Solutioning
The next question is what would happen if we just...removed these offending lines of code. And the answer is...pretty much nothing. Setting `this.adapterLogGroup = lambda.logGroup` is effectively unnecessary because the only time that `adapterLogGroup` property is used is as a CfnOutput (which already has error handling if the value is undefined!!).

Therefore, my proposal is to comment out these 4 lines of code. If someone wants to see the Log Group name, they can look it up from the Lambda at Lambda-execute time. I will be submitting a PR for this.

**Validation**

Validated using `cdk synth` locally.